### PR TITLE
feat(live): context-window live transcription

### DIFF
--- a/backend/api/v1/endpoints/recordings.py
+++ b/backend/api/v1/endpoints/recordings.py
@@ -20,6 +20,7 @@ from backend.worker.tasks import process_recording_task, infer_speakers_task, ge
 from backend.celery_app import celery_app
 from backend.utils.audio import concatenate_wavs, get_audio_duration, concatenate_binary_files
 from backend.processing.llm_services import get_llm_backend
+from backend.processing.live_transcribe import transcribe_segment_live_task
 from backend.utils.speaker_label_manager import SpeakerLabelManager
 from backend.utils.time import utc_now
 from backend.models.transcript import Transcript
@@ -97,6 +98,41 @@ async def _reset_generated_recording_state(db: AsyncSession, recording_id: int) 
 
     if preserved_user_notes:
         db.add(Transcript(recording_id=recording_id, user_notes=preserved_user_notes))
+
+
+async def _requeue_for_processing(
+    db: AsyncSession,
+    recording: Recording,
+    *,
+    engine_override: dict | None = None,
+    queued_step: str = "Queued for processing...",
+) -> None:
+    """Reset generated state and re-dispatch the processing pipeline.
+
+    Shared by retry_processing and reprocess_recording. The optional
+    engine_override is forwarded to the Celery task to swap the transcription
+    engine for this run only.
+    """
+    await _reset_generated_recording_state(db, recording.id)
+
+    # Reset processing state while preserving recording metadata and documents.
+    recording.status = RecordingStatus.QUEUED
+    recording.processing_progress = 0
+    recording.processing_step = queued_step
+    recording.processing_started_at = None
+    recording.processing_completed_at = None
+    recording.celery_task_id = None
+    db.add(recording)
+    await db.commit()
+    await db.refresh(recording)
+
+    # Trigger Celery task
+    task = process_recording_task.delay(recording.id, True, engine_override)
+    recording.celery_task_id = task.id
+    db.add(recording)
+    await db.commit()
+    await db.refresh(recording)
+
 
 def get_ordinal_suffix(day: int) -> str:
     if 11 <= day <= 13:
@@ -280,7 +316,10 @@ async def init_upload(
     db.add(recording)
     await db.commit()
     await db.refresh(recording)
-    
+
+    # Create the Transcript row early so live transcription can attach to it.
+    db.add(Transcript(recording_id=recording.id, transcript_status="processing"))
+    await db.commit()
 
     recording_upload_temp_dir(recording.id, create=True)
 
@@ -331,7 +370,21 @@ async def upload_segment(
             log_message=f"Failed to save uploaded segment {sequence} for recording {recording_id}.",
             exc=e,
         )
-        
+
+    # Dispatch the live transcription task. This is best-effort: a missed live
+    # dispatch is non-fatal because the final processing pipeline is
+    # authoritative, so a broker failure must not break the segment upload.
+    if config_manager.get("enable_live_transcription"):
+        try:
+            transcribe_segment_live_task.delay(recording.id, sequence)
+        except Exception as e:
+            logger.warning(
+                "Failed to dispatch live transcription task for recording %s segment %s: %s",
+                recording.id,
+                sequence,
+                e,
+            )
+
     return {"status": "received", "segment": sequence}
 
 
@@ -1249,26 +1302,64 @@ async def retry_processing(
             detail="Recording is already uploading or processing",
         )
 
-    await _reset_generated_recording_state(db, recording.id)
-        
-    # Reset processing state while preserving recording metadata and documents.
-    recording.status = RecordingStatus.QUEUED
-    recording.processing_progress = 0
-    recording.processing_step = "Queued for processing..."
-    recording.processing_started_at = None
-    recording.processing_completed_at = None
-    recording.celery_task_id = None
-    db.add(recording)
-    await db.commit()
-    await db.refresh(recording)
-    
-    # Trigger Celery task
-    task = process_recording_task.delay(recording.id, True)
-    recording.celery_task_id = task.id
-    db.add(recording)
-    await db.commit()
-    await db.refresh(recording)
-    
+    await _requeue_for_processing(db, recording)
+
+    return serialize_recording(recording, has_proxy=_recording_has_proxy(recording))
+
+
+class ReprocessRequest(BaseModel):
+    transcription_backend: str
+    whisper_model_size: str | None = None
+    parakeet_model: str | None = None
+
+
+@router.post("/{recording_id}/reprocess", response_model=RecordingPublicRead)
+async def reprocess_recording(
+    recording_id: str,
+    body: ReprocessRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Re-run the full processing pipeline with a caller-chosen transcription engine.
+
+    Behaves like /retry, but applies a per-reprocess transcription-engine
+    override (non-persistent) so a recording can be reprocessed at higher quality.
+    """
+    from backend.utils.config_manager import TRANSCRIPTION_BACKENDS
+
+    recording = await _get_owned_recording(db, recording_id, current_user.id)
+
+    if recording.is_deleted:
+        raise HTTPException(status_code=400, detail="Cannot retry a deleted recording")
+
+    if recording.status in {
+        RecordingStatus.UPLOADING,
+        RecordingStatus.QUEUED,
+        RecordingStatus.PROCESSING,
+    }:
+        raise HTTPException(
+            status_code=400,
+            detail="Recording is already uploading or processing",
+        )
+
+    if body.transcription_backend not in TRANSCRIPTION_BACKENDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown transcription backend: {body.transcription_backend}",
+        )
+
+    engine_override: dict = {"transcription_backend": body.transcription_backend}
+    if body.whisper_model_size is not None:
+        engine_override["whisper_model_size"] = body.whisper_model_size
+    if body.parakeet_model is not None:
+        engine_override["parakeet_model"] = body.parakeet_model
+
+    queued_step = f"Queued for reprocessing with {body.transcription_backend}..."
+    await _requeue_for_processing(
+        db, recording, engine_override=engine_override, queued_step=queued_step
+    )
+
     return serialize_recording(recording, has_proxy=_recording_has_proxy(recording))
 
 

--- a/backend/api/v1/endpoints/settings.py
+++ b/backend/api/v1/endpoints/settings.py
@@ -11,6 +11,7 @@ from backend.models.user import User
 from backend.utils.config_manager import (
     APP_THEMES,
     SENSITIVE_KEYS,
+    TRANSCRIPTION_BACKENDS,
     WHISPER_MODEL_SIZES,
     config_manager,
     get_default_user_settings,
@@ -27,6 +28,10 @@ class SettingsUpdate(BaseModel):
     gemini_api_key: Optional[str] = None
     llm_provider: Optional[str] = None
     whisper_model_size: Optional[str] = None
+    transcription_backend: Optional[str] = None
+    parakeet_model: Optional[str] = None
+    enable_live_transcription: Optional[bool] = None
+    live_transcription_backend: Optional[str] = None
     theme: Optional[str] = None
     hf_token: Optional[str] = None
     gemini_model: Optional[str] = None
@@ -46,6 +51,20 @@ class SettingsUpdate(BaseModel):
     def validate_whisper_model_size(cls, value: Optional[str]) -> Optional[str]:
         if value and value not in WHISPER_MODEL_SIZES:
             raise ValueError(f"Invalid whisper_model_size. Must be one of {WHISPER_MODEL_SIZES}")
+        return value
+
+    @field_validator('transcription_backend')
+    @classmethod
+    def validate_transcription_backend(cls, value: Optional[str]) -> Optional[str]:
+        if value and value not in TRANSCRIPTION_BACKENDS:
+            raise ValueError(f"Invalid transcription_backend. Must be one of {TRANSCRIPTION_BACKENDS}")
+        return value
+
+    @field_validator('live_transcription_backend')
+    @classmethod
+    def validate_live_transcription_backend(cls, value: Optional[str]) -> Optional[str]:
+        if value and value not in TRANSCRIPTION_BACKENDS:
+            raise ValueError(f"Invalid live_transcription_backend. Must be one of {TRANSCRIPTION_BACKENDS}")
         return value
 
     @field_validator('theme')

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -24,7 +24,7 @@ celery_app = Celery(
     "nojoin_worker",
     broker=REDIS_URL,
     backend=REDIS_URL,
-    include=["backend.worker.tasks"]
+    include=["backend.worker.tasks", "backend.processing.live_transcribe"]
 )
 
 celery_app.conf.update(

--- a/backend/preload_models.py
+++ b/backend/preload_models.py
@@ -269,6 +269,19 @@ def download_models(progress_callback=None, hf_token=None, whisper_model_size=No
         logger.error(f"Failed to load Whisper model: {e}")
         raise e
 
+    # 3b. Preload Parakeet ASR Model (pluggable transcription backend)
+    report("Checking Parakeet model...", 0, stage="parakeet")
+    try:
+        # Lazy import keeps onnx-asr out of module-level imports.
+        import onnx_asr
+        # load_model triggers the ONNX file download from the Hugging Face Hub.
+        onnx_asr.load_model("nemo-parakeet-tdt-0.6b-v3", quantization="int8")
+        report("Parakeet model loaded.", 100, stage="parakeet")
+    except Exception as e:
+        # A Parakeet download failure must not abort the whole preload.
+        logger.warning(f"Failed to load Parakeet model: {e}")
+        report("Skipping Parakeet (download failed).", 100, stage="parakeet")
+
     # 4. Preload Pyannote Diarization Model
     pipeline_name = "pyannote/speaker-diarization-community-1"
     report(f"Downloading Pyannote pipeline ({pipeline_name})...", 0, stage="pyannote")
@@ -345,6 +358,7 @@ def check_model_status(whisper_model_size=None):
     """
     status = {
         "whisper": {"downloaded": False, "path": None, "checked_paths": []},
+        "parakeet": {"downloaded": False, "path": None, "checked_paths": []},
         "pyannote": {"downloaded": False, "path": None, "checked_paths": []},
         "embedding": {"downloaded": False, "path": None, "checked_paths": []}
     }
@@ -378,10 +392,33 @@ def check_model_status(whisper_model_size=None):
                     status["whisper"]["downloaded"] = True
                     status["whisper"]["path"] = default_filepath
     
-    # Check Pyannote
-    # 1. Check HF_HOME location (Primary)
+    # Check Parakeet
+    # Best-effort detection: onnx-asr caches the model under the Hugging Face hub
+    # cache. Detection is a directory-name match; the exact repo dir name may vary
+    # by onnx-asr version, so this is treated as a heuristic, not authoritative.
     hf_cache_base = os.getenv("HF_HOME", os.path.join(os.path.expanduser("~"), ".cache", "huggingface"))
     hf_cache = os.path.join(hf_cache_base, "hub")
+    parakeet_hf_caches = [hf_cache]
+    default_hf_cache = os.path.join(os.path.expanduser("~"), ".cache", "huggingface", "hub")
+    if default_hf_cache not in parakeet_hf_caches:
+        parakeet_hf_caches.append(default_hf_cache)
+
+    for cache_dir in parakeet_hf_caches:
+        status["parakeet"]["checked_paths"].append(cache_dir)
+        if os.path.isdir(cache_dir):
+            try:
+                for entry in os.listdir(cache_dir):
+                    if "parakeet-tdt-0.6b-v3" in entry:
+                        status["parakeet"]["downloaded"] = True
+                        status["parakeet"]["path"] = os.path.join(cache_dir, entry)
+                        break
+            except OSError:
+                pass
+        if status["parakeet"]["downloaded"]:
+            break
+
+    # Check Pyannote
+    # 1. Check HF_HOME location (Primary)
     pyannote_path = os.path.join(hf_cache, "models--pyannote--speaker-diarization-community-1")
     
     status["pyannote"]["checked_paths"].append(pyannote_path)

--- a/backend/processing/engines/__init__.py
+++ b/backend/processing/engines/__init__.py
@@ -1,0 +1,1 @@
+"""Pluggable transcription engine package."""

--- a/backend/processing/engines/base.py
+++ b/backend/processing/engines/base.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+
+
+class TranscriptionEngine(ABC):
+    """Base of a pluggable transcription engine.
+
+    transcribe() returns the canonical schema the rest of the pipeline expects
+    (consumed by backend/utils/transcript_utils.py:combine_transcription_diarization):
+
+        {
+          "text": str,                 # full transcript (-> transcript.text)
+          "language": str,             # optional; logged only
+          "segments": [
+            {"start": float, "end": float, "text": str,
+             "words": [{"start": float, "end": float, "word": str}]}  # words optional
+          ]
+        }
+
+    Returns None on failure or missing file (does NOT raise). The pipeline
+    handles None safely.
+    """
+
+    name: str
+
+    @abstractmethod
+    def transcribe(self, audio_path: str, config: dict) -> dict | None:
+        ...
+
+    def release(self) -> None:
+        """Release cached models / VRAM. Default no-op."""
+        return None

--- a/backend/processing/engines/parakeet_engine.py
+++ b/backend/processing/engines/parakeet_engine.py
@@ -1,0 +1,171 @@
+# nojoin/processing/engines/parakeet_engine.py
+# Parakeet transcription engine backed by onnx-asr. Heavy imports (onnx_asr,
+# onnxruntime, soundfile) live inside methods, never at module top.
+
+import logging
+
+from .base import TranscriptionEngine
+
+logger = logging.getLogger(__name__)
+
+# Maps Nojoin model ids to onnx-asr model ids.
+_ONNX_ASR_MODEL_IDS = {"parakeet-tdt-0.6b-v3": "nemo-parakeet-tdt-0.6b-v3"}
+
+# Gap (seconds) between consecutive words that starts a new segment.
+SEGMENT_PAUSE_THRESHOLD_S = 0.8
+
+
+def _to_onnx_asr_id(nojoin_id: str) -> str:
+    """Resolve a Nojoin model id to its onnx-asr equivalent."""
+    return _ONNX_ASR_MODEL_IDS.get(nojoin_id, nojoin_id)
+
+
+def map_parakeet_result(text: str, tokens: list[str] | None, timestamps: list[float] | None,
+                        audio_duration: float | None = None) -> dict:
+    """Map an onnx-asr timestamped result into the canonical transcription schema.
+
+    Args:
+        text: The recognized transcript text (already space-reconstructed).
+        tokens: Parallel list of subword tokens, or None.
+        timestamps: Parallel list of per-token start times in seconds, or None.
+        audio_duration: Total audio duration in seconds, optional.
+
+    Returns:
+        A dict with the canonical schema: text, language (always None), segments.
+    """
+    # Fallback: no usable token-level timing data.
+    if not tokens or not timestamps or len(tokens) != len(timestamps):
+        return {
+            "text": text,
+            "language": None,
+            "segments": ([{"start": 0.0, "end": audio_duration or 0.0, "text": text}] if text else []),
+        }
+
+    # Build words by grouping subword tokens. A new word begins at index 0 and at
+    # any token whose string starts with a space.
+    words: list[dict] = []
+    for index, token in enumerate(tokens):
+        if index == 0 or token.startswith(" "):
+            words.append({"start": timestamps[index], "word": token})
+        else:
+            words[-1]["word"] += token
+
+    # Assign word end times: next word's start, or audio end for the last word.
+    # When the gap to the next word exceeds the pause threshold, the word ends
+    # shortly after its start so the silent gap is not absorbed into the word
+    # (this keeps the segment-split logic below functional).
+    for index, word in enumerate(words):
+        if index + 1 < len(words):
+            next_start = words[index + 1]["start"]
+            if next_start - word["start"] > SEGMENT_PAUSE_THRESHOLD_S:
+                word["end"] = word["start"] + 0.2
+            else:
+                word["end"] = next_start
+        elif audio_duration is not None and audio_duration > word["start"]:
+            word["end"] = audio_duration
+        else:
+            word["end"] = word["start"] + 0.2
+
+    # Ensure every word string carries a single leading space for downstream
+    # text reconstruction.
+    for word in words:
+        if not word["word"].startswith(" "):
+            word["word"] = " " + word["word"]
+
+    # Fallback: grouping yielded no words but text exists.
+    if not words:
+        return {
+            "text": text,
+            "language": None,
+            "segments": ([{"start": 0.0, "end": audio_duration or 0.0, "text": text}] if text else []),
+        }
+
+    # Group words into segments separated by pauses.
+    segments: list[dict] = []
+    current: list[dict] = [words[0]]
+    for word in words[1:]:
+        if word["start"] - current[-1]["end"] > SEGMENT_PAUSE_THRESHOLD_S:
+            segments.append(current)
+            current = [word]
+        else:
+            current.append(word)
+    segments.append(current)
+
+    result_segments: list[dict] = []
+    for group in segments:
+        result_segments.append({
+            "start": group[0]["start"],
+            "end": group[-1]["end"],
+            "text": "".join(word["word"] for word in group),
+            "words": [{"start": w["start"], "end": w["end"], "word": w["word"]} for w in group],
+        })
+
+    return {"text": text, "language": None, "segments": result_segments}
+
+
+class ParakeetEngine(TranscriptionEngine):
+    """Parakeet transcription engine backed by onnx-asr."""
+
+    name = "parakeet"
+
+    def __init__(self) -> None:
+        # Cache for loaded models, keyed by onnx-asr model id.
+        self._model_cache: dict = {}
+
+    def _get_model(self, config: dict):
+        """Load (once, lazily) and return the onnx-asr model for the given config."""
+        nojoin_id = config.get("parakeet_model", "parakeet-tdt-0.6b-v3") if config else "parakeet-tdt-0.6b-v3"
+        onnx_id = _to_onnx_asr_id(nojoin_id)
+        if onnx_id not in self._model_cache:
+            import onnx_asr
+            logger.info(f"Loading Parakeet model: {onnx_id}")
+            self._model_cache[onnx_id] = onnx_asr.load_model(
+                onnx_id,
+                quantization="int8",
+                providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+            )
+            logger.info(f"Parakeet model {onnx_id} loaded successfully.")
+        return self._model_cache[onnx_id]
+
+    def transcribe(self, audio_path: str, config: dict) -> dict | None:
+        """Transcribe the given audio file using onnx-asr Parakeet.
+
+        Args:
+            audio_path: Path to a 16kHz mono WAV file.
+            config: Configuration dictionary (reads parakeet_model).
+
+        Returns:
+            The canonical transcription dict, or None on failure / missing file.
+        """
+        import os
+
+        if not os.path.exists(audio_path):
+            logger.error(f"Audio file not found for transcription: {audio_path}")
+            return None
+
+        try:
+            model = self._get_model(config or {})
+
+            logger.info(f"Starting Parakeet transcription for {audio_path}")
+            result = model.with_timestamps().recognize(audio_path)
+
+            # Audio duration is optional; failure to read it must not abort.
+            audio_duration: float | None = None
+            try:
+                import soundfile
+                audio_duration = soundfile.info(audio_path).duration
+            except Exception as e:
+                logger.warning(f"Could not read audio duration for {audio_path}: {e}")
+
+            logger.info(f"Parakeet transcription completed for {audio_path}")
+            return map_parakeet_result(result.text, result.tokens, result.timestamps, audio_duration)
+
+        except Exception as e:
+            logger.error(f"Error during Parakeet transcription for {audio_path}: {e}", exc_info=True)
+            return None
+
+    def release(self) -> None:
+        """Release all loaded Parakeet models from memory."""
+        if self._model_cache:
+            logger.info(f"Releasing {list(self._model_cache.keys())} from Parakeet model cache.")
+            self._model_cache.clear()

--- a/backend/processing/engines/whisper_engine.py
+++ b/backend/processing/engines/whisper_engine.py
@@ -1,0 +1,259 @@
+# nojoin/processing/engines/whisper_engine.py
+# Whisper transcription engine. Heavy imports (whisper, torch, tqdm) live here,
+# not in the thin dispatcher backend/processing/transcribe.py.
+
+import whisper
+import logging
+import os
+import torch
+import tqdm
+import threading
+
+from ...utils.config_manager import config_manager
+from .base import TranscriptionEngine
+
+logger = logging.getLogger(__name__)
+
+# Cache for loaded models to avoid reloading
+_model_cache = {}
+
+# --- Whisper Progress Listener Infrastructure ---
+class ProgressListener:
+    def __init__(self, callback):
+        self.callback = callback
+    def on_progress(self, current, total):
+        percent = int((current / total) * 100) if total else 0
+        if self.callback:
+            self.callback(min(percent, 100))
+    def on_finished(self):
+        if self.callback:
+            self.callback(100)
+
+class ProgressListenerHandle:
+    def __init__(self, listener):
+        self.listener = listener
+    def __enter__(self):
+        register_thread_local_progress_listener(self.listener)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        unregister_thread_local_progress_listener(self.listener)
+        if exc_type is None:
+            self.listener.on_finished()
+
+class _CustomProgressBar(tqdm.tqdm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._current = self.n
+    def update(self, n):
+        super().update(n)
+        self._current += n
+        listeners = _get_thread_local_listeners()
+        for listener in listeners:
+            listener.on_progress(self._current, self.total)
+
+_thread_local = threading.local()
+_hooked = False
+
+def _get_thread_local_listeners():
+    if not hasattr(_thread_local, 'listeners'):
+        _thread_local.listeners = []
+    return _thread_local.listeners
+
+def init_progress_hook():
+    global _hooked
+    if _hooked:
+        return
+    import tqdm
+    tqdm.tqdm = _CustomProgressBar
+    _hooked = True
+
+def register_thread_local_progress_listener(progress_listener):
+    init_progress_hook()
+    listeners = _get_thread_local_listeners()
+    listeners.append(progress_listener)
+
+def unregister_thread_local_progress_listener(progress_listener):
+    listeners = _get_thread_local_listeners()
+    if progress_listener in listeners:
+        listeners.remove(progress_listener)
+
+def create_progress_listener_handle(progress_listener):
+    return ProgressListenerHandle(progress_listener)
+
+def transcribe_audio_with_progress(audio_path: str, progress_callback=None, cancel_check=None) -> dict | None:
+    """Transcribes the given audio file using OpenAI Whisper, emitting progress via callback. Supports cancellation."""
+    if not os.path.exists(audio_path):
+        logger.error(f"Audio file not found for transcription: {audio_path}")
+        return None
+
+    model_size = config_manager.get("whisper_model_size", "base")
+    device = config_manager.get("processing_device", "cpu")
+
+    logger.info(f"Starting transcription for {audio_path} using model: {model_size}, device: {device}")
+
+    # Ensure ffmpeg is in PATH
+    from backend.utils.audio import ensure_ffmpeg_in_path
+    ensure_ffmpeg_in_path()
+
+    try:
+        # Load model (use cache)
+        if model_size not in _model_cache:
+            logger.info(f"Loading Whisper model: {model_size}")
+            # Check if model exists locally, if not it will be downloaded by whisper.load_model
+            from ...utils.model_utils import is_whisper_model_downloaded
+            if not is_whisper_model_downloaded(model_size):
+                logger.info(f"Whisper model {model_size} not found locally - will be downloaded")
+            _model_cache[model_size] = whisper.load_model(model_size, device=device)
+            logger.info(f"Whisper model {model_size} loaded successfully.")
+        model = _model_cache[model_size]
+
+        # Use unified progress system for transcription
+        # progress_manager = get_progress_manager()
+
+        # with progress_manager.create_transcription_context(progress_callback) as context:
+        if True: # Placeholder to keep indentation
+            try:
+                use_fp16 = device == "cuda"
+
+                # Check for cancellation before starting
+                if cancel_check and cancel_check():
+                    logger.info("Transcription cancelled before starting model.transcribe.")
+                    return None
+
+                # Perform transcription with progress tracking
+
+                # Check environment variable for word timestamps
+                # Default to True now that we have triton-windows support
+                env_var = os.environ.get("WHISPER_ENABLE_WORD_TIMESTAMPS")
+                if env_var is not None:
+                    enable_word_timestamps = env_var.lower() == "true"
+                else:
+                    import platform
+                    enable_word_timestamps = platform.system().lower() != "windows"
+
+                result = model.transcribe(audio_path, fp16=use_fp16, verbose=None, word_timestamps=enable_word_timestamps)
+
+                # Check for cancellation after transcribe
+                if cancel_check and cancel_check():
+                    logger.info("Transcription cancelled after model.transcribe.")
+                    return None
+
+                # Ensure 100% completion is reported
+                # context.emit_progress(100, 100) # context is not defined here
+                if progress_callback:
+                    progress_callback(100)
+
+                logger.info(f"Transcription completed for {audio_path}. Detected language: {result.get('language')}")
+                return result
+
+            except Exception as e:
+                logger.error(f"Error during transcription: {e}", exc_info=True)
+                raise
+
+    except Exception as e:
+        logger.error(f"Error during Whisper transcription for {audio_path}: {e}", exc_info=True)
+        if model_size in _model_cache and isinstance(e, RuntimeError):
+            logger.warning(f"Clearing model cache for {model_size} due to error.")
+            del _model_cache[model_size]
+            if device == "cuda":
+                torch.cuda.empty_cache()
+        return None
+
+
+class WhisperEngine(TranscriptionEngine):
+    """OpenAI Whisper transcription engine."""
+
+    name = "whisper"
+
+    def transcribe(self, audio_path: str, config: dict) -> dict | None:
+        """Transcribes the given audio file using OpenAI Whisper.
+
+        Args:
+            audio_path: Path to the audio file (e.g., MP3).
+            config: Optional configuration dictionary to override defaults.
+
+        Returns:
+            A dictionary containing the transcription result (including text, segments, language)
+            or None if transcription fails.
+        """
+        if not os.path.exists(audio_path):
+            logger.error(f"Audio file not found for transcription: {audio_path}")
+            return None
+
+        # Use provided config or fall back to system config
+        get_config = config.get if config else config_manager.get
+        model_size = get_config("whisper_model_size", "base")
+        device = get_config("processing_device", "auto")
+
+        if device == "auto":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        logger.info(f"Starting transcription for {audio_path} using model: {model_size}, device: {device}")
+
+        # Ensure ffmpeg is in PATH
+        from backend.utils.audio import ensure_ffmpeg_in_path
+        ensure_ffmpeg_in_path()
+
+        try:
+            # Load model (use cache)
+            if model_size not in _model_cache:
+                logger.info(f"Loading Whisper model: {model_size}")
+
+                # Explicitly define download root to match preload_models.py
+                download_root = os.getenv("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache"))
+                download_root = os.path.join(download_root, "whisper")
+
+                _model_cache[model_size] = whisper.load_model(model_size, device=device, download_root=download_root)
+                logger.info(f"Whisper model {model_size} loaded successfully.")
+            model = _model_cache[model_size]
+
+            # Perform transcription
+
+            use_fp16 = device == "cuda"
+
+            # Check environment variable for word timestamps
+            # Default to True now that we have triton-windows support
+            env_var = os.environ.get("WHISPER_ENABLE_WORD_TIMESTAMPS")
+
+            if env_var is not None:
+                enable_word_timestamps = env_var.lower() == "true"
+                logger.info(f"Word timestamps set via env var: {enable_word_timestamps}")
+            else:
+                # Fallback to False on Windows if Triton is not working
+                import platform
+                is_windows = platform.system().lower() == "windows"
+                enable_word_timestamps = not is_windows
+                logger.info(f"Word timestamps auto-detected (Windows={is_windows}): {enable_word_timestamps}")
+
+            # condition_on_previous_text=False helps prevent hallucinations (e.g. "Thank you")
+            # especially when there are silence gaps or non-speech segments.
+            result = model.transcribe(
+                audio_path,
+                fp16=use_fp16,
+                word_timestamps=enable_word_timestamps,
+                condition_on_previous_text=False
+            )
+
+            logger.info(f"Transcription completed for {audio_path}. Detected language: {result.get('language')}")
+            # logger.debug(f"Transcription result: {result}") # Can be very verbose
+
+            return result
+
+        except Exception as e:
+            logger.error(f"Error during Whisper transcription for {audio_path}: {e}", exc_info=True)
+
+            if model_size in _model_cache and isinstance(e, RuntimeError): # e.g., CUDA out of memory
+                 logger.warning(f"Clearing model cache for {model_size} due to error.")
+                 del _model_cache[model_size]
+                 if device == "cuda":
+                     torch.cuda.empty_cache()
+            return None
+
+    def release(self) -> None:
+        """Releases all loaded Whisper models from memory and clears CUDA cache."""
+        global _model_cache
+        if _model_cache:
+            logger.info(f"Releasing {_model_cache.keys()} from Whisper model cache.")
+            _model_cache.clear()
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()

--- a/backend/processing/live_transcribe.py
+++ b/backend/processing/live_transcribe.py
@@ -1,0 +1,262 @@
+# backend/processing/live_transcribe.py
+# Live transcription lane: a Celery task that transcribes recording segments
+# as they arrive, producing provisional transcript segments. A sequence-gated
+# buffer re-imposes ordering on concurrently uploaded segments and carries the
+# trailing (incomplete) utterance forward across runs.
+
+import json
+import logging
+import os
+
+from backend.celery_app import celery_app
+from backend.utils.config_manager import config_manager
+from backend.utils.recording_storage import recording_upload_temp_dir
+
+logger = logging.getLogger(__name__)
+
+# Tolerance (seconds) for treating a speech region as touching the buffer end.
+TRAIL_EPS = 0.20
+# Maximum length (seconds) of a trailing utterance before a forced cut.
+FORCED_MAX = 30.0
+# Sample rate of the live audio buffer.
+LIVE_SAMPLE_RATE = 16000
+# Silence threshold (ms) for the live lane: longer than the batch default so
+# normal inter-phrase pauses do not fragment the live transcript.
+LIVE_MIN_SILENCE_MS = 700
+
+_STATE_FILENAME = "state.json"
+_BUFFER_FILENAME = "buffer.wav"
+
+
+def read_live_state(live_dir) -> dict:
+    """Read the live lane state, returning defaults when absent or unreadable."""
+    state_path = os.path.join(str(live_dir), _STATE_FILENAME)
+    default = {"next_expected": 1, "buffer_abs_start": 0.0}
+    try:
+        with open(state_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return {
+            "next_expected": int(data.get("next_expected", 1)),
+            "buffer_abs_start": float(data.get("buffer_abs_start", 0.0)),
+        }
+    except (FileNotFoundError, ValueError, OSError):
+        return default
+
+
+def write_live_state(live_dir, state: dict) -> None:
+    """Persist the live lane state to disk."""
+    state_path = os.path.join(str(live_dir), _STATE_FILENAME)
+    with open(state_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "next_expected": int(state["next_expected"]),
+                "buffer_abs_start": float(state["buffer_abs_start"]),
+            },
+            f,
+        )
+
+
+def classify_speech(speech: list[dict], combined_len: float) -> tuple[list[dict], float]:
+    """Split detected speech regions into completed regions and a carry-over cut point.
+
+    Returns (complete_segments, cut_point) where cut_point is the buffer offset
+    (seconds) from which unconsumed audio should be carried into the next run.
+    """
+    if not speech:
+        # No speech: drop the silent buffer entirely.
+        return [], combined_len
+
+    last = speech[-1]
+    trailing_incomplete = last["end"] >= combined_len - TRAIL_EPS
+
+    if trailing_incomplete and (combined_len - last["start"]) >= FORCED_MAX:
+        # Trailing utterance has run too long; treat it as complete now.
+        return speech, combined_len
+    if trailing_incomplete:
+        # Carry the trailing utterance forward from its start.
+        return speech[:-1], last["start"]
+    # Last region ended with silence; everything is complete.
+    return speech, last["end"]
+
+
+def _build_live_config() -> dict:
+    """Build a minimal config dict for the live transcription engine call."""
+    backend = config_manager.get("live_transcription_backend", "parakeet")
+    return {
+        "transcription_backend": backend,
+        "live_transcription_backend": backend,
+        "parakeet_model": config_manager.get("parakeet_model", "parakeet-tdt-0.6b-v3"),
+        "whisper_model_size": config_manager.get("whisper_model_size", "turbo"),
+        "processing_device": config_manager.get("processing_device", "auto"),
+    }
+
+
+@celery_app.task(bind=True)
+def transcribe_segment_live_task(self, recording_id: int, sequence: int):
+    """Transcribe an uploaded recording segment in the live lane.
+
+    Sequence-gated: only the task holding next_expected drains the contiguous
+    run of segments on disk. Any failure is logged and the lane still advances;
+    the final processing pipeline recovers everything.
+    """
+    import torch
+
+    from backend.core.db import get_sync_session
+    from backend.models.recording import Recording, RecordingStatus
+    from backend.processing.vad import detect_speech_segments, safe_read_audio
+    from backend.processing.transcribe import transcribe_audio
+
+    config_manager.reload()
+
+    # The live lane is only meaningful while the recording is uploading. Once
+    # finalize() runs, the API deletes the upload temp dir; a live task that is
+    # still queued must stop here rather than recreate an orphan dir or crash on
+    # the vanished buffer/state files. The final pipeline is authoritative.
+    session = get_sync_session()
+    try:
+        recording = session.get(Recording, recording_id)
+        if not recording or recording.status != RecordingStatus.UPLOADING:
+            return
+    finally:
+        session.close()
+
+    temp_dir = recording_upload_temp_dir(recording_id, create=False)
+    live_dir = temp_dir / "live"
+    live_dir.mkdir(parents=True, exist_ok=True)
+
+    state = read_live_state(live_dir)
+    next_expected = state["next_expected"]
+    buffer_abs_start = state["buffer_abs_start"]
+
+    # --- Gating ---
+    if sequence < next_expected:
+        # Already consumed by an earlier run.
+        return
+    if sequence > next_expected:
+        # Gap: this segment waits on disk until the run reaches it.
+        return
+
+    # --- Drain: contiguous run starting at next_expected ---
+    run = []
+    n = next_expected
+    while os.path.exists(str(temp_dir / f"{n}.wav")):
+        run.append(n)
+        n += 1
+    if not run:
+        # Defensive: the triggering segment should exist; nothing to do.
+        return
+
+    buffer_path = str(live_dir / _BUFFER_FILENAME)
+
+    try:
+        # --- Build combined buffer ---
+        parts = []
+        if os.path.exists(buffer_path):
+            parts.append(safe_read_audio(buffer_path, sampling_rate=LIVE_SAMPLE_RATE))
+        for seg_n in run:
+            parts.append(
+                safe_read_audio(str(temp_dir / f"{seg_n}.wav"), sampling_rate=LIVE_SAMPLE_RATE)
+            )
+
+        combined = torch.cat(parts) if parts else torch.zeros(0)
+        combined_len = combined.numel() / LIVE_SAMPLE_RATE
+        combined_abs_start = buffer_abs_start
+
+        # --- Detect speech and classify ---
+        speech = detect_speech_segments(combined, min_silence_duration_ms=LIVE_MIN_SILENCE_MS)
+        complete, cut_point = classify_speech(speech, combined_len)
+
+        # --- Transcribe each completed speech region ---
+        live_config = _build_live_config()
+        new_segments = []
+        for sp in complete:
+            start_sample = int(sp["start"] * LIVE_SAMPLE_RATE)
+            end_sample = int(sp["end"] * LIVE_SAMPLE_RATE)
+            clip = combined[start_sample:end_sample]
+            if clip.numel() == 0:
+                continue
+
+            clip_path = str(live_dir / "clip.wav")
+            try:
+                import silero_vad
+
+                tensor = clip if clip.ndim > 1 else clip.unsqueeze(0)
+                silero_vad.save_audio(clip_path, tensor, sampling_rate=LIVE_SAMPLE_RATE)
+                result = transcribe_audio(clip_path, config=live_config)
+            finally:
+                if os.path.exists(clip_path):
+                    try:
+                        os.remove(clip_path)
+                    except OSError:
+                        pass
+
+            if not result:
+                continue
+            text = (result.get("text") or "").strip()
+            if not text:
+                continue
+
+            new_segments.append(
+                {
+                    "start": combined_abs_start + sp["start"],
+                    "end": combined_abs_start + sp["end"],
+                    "speaker": "UNKNOWN",
+                    "text": text,
+                    "provisional": True,
+                }
+            )
+
+        # --- Carry over the unconsumed trailing audio ---
+        new_buffer = combined[int(cut_point * LIVE_SAMPLE_RATE):]
+        if new_buffer.numel() > 0:
+            tensor = new_buffer if new_buffer.ndim > 1 else new_buffer.unsqueeze(0)
+            import silero_vad
+
+            silero_vad.save_audio(buffer_path, tensor, sampling_rate=LIVE_SAMPLE_RATE)
+        elif os.path.exists(buffer_path):
+            try:
+                os.remove(buffer_path)
+            except OSError:
+                pass
+        new_abs_start = combined_abs_start + cut_point
+
+        # --- Persist provisional segments (race-guarded) ---
+        if new_segments:
+            from sqlalchemy.orm.attributes import flag_modified
+
+            session = get_sync_session()
+            try:
+                recording = session.get(Recording, recording_id)
+                if recording and recording.status == RecordingStatus.UPLOADING:
+                    transcript = recording.transcript
+                    if transcript is not None:
+                        transcript.segments = (transcript.segments or []) + new_segments
+                        flag_modified(transcript, "segments")
+                        session.add(transcript)
+                        session.commit()
+            finally:
+                session.close()
+
+        # --- Advance the lane ---
+        state["next_expected"] = run[-1] + 1
+        state["buffer_abs_start"] = new_abs_start
+        write_live_state(live_dir, state)
+
+    except Exception as exc:
+        # Non-fatal: log, advance past the run, do not re-raise. The final
+        # processing pipeline re-transcribes everything from the source audio.
+        logger.error(
+            "Live transcription failed for recording %s run %s: %s",
+            recording_id,
+            run,
+            exc,
+            exc_info=True,
+        )
+        # Best-effort advance: if the live dir vanished (recording finalized
+        # mid-run) there is nothing left to advance — the final pipeline owns
+        # the transcript now.
+        try:
+            state["next_expected"] = run[-1] + 1
+            write_live_state(live_dir, state)
+        except OSError:
+            pass

--- a/backend/processing/live_transcribe.py
+++ b/backend/processing/live_transcribe.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import os
+import re
 
 from backend.celery_app import celery_app
 from backend.utils.config_manager import config_manager
@@ -26,6 +27,7 @@ LIVE_MIN_SILENCE_MS = 700
 
 _STATE_FILENAME = "state.json"
 _BUFFER_FILENAME = "buffer.wav"
+_CONTEXT_FILENAME = "context.wav"
 
 
 def read_live_state(live_dir) -> dict:
@@ -88,7 +90,103 @@ def _build_live_config() -> dict:
         "parakeet_model": config_manager.get("parakeet_model", "parakeet-tdt-0.6b-v3"),
         "whisper_model_size": config_manager.get("whisper_model_size", "turbo"),
         "processing_device": config_manager.get("processing_device", "auto"),
+        "context_window_s": config_manager.get("live_context_window_s", 5.0),
+        "speech_pad_ms": config_manager.get("live_speech_pad_ms", 300),
     }
+
+
+def _extract_region_text(result: dict, prefix_s: float) -> str:
+    """Select, from an engine result for a context-prefixed clip, the text that
+    belongs to the speech region (the audio after `prefix_s` seconds).
+
+    The clip handed to the engine is `left_context ++ region`; `prefix_s` is the
+    length of the left-context run-up. Segment/word timestamps are clip-relative.
+    """
+    EPS = 0.10
+    segments = result.get("segments") or []
+    if not segments:
+        if prefix_s <= 0:
+            return (result.get("text") or "").strip()
+        return ""
+
+    kept: list[str] = []
+    for seg in segments:
+        start = float(seg.get("start", 0.0))
+        end = float(seg.get("end", 0.0))
+        seg_text = (seg.get("text") or "").strip()
+        if not seg_text:
+            continue
+        if end <= prefix_s + EPS:
+            # Pure context: entirely within the run-up.
+            continue
+        if start >= prefix_s - EPS:
+            # Entirely within the region.
+            kept.append(seg_text)
+            continue
+        # Straddles the prefix boundary.
+        words = seg.get("words")
+        if words:
+            region_words = [
+                (w.get("word") or "")
+                for w in words
+                if float(w.get("start", 0.0)) >= prefix_s - EPS
+            ]
+            joined = " ".join(p.strip() for p in region_words if p.strip())
+            if joined:
+                kept.append(joined)
+        elif (start + end) / 2 >= prefix_s:
+            kept.append(seg_text)
+
+    return re.sub(r"\s+", " ", " ".join(kept)).strip()
+
+
+def _strip_repetition(text: str) -> str:
+    """Lightweight hallucination guard: collapse runs of repeated words or short
+    phrases. Defensive only — on any doubt the text is returned unchanged.
+    """
+    if not text:
+        return text
+    words = text.split()
+    if len(words) < 3:
+        return text
+
+    # Collapse a run of 3+ consecutive identical words to a single occurrence.
+    deduped: list[str] = []
+    i = 0
+    n_words = len(words)
+    while i < n_words:
+        j = i
+        while j < n_words and words[j] == words[i]:
+            j += 1
+        run = j - i
+        deduped.extend([words[i]] if run >= 3 else words[i:j])
+        i = j
+
+    # Collapse a short phrase (2-5 words) repeated 3+ times consecutively.
+    out: list[str] = []
+    i = 0
+    n = len(deduped)
+    while i < n:
+        collapsed = False
+        for plen in range(2, 6):
+            if i + plen * 3 > n:
+                continue
+            phrase = deduped[i : i + plen]
+            reps = 1
+            j = i + plen
+            while j + plen <= n and deduped[j : j + plen] == phrase:
+                reps += 1
+                j += plen
+            if reps >= 3:
+                out.extend(phrase)
+                i = j
+                collapsed = True
+                break
+        if not collapsed:
+            out.append(deduped[i])
+            i += 1
+
+    return " ".join(out)
 
 
 @celery_app.task(bind=True)
@@ -162,19 +260,42 @@ def transcribe_segment_live_task(self, recording_id: int, sequence: int):
         combined_len = combined.numel() / LIVE_SAMPLE_RATE
         combined_abs_start = buffer_abs_start
 
+        # --- Build the live engine config (needed before the VAD call) ---
+        live_config = _build_live_config()
+        W = int(live_config["context_window_s"] * LIVE_SAMPLE_RATE)
+
         # --- Detect speech and classify ---
-        speech = detect_speech_segments(combined, min_silence_duration_ms=LIVE_MIN_SILENCE_MS)
+        speech = detect_speech_segments(
+            combined,
+            min_silence_duration_ms=LIVE_MIN_SILENCE_MS,
+            speech_pad_ms=live_config["speech_pad_ms"],
+        )
         complete, cut_point = classify_speech(speech, combined_len)
 
+        # --- Read the rolling left-context buffer (already-consumed audio) ---
+        context_path = str(live_dir / _CONTEXT_FILENAME)
+        if os.path.exists(context_path):
+            prev_context = safe_read_audio(context_path, sampling_rate=LIVE_SAMPLE_RATE)
+        else:
+            prev_context = torch.zeros(0)
+
         # --- Transcribe each completed speech region ---
-        live_config = _build_live_config()
         new_segments = []
         for sp in complete:
             start_sample = int(sp["start"] * LIVE_SAMPLE_RATE)
             end_sample = int(sp["end"] * LIVE_SAMPLE_RATE)
-            clip = combined[start_sample:end_sample]
-            if clip.numel() == 0:
+            region = combined[start_sample:end_sample]
+            if region.numel() == 0:
                 continue
+
+            # Prepend a rolling audio context window so the engine has run-up.
+            left_context = torch.cat([prev_context, combined[:start_sample]])
+            if W > 0:
+                left_context = left_context[-W:]
+            else:
+                left_context = left_context[:0]
+            clip = torch.cat([left_context, region])
+            prefix_s = left_context.numel() / LIVE_SAMPLE_RATE
 
             clip_path = str(live_dir / "clip.wav")
             try:
@@ -192,7 +313,7 @@ def transcribe_segment_live_task(self, recording_id: int, sequence: int):
 
             if not result:
                 continue
-            text = (result.get("text") or "").strip()
+            text = _strip_repetition(_extract_region_text(result, prefix_s))
             if not text:
                 continue
 
@@ -207,7 +328,8 @@ def transcribe_segment_live_task(self, recording_id: int, sequence: int):
             )
 
         # --- Carry over the unconsumed trailing audio ---
-        new_buffer = combined[int(cut_point * LIVE_SAMPLE_RATE):]
+        cut_sample = int(cut_point * LIVE_SAMPLE_RATE)
+        new_buffer = combined[cut_sample:]
         if new_buffer.numel() > 0:
             tensor = new_buffer if new_buffer.ndim > 1 else new_buffer.unsqueeze(0)
             import silero_vad
@@ -219,6 +341,25 @@ def transcribe_segment_live_task(self, recording_id: int, sequence: int):
             except OSError:
                 pass
         new_abs_start = combined_abs_start + cut_point
+
+        # --- Update the rolling left-context buffer ---
+        # consumed = the already-consumed audio immediately preceding the new
+        # buffer; its last W samples become run-up for the next run.
+        consumed = torch.cat([prev_context, combined[:cut_sample]])
+        if W > 0:
+            consumed = consumed[-W:]
+        else:
+            consumed = consumed[:0]
+        if consumed.numel() > 0:
+            tensor = consumed if consumed.ndim > 1 else consumed.unsqueeze(0)
+            import silero_vad
+
+            silero_vad.save_audio(context_path, tensor, sampling_rate=LIVE_SAMPLE_RATE)
+        elif os.path.exists(context_path):
+            try:
+                os.remove(context_path)
+            except OSError:
+                pass
 
         # --- Persist provisional segments (race-guarded) ---
         if new_segments:

--- a/backend/processing/transcribe.py
+++ b/backend/processing/transcribe.py
@@ -1,252 +1,57 @@
 # nojoin/processing/transcribe.py
+# Thin dispatcher: selects a pluggable transcription engine. The Whisper engine
+# logic lives in backend/processing/engines/whisper_engine.py.
 
-import whisper
 import logging
-import os
-import torch
-import tqdm
-import threading
 
 from ..utils.config_manager import config_manager
-# from ..utils.progress_manager import get_progress_manager
 
 logger = logging.getLogger(__name__)
 
-# Cache for loaded models to avoid reloading
-_model_cache = {}
+_ENGINE_REGISTRY = {}  # name -> TranscriptionEngine instance
 
-def release_model_cache():
-    """Releases all loaded Whisper models from memory and clears CUDA cache."""
-    global _model_cache
-    if _model_cache:
-        logger.info(f"Releasing {_model_cache.keys()} from Whisper model cache.")
-        _model_cache.clear()
-    
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
 
-# --- Whisper Progress Listener Infrastructure ---
-class ProgressListener:
-    def __init__(self, callback):
-        self.callback = callback
-    def on_progress(self, current, total):
-        percent = int((current / total) * 100) if total else 0
-        if self.callback:
-            self.callback(min(percent, 100))
-    def on_finished(self):
-        if self.callback:
-            self.callback(100)
+def _get_engine(name: str):
+    """Return (creating once, lazily) the engine instance for the given name.
 
-class ProgressListenerHandle:
-    def __init__(self, listener):
-        self.listener = listener
-    def __enter__(self):
-        register_thread_local_progress_listener(self.listener)
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        unregister_thread_local_progress_listener(self.listener)
-        if exc_type is None:
-            self.listener.on_finished()
+    Heavy engine modules are imported lazily so this dispatcher carries no
+    heavy module-level imports.
+    """
+    if name in _ENGINE_REGISTRY:
+        return _ENGINE_REGISTRY[name]
+    if name == "whisper":
+        from .engines.whisper_engine import WhisperEngine
+        engine = WhisperEngine()
+    elif name == "parakeet":
+        from .engines.parakeet_engine import ParakeetEngine
+        engine = ParakeetEngine()
+    else:
+        raise ValueError(f"Unknown transcription backend: {name}")
+    _ENGINE_REGISTRY[name] = engine
+    return engine
 
-class _CustomProgressBar(tqdm.tqdm):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._current = self.n
-    def update(self, n):
-        super().update(n)
-        self._current += n
-        listeners = _get_thread_local_listeners()
-        for listener in listeners:
-            listener.on_progress(self._current, self.total)
-
-_thread_local = threading.local()
-_hooked = False
-
-def _get_thread_local_listeners():
-    if not hasattr(_thread_local, 'listeners'):
-        _thread_local.listeners = []
-    return _thread_local.listeners
-
-def init_progress_hook():
-    global _hooked
-    if _hooked:
-        return
-    import tqdm
-    tqdm.tqdm = _CustomProgressBar
-    _hooked = True
-
-def register_thread_local_progress_listener(progress_listener):
-    init_progress_hook()
-    listeners = _get_thread_local_listeners()
-    listeners.append(progress_listener)
-
-def unregister_thread_local_progress_listener(progress_listener):
-    listeners = _get_thread_local_listeners()
-    if progress_listener in listeners:
-        listeners.remove(progress_listener)
-
-def create_progress_listener_handle(progress_listener):
-    return ProgressListenerHandle(progress_listener)
 
 def transcribe_audio(audio_path: str, config: dict = None) -> dict | None:
-    """Transcribes the given audio file using OpenAI Whisper.
+    """Transcribe an audio file with the engine selected in config.
 
-    Args:
-        audio_path: Path to the audio file (e.g., MP3).
-        config: Optional configuration dictionary to override defaults.
-
-    Returns:
-        A dictionary containing the transcription result (including text, segments, language)
-        or None if transcription fails.
+    Reads config['transcription_backend'] (default 'whisper'). Public signature
+    preserved for backend/worker/tasks.py. Returns the canonical transcription
+    dict, or None on failure / unknown engine.
     """
-    if not os.path.exists(audio_path):
-        logger.error(f"Audio file not found for transcription: {audio_path}")
-        return None
-
-    # Use provided config or fall back to system config
     get_config = config.get if config else config_manager.get
-    model_size = get_config("whisper_model_size", "base")
-    device = get_config("processing_device", "auto")
-    
-    if device == "auto":
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-
-    logger.info(f"Starting transcription for {audio_path} using model: {model_size}, device: {device}")
-
-    # Ensure ffmpeg is in PATH
-    from backend.utils.audio import ensure_ffmpeg_in_path
-    ensure_ffmpeg_in_path()
-
+    backend = get_config("transcription_backend", "whisper")
     try:
-        # Load model (use cache)
-        if model_size not in _model_cache:
-            logger.info(f"Loading Whisper model: {model_size}")
-            
-            # Explicitly define download root to match preload_models.py
-            download_root = os.getenv("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache"))
-            download_root = os.path.join(download_root, "whisper")
-            
-            _model_cache[model_size] = whisper.load_model(model_size, device=device, download_root=download_root)
-            logger.info(f"Whisper model {model_size} loaded successfully.")
-        model = _model_cache[model_size]
-
-        # Perform transcription
-
-        use_fp16 = device == "cuda" 
-        
-        # Check environment variable for word timestamps
-        # Default to True now that we have triton-windows support
-        env_var = os.environ.get("WHISPER_ENABLE_WORD_TIMESTAMPS")
-        
-        if env_var is not None:
-            enable_word_timestamps = env_var.lower() == "true"
-            logger.info(f"Word timestamps set via env var: {enable_word_timestamps}")
-        else:
-            # Fallback to False on Windows if Triton is not working
-            import platform
-            is_windows = platform.system().lower() == "windows"
-            enable_word_timestamps = not is_windows
-            logger.info(f"Word timestamps auto-detected (Windows={is_windows}): {enable_word_timestamps}")
-
-        # condition_on_previous_text=False helps prevent hallucinations (e.g. "Thank you")
-        # especially when there are silence gaps or non-speech segments.
-        result = model.transcribe(
-            audio_path, 
-            fp16=use_fp16, 
-            word_timestamps=enable_word_timestamps,
-            condition_on_previous_text=False
-        )
-
-        logger.info(f"Transcription completed for {audio_path}. Detected language: {result.get('language')}")
-        # logger.debug(f"Transcription result: {result}") # Can be very verbose
-
-        return result
-
-    except Exception as e:
-        logger.error(f"Error during Whisper transcription for {audio_path}: {e}", exc_info=True)
-
-        if model_size in _model_cache and isinstance(e, RuntimeError): # e.g., CUDA out of memory
-             logger.warning(f"Clearing model cache for {model_size} due to error.")
-             del _model_cache[model_size]
-             if device == "cuda":
-                 torch.cuda.empty_cache()
+        engine = _get_engine(backend)
+    except (ValueError, ImportError) as e:
+        logger.error(f"Transcription backend '{backend}' unavailable: {e}")
         return None
+    return engine.transcribe(audio_path, config or {})
 
-def transcribe_audio_with_progress(audio_path: str, progress_callback=None, cancel_check=None) -> dict | None:
-    """Transcribes the given audio file using OpenAI Whisper, emitting progress via callback. Supports cancellation."""
-    if not os.path.exists(audio_path):
-        logger.error(f"Audio file not found for transcription: {audio_path}")
-        return None
 
-    model_size = config_manager.get("whisper_model_size", "base")
-    device = config_manager.get("processing_device", "cpu")
-
-    logger.info(f"Starting transcription for {audio_path} using model: {model_size}, device: {device}")
-
-    # Ensure ffmpeg is in PATH
-    from backend.utils.audio import ensure_ffmpeg_in_path
-    ensure_ffmpeg_in_path()
-
-    try:
-        # Load model (use cache)
-        if model_size not in _model_cache:
-            logger.info(f"Loading Whisper model: {model_size}")
-            # Check if model exists locally, if not it will be downloaded by whisper.load_model
-            from ..utils.model_utils import is_whisper_model_downloaded
-            if not is_whisper_model_downloaded(model_size):
-                logger.info(f"Whisper model {model_size} not found locally - will be downloaded")
-            _model_cache[model_size] = whisper.load_model(model_size, device=device)
-            logger.info(f"Whisper model {model_size} loaded successfully.")
-        model = _model_cache[model_size]
-
-        # Use unified progress system for transcription
-        # progress_manager = get_progress_manager()
-        
-        # with progress_manager.create_transcription_context(progress_callback) as context:
-        if True: # Placeholder to keep indentation
-            try:
-                use_fp16 = device == "cuda"
-                
-                # Check for cancellation before starting
-                if cancel_check and cancel_check():
-                    logger.info("Transcription cancelled before starting model.transcribe.")
-                    return None
-                    
-                # Perform transcription with progress tracking
-                
-                # Check environment variable for word timestamps
-                # Default to True now that we have triton-windows support
-                env_var = os.environ.get("WHISPER_ENABLE_WORD_TIMESTAMPS")
-                if env_var is not None:
-                    enable_word_timestamps = env_var.lower() == "true"
-                else:
-                    import platform
-                    enable_word_timestamps = platform.system().lower() != "windows"
-                
-                result = model.transcribe(audio_path, fp16=use_fp16, verbose=None, word_timestamps=enable_word_timestamps)
-                
-                # Check for cancellation after transcribe
-                if cancel_check and cancel_check():
-                    logger.info("Transcription cancelled after model.transcribe.")
-                    return None
-                    
-                # Ensure 100% completion is reported
-                # context.emit_progress(100, 100) # context is not defined here
-                if progress_callback:
-                    progress_callback(100)
-                    
-                logger.info(f"Transcription completed for {audio_path}. Detected language: {result.get('language')}")
-                return result
-                
-            except Exception as e:
-                logger.error(f"Error during transcription: {e}", exc_info=True)
-                raise
-                
-    except Exception as e:
-        logger.error(f"Error during Whisper transcription for {audio_path}: {e}", exc_info=True)
-        if model_size in _model_cache and isinstance(e, RuntimeError):
-            logger.warning(f"Clearing model cache for {model_size} due to error.")
-            del _model_cache[model_size]
-            if device == "cuda":
-                torch.cuda.empty_cache()
-        return None
-
+def release_model_cache() -> None:
+    """Release cached models of every instantiated engine."""
+    for engine in _ENGINE_REGISTRY.values():
+        try:
+            engine.release()
+        except Exception as e:
+            logger.warning(f"Error releasing engine '{engine.name}': {e}")

--- a/backend/processing/vad.py
+++ b/backend/processing/vad.py
@@ -323,6 +323,52 @@ def _apply_vad_processing(
     return processed_audio
 
 
+def detect_speech_segments(audio, sample_rate: int = 16000, min_silence_duration_ms: int | None = None) -> list:
+    """Return speech-region boundaries for a 16 kHz mono audio buffer.
+
+    audio: either a 1-D torch tensor of 16 kHz mono samples, OR a path to a WAV file.
+    min_silence_duration_ms: optional override for the minimum silence gap (ms).
+        When not None, it overrides the value from get_vad_config_from_settings();
+        when None, the config/default value is used (behaviour unchanged).
+    Returns: list[dict] of {"start": float_seconds, "end": float_seconds}.
+    """
+    from pathlib import Path
+
+    # Resolve the input into a tensor.
+    if isinstance(audio, (str, Path)):
+        tensor = safe_read_audio(str(audio), sampling_rate=sample_rate)
+    else:
+        tensor = audio
+
+    # Load the VAD model.
+    model = silero_vad.load_silero_vad()
+
+    # Merge VAD parameters from settings, falling back to sensible defaults.
+    vad_config = get_vad_config_from_settings()
+    threshold = vad_config.get("threshold", 0.5)
+    min_speech_duration_ms = vad_config.get("min_speech_duration_ms", 250)
+    if min_silence_duration_ms is None:
+        min_silence_duration_ms = vad_config.get("min_silence_duration_ms", 2000)
+    speech_pad_ms = vad_config.get("speech_pad_ms", 30)
+
+    timestamps = silero_vad.get_speech_timestamps(
+        tensor,
+        model,
+        sampling_rate=sample_rate,
+        return_seconds=True,
+        threshold=threshold,
+        min_speech_duration_ms=min_speech_duration_ms,
+        min_silence_duration_ms=min_silence_duration_ms,
+        speech_pad_ms=speech_pad_ms,
+    )
+
+    # Normalise the dict shape and coerce to float seconds.
+    return [
+        {"start": float(seg["start"]), "end": float(seg["end"])}
+        for seg in timestamps
+    ]
+
+
 def get_vad_config_from_settings() -> Dict[str, Any]:
     """Get VAD configuration from application settings."""
     from backend.utils.config_manager import config_manager

--- a/backend/processing/vad.py
+++ b/backend/processing/vad.py
@@ -323,13 +323,22 @@ def _apply_vad_processing(
     return processed_audio
 
 
-def detect_speech_segments(audio, sample_rate: int = 16000, min_silence_duration_ms: int | None = None) -> list:
+def detect_speech_segments(
+    audio,
+    sample_rate: int = 16000,
+    min_silence_duration_ms: int | None = None,
+    speech_pad_ms: int | None = None,
+) -> list:
     """Return speech-region boundaries for a 16 kHz mono audio buffer.
 
     audio: either a 1-D torch tensor of 16 kHz mono samples, OR a path to a WAV file.
     min_silence_duration_ms: optional override for the minimum silence gap (ms).
         When not None, it overrides the value from get_vad_config_from_settings();
         when None, the config/default value is used (behaviour unchanged).
+    speech_pad_ms: optional override for the per-region padding (ms) applied by
+        silero VAD. When not None, it overrides the value from
+        get_vad_config_from_settings(); when None, the config/default value is
+        used (behaviour unchanged for the batch path).
     Returns: list[dict] of {"start": float_seconds, "end": float_seconds}.
     """
     from pathlib import Path
@@ -349,7 +358,8 @@ def detect_speech_segments(audio, sample_rate: int = 16000, min_silence_duration
     min_speech_duration_ms = vad_config.get("min_speech_duration_ms", 250)
     if min_silence_duration_ms is None:
         min_silence_duration_ms = vad_config.get("min_silence_duration_ms", 2000)
-    speech_pad_ms = vad_config.get("speech_pad_ms", 30)
+    if speech_pad_ms is None:
+        speech_pad_ms = vad_config.get("speech_pad_ms", 30)
 
     timestamps = silero_vad.get_speech_timestamps(
         tensor,

--- a/backend/tests/test_live_transcription.py
+++ b/backend/tests/test_live_transcription.py
@@ -1,0 +1,878 @@
+"""Tests for live transcription config keys and early Transcript creation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.api.deps import get_current_recording_client_user, get_db
+from backend.api.v1.api import api_router
+from backend.utils.config_manager import (
+    DEFAULT_SYSTEM_CONFIG,
+    ConfigManager,
+    config_manager,
+)
+
+validate_config_value = config_manager.validate_config_value
+
+
+# --- Config key tests -------------------------------------------------------
+
+
+def test_config_default_live_transcription_keys_present():
+    """The two live transcription keys ship in DEFAULT_SYSTEM_CONFIG."""
+    assert DEFAULT_SYSTEM_CONFIG["enable_live_transcription"] is True
+    assert DEFAULT_SYSTEM_CONFIG["live_transcription_backend"] == "parakeet"
+
+
+def test_live_transcription_keys_survive_reload(tmp_path):
+    """Persisted live transcription keys survive a config_manager reload.
+
+    Keys absent from DEFAULT_SYSTEM_CONFIG are dropped by the persistence
+    filter on reload, so this guards against that regression.
+    """
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "enable_live_transcription": False,
+                "live_transcription_backend": "whisper",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = ConfigManager(config_path=str(config_path))
+    assert manager.get("enable_live_transcription") is False
+    assert manager.get("live_transcription_backend") == "whisper"
+
+    manager.reload()
+    assert manager.get("enable_live_transcription") is False
+    assert manager.get("live_transcription_backend") == "whisper"
+
+
+def test_validate_config_value_live_transcription_backend():
+    """live_transcription_backend accepts known backends and rejects others."""
+    assert validate_config_value("live_transcription_backend", "whisper") is True
+    assert validate_config_value("live_transcription_backend", "parakeet") is True
+    assert validate_config_value("live_transcription_backend", "bogus") is False
+
+
+def test_validate_config_value_enable_live_transcription():
+    """enable_live_transcription is validated as a boolean."""
+    assert validate_config_value("enable_live_transcription", True) is True
+    assert validate_config_value("enable_live_transcription", False) is True
+    assert validate_config_value("enable_live_transcription", "yes") is False
+
+
+# --- init endpoint Transcript creation test ---------------------------------
+
+RECORDINGS_SCHEMA = """
+CREATE TABLE recordings (
+    id INTEGER PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    public_id VARCHAR(36) NOT NULL,
+    meeting_uid VARCHAR(36) NOT NULL,
+    audio_path VARCHAR(1024) NOT NULL,
+    proxy_path VARCHAR(1024),
+    celery_task_id VARCHAR(255),
+    duration_seconds FLOAT,
+    file_size_bytes INTEGER,
+    status VARCHAR(32) NOT NULL,
+    client_status VARCHAR(32),
+    upload_progress INTEGER NOT NULL,
+    processing_progress INTEGER NOT NULL,
+    processing_step VARCHAR(255),
+    processing_started_at DATETIME,
+    processing_completed_at DATETIME,
+    is_archived BOOLEAN NOT NULL,
+    is_deleted BOOLEAN NOT NULL,
+    user_id INTEGER
+)
+"""
+
+TRANSCRIPTS_SCHEMA = """
+CREATE TABLE transcripts (
+    id INTEGER PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    recording_id INTEGER NOT NULL UNIQUE,
+    text TEXT,
+    segments JSON,
+    notes TEXT,
+    user_notes TEXT,
+    notes_status VARCHAR(32) NOT NULL,
+    transcript_status VARCHAR(32) NOT NULL,
+    error_message TEXT
+)
+"""
+
+
+def build_test_user(user_id: int = 1, username: str = "alice"):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=user_id,
+        username=username,
+        force_password_change=False,
+    )
+
+
+@pytest.fixture
+async def test_session_maker() -> sessionmaker:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as connection:
+        await connection.execute(text(RECORDINGS_SCHEMA))
+        await connection.execute(text(TRANSCRIPTS_SCHEMA))
+
+    try:
+        yield session_maker
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def api_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+async def client(api_app: FastAPI, test_session_maker: sessionmaker, monkeypatch) -> AsyncClient:
+    async def override_get_db():
+        async with test_session_maker() as session:
+            yield session
+
+    api_app.dependency_overrides[get_db] = override_get_db
+    api_app.dependency_overrides[get_current_recording_client_user] = lambda: build_test_user()
+
+    transport = ASGITransport(app=api_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+    api_app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_init_endpoint_creates_processing_transcript(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """POST /recordings/init creates a Transcript row in 'processing' status."""
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    monkeypatch.setattr(
+        recordings_module, "recordings_root_dir", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        recordings_module, "recording_upload_temp_dir", lambda *a, **k: tmp_path
+    )
+
+    response = await client.post("/api/v1/recordings/init", params={"name": "Live meeting"})
+
+    assert response.status_code == 200
+
+    async with test_session_maker() as session:
+        result = await session.execute(
+            text("SELECT recording_id, transcript_status FROM transcripts")
+        )
+        rows = result.all()
+
+    assert len(rows) == 1
+    assert rows[0][1] == "processing"
+
+
+# --- detect_speech_segments VAD helper tests --------------------------------
+
+
+def test_detect_speech_segments_normalises_tensor_input(monkeypatch):
+    """detect_speech_segments returns clean {start, end} float dicts for a tensor."""
+    import torch
+
+    from backend.processing import vad as vad_module
+
+    # Synthetic 16 kHz mono buffer: silence + noise burst + silence (3 seconds).
+    sample_rate = 16000
+    buffer = torch.zeros(3 * sample_rate)
+    buffer[sample_rate : 2 * sample_rate] = torch.randn(sample_rate) * 0.5
+
+    fake_timestamps = [{"start": 1.0, "end": 2.0}]
+
+    monkeypatch.setattr(
+        vad_module.silero_vad, "load_silero_vad", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(
+        vad_module.silero_vad,
+        "get_speech_timestamps",
+        lambda *a, **k: fake_timestamps,
+    )
+
+    result = vad_module.detect_speech_segments(buffer, sample_rate=sample_rate)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    segment = result[0]
+    assert set(segment.keys()) == {"start", "end"}
+    assert isinstance(segment["start"], float)
+    assert isinstance(segment["end"], float)
+    assert segment["start"] < segment["end"]
+    assert 0.0 <= segment["start"]
+    assert segment["end"] <= 3.0
+
+
+def test_detect_speech_segments_path_input(monkeypatch):
+    """detect_speech_segments loads a WAV path via safe_read_audio."""
+    import torch
+
+    from backend.processing import vad as vad_module
+
+    dummy_tensor = torch.zeros(16000)
+    calls = {}
+
+    def fake_safe_read_audio(path, sampling_rate=16000):
+        calls["path"] = path
+        calls["sampling_rate"] = sampling_rate
+        return dummy_tensor
+
+    monkeypatch.setattr(vad_module, "safe_read_audio", fake_safe_read_audio)
+    monkeypatch.setattr(
+        vad_module.silero_vad, "load_silero_vad", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(
+        vad_module.silero_vad,
+        "get_speech_timestamps",
+        lambda *a, **k: [{"start": 0.25, "end": 0.75}],
+    )
+
+    result = vad_module.detect_speech_segments("/tmp/sample.wav", sample_rate=16000)
+
+    assert calls["path"] == "/tmp/sample.wav"
+    assert calls["sampling_rate"] == 16000
+    assert result == [{"start": 0.25, "end": 0.75}]
+
+
+def test_detect_speech_segments_min_silence_override(monkeypatch):
+    """An explicit min_silence_duration_ms overrides the config value."""
+    import torch
+
+    from backend.processing import vad as vad_module
+
+    captured = {}
+
+    def fake_get_speech_timestamps(*a, **k):
+        captured.update(k)
+        return []
+
+    monkeypatch.setattr(
+        vad_module.silero_vad, "load_silero_vad", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(
+        vad_module.silero_vad, "get_speech_timestamps", fake_get_speech_timestamps
+    )
+
+    vad_module.detect_speech_segments(
+        torch.zeros(16000), sample_rate=16000, min_silence_duration_ms=700
+    )
+
+    assert captured["min_silence_duration_ms"] == 700
+
+
+def test_detect_speech_segments_min_silence_default(monkeypatch):
+    """Without an override, the config/default min_silence value is used."""
+    import torch
+
+    from backend.processing import vad as vad_module
+
+    captured = {}
+
+    def fake_get_speech_timestamps(*a, **k):
+        captured.update(k)
+        return []
+
+    monkeypatch.setattr(
+        vad_module.silero_vad, "load_silero_vad", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(
+        vad_module.silero_vad, "get_speech_timestamps", fake_get_speech_timestamps
+    )
+
+    vad_module.detect_speech_segments(torch.zeros(16000), sample_rate=16000)
+
+    # get_vad_config_from_settings ships the batch-tuned default of 100 ms.
+    assert captured["min_silence_duration_ms"] == 100
+
+
+def test_detect_speech_segments_silence_returns_empty(monkeypatch):
+    """detect_speech_segments returns [] when no speech is detected."""
+    import torch
+
+    from backend.processing import vad as vad_module
+
+    silence = torch.zeros(2 * 16000)
+
+    monkeypatch.setattr(
+        vad_module.silero_vad, "load_silero_vad", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(
+        vad_module.silero_vad, "get_speech_timestamps", lambda *a, **k: []
+    )
+
+    result = vad_module.detect_speech_segments(silence, sample_rate=16000)
+
+    assert result == []
+
+
+# --- live_transcribe helper + task tests -----------------------------------
+
+
+def _make_segment_wav(temp_dir, sequence: int, seconds: float):
+    """Write a synthetic 16 kHz mono WAV segment to the recording temp dir."""
+    import torch
+    import torchaudio
+
+    from backend.processing.live_transcribe import LIVE_SAMPLE_RATE
+
+    samples = int(seconds * LIVE_SAMPLE_RATE)
+    tensor = torch.zeros(1, samples)
+    path = temp_dir / f"{sequence}.wav"
+    torchaudio.save(str(path), tensor, LIVE_SAMPLE_RATE)
+    return path
+
+
+def test_classify_speech_empty():
+    """Empty speech drops the silent buffer; cut point is the whole buffer."""
+    from backend.processing.live_transcribe import classify_speech
+
+    complete, cut = classify_speech([], 5.0)
+    assert complete == []
+    assert cut == 5.0
+
+
+def test_classify_speech_trailing_incomplete_carries():
+    """A region touching the buffer end is carried from its start."""
+    from backend.processing.live_transcribe import classify_speech
+
+    speech = [{"start": 0.0, "end": 1.0}, {"start": 3.0, "end": 5.0}]
+    complete, cut = classify_speech(speech, 5.0)
+    assert complete == [{"start": 0.0, "end": 1.0}]
+    assert cut == 3.0
+
+
+def test_classify_speech_last_ends_with_silence():
+    """A region ending before the buffer end is complete; cut at its end."""
+    from backend.processing.live_transcribe import classify_speech
+
+    speech = [{"start": 0.0, "end": 1.0}, {"start": 2.0, "end": 3.0}]
+    complete, cut = classify_speech(speech, 5.0)
+    assert complete == speech
+    assert cut == 3.0
+
+
+def test_classify_speech_forced_cut():
+    """A trailing region longer than FORCED_MAX is treated as complete."""
+    from backend.processing.live_transcribe import classify_speech
+
+    speech = [{"start": 0.0, "end": 31.0}]
+    complete, cut = classify_speech(speech, 31.0)
+    assert complete == speech
+    assert cut == 31.0
+
+
+def _patch_live_deps(monkeypatch, *, speech_map, transcribe_text="hello", db_status="UPLOADING"):
+    """Patch torch-free fakes for vad / transcribe / DB used by the live task.
+
+    speech_map: callable(combined_tensor) -> list[{"start", "end"}].
+    """
+    import torch
+
+    from backend.processing import live_transcribe as lt
+    from backend.processing import vad as vad_module
+    from backend.processing import transcribe as transcribe_module
+
+    monkeypatch.setattr(vad_module, "detect_speech_segments", lambda audio, *a, **k: speech_map(audio))
+    monkeypatch.setattr(
+        transcribe_module,
+        "transcribe_audio",
+        lambda path, config=None: {"text": transcribe_text, "language": None, "segments": []},
+    )
+    # silero_vad.save_audio is real (torchaudio-backed); the buffer.wav it
+    # writes is needed for the carry-over seam test.
+
+
+class _FakeTranscript:
+    def __init__(self, segments=None):
+        self.segments = segments if segments is not None else []
+
+
+class _FakeRecording:
+    def __init__(self, status, transcript):
+        self.status = status
+        self.transcript = transcript
+
+
+class _FakeSession:
+    def __init__(self, recording):
+        self._recording = recording
+        self.committed = False
+
+    def get(self, model, recording_id):
+        return self._recording
+
+    def add(self, obj):
+        pass
+
+    def commit(self):
+        self.committed = True
+
+    def close(self):
+        pass
+
+
+def _run_live_task(monkeypatch, recording_id, sequence, fake_session):
+    """Invoke the live task with the DB session and flag_modified stubbed."""
+    from backend.core import db as db_module
+    from sqlalchemy.orm import attributes
+
+    from backend.processing.live_transcribe import transcribe_segment_live_task
+
+    monkeypatch.setattr(db_module, "get_sync_session", lambda: fake_session)
+    monkeypatch.setattr(attributes, "flag_modified", lambda obj, key: None)
+    transcribe_segment_live_task.run(recording_id, sequence)
+
+
+def test_live_in_order_run(monkeypatch, tmp_path):
+    """Segments 1,2,3 dispatched in order append provisional segments in order."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+
+    temp_dir = tmp_path / "42"
+    temp_dir.mkdir()
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+
+    # Each single-segment run yields one speech region ending in silence.
+    def speech_map(audio):
+        return [{"start": 0.0, "end": 1.0}]
+
+    _patch_live_deps(monkeypatch, speech_map=speech_map)
+
+    transcript = _FakeTranscript()
+    recording = _FakeRecording(RecordingStatus.UPLOADING, transcript)
+    session = _FakeSession(recording)
+
+    # Create each segment just-in-time so each run drains a single segment.
+    for seq in (1, 2, 3):
+        _make_segment_wav(temp_dir, seq, 2.0)
+        _run_live_task(monkeypatch, 42, seq, session)
+
+    assert len(transcript.segments) == 3
+    starts = [s["start"] for s in transcript.segments]
+    # buffer_abs_start advances by cut_point (1.0) each run.
+    assert starts == [0.0, 1.0, 2.0]
+    assert all(s["provisional"] is True for s in transcript.segments)
+    state = lt.read_live_state(temp_dir / "live")
+    assert state["next_expected"] == 4
+
+
+def test_live_out_of_order_arrival(monkeypatch, tmp_path):
+    """seq=2 first returns without advancing; seq=1 drains the run [1,2]."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+
+    temp_dir = tmp_path / "7"
+    temp_dir.mkdir()
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+
+    def speech_map(audio):
+        return [{"start": 0.0, "end": 1.0}]
+
+    _patch_live_deps(monkeypatch, speech_map=speech_map)
+
+    transcript = _FakeTranscript()
+    recording = _FakeRecording(RecordingStatus.UPLOADING, transcript)
+    session = _FakeSession(recording)
+
+    # seq=2 arrives first; only its file exists.
+    _make_segment_wav(temp_dir, 2, 2.0)
+    _run_live_task(monkeypatch, 7, 2, session)
+    assert transcript.segments == []
+    assert lt.read_live_state(temp_dir / "live")["next_expected"] == 1
+
+    # seq=1 arrives; both files now present -> drains [1, 2].
+    _make_segment_wav(temp_dir, 1, 2.0)
+    _run_live_task(monkeypatch, 7, 1, session)
+
+    assert len(transcript.segments) == 1
+    assert transcript.segments[0]["start"] == 0.0
+    assert lt.read_live_state(temp_dir / "live")["next_expected"] == 3
+
+
+def test_live_carry_over_across_seam(monkeypatch, tmp_path):
+    """A region touching the buffer end is carried and completed by a later run."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+
+    temp_dir = tmp_path / "9"
+    temp_dir.mkdir()
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+
+    # Run 1 (3 s buffer): speech runs to the end -> incomplete, carried.
+    # Run 2 (carry ~1 s + 3 s = ~4 s): one region ending in silence -> complete.
+    calls = {"n": 0}
+
+    def speech_map(audio):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [{"start": 2.0, "end": 3.0}]
+        return [{"start": 0.0, "end": 1.5}]
+
+    _patch_live_deps(monkeypatch, speech_map=speech_map)
+
+    transcript = _FakeTranscript()
+    recording = _FakeRecording(RecordingStatus.UPLOADING, transcript)
+    session = _FakeSession(recording)
+
+    _make_segment_wav(temp_dir, 1, 3.0)
+    _run_live_task(monkeypatch, 9, 1, session)
+    # Run 1 carried the trailing utterance: no completed segment yet.
+    assert transcript.segments == []
+    assert (temp_dir / "live" / "buffer.wav").exists()
+
+    _make_segment_wav(temp_dir, 2, 3.0)
+    _run_live_task(monkeypatch, 9, 2, session)
+    # Run 2 completes exactly one provisional segment.
+    assert len(transcript.segments) == 1
+    assert transcript.segments[0]["provisional"] is True
+
+
+def test_live_forced_cut(monkeypatch, tmp_path):
+    """A >30 s continuous speech region produces a completed provisional segment."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+
+    temp_dir = tmp_path / "11"
+    temp_dir.mkdir()
+    _make_segment_wav(temp_dir, 1, 31.0)
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+
+    def speech_map(audio):
+        return [{"start": 0.0, "end": 31.0}]
+
+    _patch_live_deps(monkeypatch, speech_map=speech_map)
+
+    transcript = _FakeTranscript()
+    recording = _FakeRecording(RecordingStatus.UPLOADING, transcript)
+    session = _FakeSession(recording)
+
+    _run_live_task(monkeypatch, 11, 1, session)
+
+    assert len(transcript.segments) == 1
+    assert transcript.segments[0]["start"] == 0.0
+    assert transcript.segments[0]["end"] == 31.0
+
+
+def test_live_entry_guard_bails_when_not_uploading(monkeypatch, tmp_path):
+    """A task whose recording is no longer UPLOADING stops at entry: no DB
+    write, no work, and no orphan live dir recreated after finalize()."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+
+    temp_dir = tmp_path / "13"
+    temp_dir.mkdir()
+    _make_segment_wav(temp_dir, 1, 2.0)
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+
+    def speech_map(audio):
+        return [{"start": 0.0, "end": 1.0}]
+
+    _patch_live_deps(monkeypatch, speech_map=speech_map)
+
+    transcript = _FakeTranscript()
+    recording = _FakeRecording(RecordingStatus.PROCESSING, transcript)
+    session = _FakeSession(recording)
+
+    _run_live_task(monkeypatch, 13, 1, session)
+
+    assert transcript.segments == []
+    assert session.committed is False
+    # Entry guard ran before any file work: no live dir was created.
+    assert not (temp_dir / "live").exists()
+
+
+def test_live_race_guard_skips_db_write_on_late_status_flip(monkeypatch, tmp_path):
+    """finalize() landing mid-run (UPLOADING at entry, PROCESSING at the DB
+    write) skips the provisional write but still advances the lane cleanly."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+
+    temp_dir = tmp_path / "14"
+    temp_dir.mkdir()
+    _make_segment_wav(temp_dir, 1, 2.0)
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+
+    def speech_map(audio):
+        return [{"start": 0.0, "end": 1.0}]
+
+    _patch_live_deps(monkeypatch, speech_map=speech_map)
+
+    class _FlipToProcessingRecording:
+        """UPLOADING on the first status read, PROCESSING thereafter."""
+
+        def __init__(self, transcript):
+            self.transcript = transcript
+            self._reads = 0
+
+        @property
+        def status(self):
+            self._reads += 1
+            return (
+                RecordingStatus.UPLOADING
+                if self._reads == 1
+                else RecordingStatus.PROCESSING
+            )
+
+    transcript = _FakeTranscript()
+    recording = _FlipToProcessingRecording(transcript)
+    session = _FakeSession(recording)
+
+    _run_live_task(monkeypatch, 14, 1, session)
+
+    assert transcript.segments == []
+    assert session.committed is False
+    # The run completed normally; only the DB write was guarded.
+    assert lt.read_live_state(temp_dir / "live")["next_expected"] == 2
+
+
+def test_live_failure_path_advances_without_raising(monkeypatch, tmp_path):
+    """transcribe_audio raising is logged; the lane advances; no re-raise."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+    from backend.processing import vad as vad_module
+    from backend.processing import transcribe as transcribe_module
+
+    temp_dir = tmp_path / "15"
+    temp_dir.mkdir()
+    _make_segment_wav(temp_dir, 1, 2.0)
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+    monkeypatch.setattr(
+        vad_module, "detect_speech_segments", lambda audio, *a, **k: [{"start": 0.0, "end": 1.0}]
+    )
+
+    import silero_vad
+
+    monkeypatch.setattr(silero_vad, "save_audio", lambda *a, **k: None)
+
+    def boom(path, config=None):
+        raise RuntimeError("engine exploded")
+
+    monkeypatch.setattr(transcribe_module, "transcribe_audio", boom)
+
+    transcript = _FakeTranscript()
+    recording = _FakeRecording(RecordingStatus.UPLOADING, transcript)
+    session = _FakeSession(recording)
+
+    # Must not raise.
+    _run_live_task(monkeypatch, 15, 1, session)
+
+    assert transcript.segments == []
+    assert lt.read_live_state(temp_dir / "live")["next_expected"] == 2
+
+
+# --- segment endpoint live-task dispatch tests ------------------------------
+
+
+async def _insert_uploading_recording(
+    session_maker: sessionmaker,
+    *,
+    recording_id: int = 101,
+    public_id: str = "live-rec-public-id",
+    user_id: int = 1,
+) -> None:
+    """Insert a single recording row in UPLOADING status into the test DB."""
+    async with session_maker() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO recordings (
+                    id, created_at, updated_at, name, public_id, meeting_uid,
+                    audio_path, status, upload_progress, processing_progress,
+                    is_archived, is_deleted, user_id
+                ) VALUES (
+                    :id, :now, :now, :name, :public_id, :meeting_uid,
+                    :audio_path, :status, 0, 0, 0, 0, :user_id
+                )
+                """
+            ),
+            {
+                "id": recording_id,
+                "now": "2026-05-16 00:00:00",
+                "name": "Live meeting",
+                "public_id": public_id,
+                "meeting_uid": "live-meeting-uid",
+                "audio_path": "/tmp/live.wav",
+                "status": "UPLOADING",
+                "user_id": user_id,
+            },
+        )
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_segment_upload_dispatches_live_task_when_enabled(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """When enable_live_transcription is true, a segment upload enqueues the task."""
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    await _insert_uploading_recording(test_session_maker, recording_id=101)
+
+    monkeypatch.setattr(
+        recordings_module, "recording_upload_temp_dir", lambda *a, **k: tmp_path
+    )
+    monkeypatch.setattr(
+        recordings_module.config_manager,
+        "get",
+        lambda key, default=None: True if key == "enable_live_transcription" else default,
+    )
+
+    calls = []
+    monkeypatch.setattr(
+        recordings_module.transcribe_segment_live_task,
+        "delay",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    response = await client.post(
+        "/api/v1/recordings/live-rec-public-id/segment",
+        params={"sequence": 3},
+        files={"file": ("3.wav", b"fake-wav-bytes", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "received", "segment": 3}
+    assert len(calls) == 1
+    assert calls[0][0] == (101, 3)
+
+
+@pytest.mark.anyio
+async def test_segment_upload_skips_live_task_when_disabled(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """When enable_live_transcription is false, no task is enqueued."""
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    await _insert_uploading_recording(test_session_maker, recording_id=101)
+
+    monkeypatch.setattr(
+        recordings_module, "recording_upload_temp_dir", lambda *a, **k: tmp_path
+    )
+    monkeypatch.setattr(
+        recordings_module.config_manager,
+        "get",
+        lambda key, default=None: False if key == "enable_live_transcription" else default,
+    )
+
+    calls = []
+    monkeypatch.setattr(
+        recordings_module.transcribe_segment_live_task,
+        "delay",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    response = await client.post(
+        "/api/v1/recordings/live-rec-public-id/segment",
+        params={"sequence": 0},
+        files={"file": ("0.wav", b"fake-wav-bytes", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "received", "segment": 0}
+    assert calls == []
+
+
+@pytest.mark.anyio
+async def test_segment_upload_swallows_live_task_dispatch_failure(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A failing .delay() is logged and the segment upload still succeeds."""
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    await _insert_uploading_recording(test_session_maker, recording_id=101)
+
+    monkeypatch.setattr(
+        recordings_module, "recording_upload_temp_dir", lambda *a, **k: tmp_path
+    )
+    monkeypatch.setattr(
+        recordings_module.config_manager,
+        "get",
+        lambda key, default=None: True if key == "enable_live_transcription" else default,
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("broker unreachable")
+
+    monkeypatch.setattr(
+        recordings_module.transcribe_segment_live_task, "delay", boom
+    )
+
+    response = await client.post(
+        "/api/v1/recordings/live-rec-public-id/segment",
+        params={"sequence": 5},
+        files={"file": ("5.wav", b"fake-wav-bytes", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "received", "segment": 5}
+
+
+# --- Celery registration test ----------------------------------------------
+
+
+def test_live_task_registered_with_celery():
+    """The live task module is wired into the Celery app and the task registers.
+
+    Without backend.processing.live_transcribe in the Celery include list the
+    worker would never import the module, so transcribe_segment_live_task.delay
+    would fail at runtime with a NotRegistered error.
+    """
+    from backend.celery_app import celery_app
+
+    celery_app.loader.import_default_modules()
+
+    assert (
+        "backend.processing.live_transcribe.transcribe_segment_live_task"
+        in celery_app.tasks
+    )

--- a/backend/tests/test_live_transcription.py
+++ b/backend/tests/test_live_transcription.py
@@ -295,6 +295,59 @@ def test_detect_speech_segments_min_silence_override(monkeypatch):
     assert captured["min_silence_duration_ms"] == 700
 
 
+def test_detect_speech_segments_speech_pad_override(monkeypatch):
+    """An explicit speech_pad_ms overrides the config value."""
+    import torch
+
+    from backend.processing import vad as vad_module
+
+    captured = {}
+
+    def fake_get_speech_timestamps(*a, **k):
+        captured.update(k)
+        return []
+
+    monkeypatch.setattr(
+        vad_module.silero_vad, "load_silero_vad", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(
+        vad_module.silero_vad, "get_speech_timestamps", fake_get_speech_timestamps
+    )
+
+    vad_module.detect_speech_segments(
+        torch.zeros(16000), sample_rate=16000, speech_pad_ms=300
+    )
+
+    assert captured["speech_pad_ms"] == 300
+
+
+def test_detect_speech_segments_speech_pad_default(monkeypatch):
+    """Without an override, the config/default speech_pad value (30 ms) is used.
+
+    Guards the batch path: an unpadded call must behave exactly as before.
+    """
+    import torch
+
+    from backend.processing import vad as vad_module
+
+    captured = {}
+
+    def fake_get_speech_timestamps(*a, **k):
+        captured.update(k)
+        return []
+
+    monkeypatch.setattr(
+        vad_module.silero_vad, "load_silero_vad", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(
+        vad_module.silero_vad, "get_speech_timestamps", fake_get_speech_timestamps
+    )
+
+    vad_module.detect_speech_segments(torch.zeros(16000), sample_rate=16000)
+
+    assert captured["speech_pad_ms"] == 30
+
+
 def test_detect_speech_segments_min_silence_default(monkeypatch):
     """Without an override, the config/default min_silence value is used."""
     import torch
@@ -408,11 +461,20 @@ def _patch_live_deps(monkeypatch, *, speech_map, transcribe_text="hello", db_sta
     from backend.processing import transcribe as transcribe_module
 
     monkeypatch.setattr(vad_module, "detect_speech_segments", lambda audio, *a, **k: speech_map(audio))
-    monkeypatch.setattr(
-        transcribe_module,
-        "transcribe_audio",
-        lambda path, config=None: {"text": transcribe_text, "language": None, "segments": []},
-    )
+
+    def fake_transcribe_audio(path, config=None):
+        # A single segment spanning the whole clip: with no `words`, the
+        # midpoint heuristic in _extract_region_text keeps it for any
+        # prefix_s, so context-window runs still emit text.
+        return {
+            "text": transcribe_text,
+            "language": None,
+            "segments": [
+                {"start": 0.0, "end": 1.0e9, "text": transcribe_text}
+            ],
+        }
+
+    monkeypatch.setattr(transcribe_module, "transcribe_audio", fake_transcribe_audio)
     # silero_vad.save_audio is real (torchaudio-backed); the buffer.wav it
     # writes is needed for the carry-over seam test.
 
@@ -700,6 +762,181 @@ def test_live_failure_path_advances_without_raising(monkeypatch, tmp_path):
 
     assert transcript.segments == []
     assert lt.read_live_state(temp_dir / "live")["next_expected"] == 2
+
+
+# --- _extract_region_text unit tests ----------------------------------------
+
+
+def test_extract_region_text_drops_pure_context_segment():
+    """A segment entirely within the prefix run-up is dropped."""
+    from backend.processing.live_transcribe import _extract_region_text
+
+    result = {
+        "segments": [
+            {"start": 0.0, "end": 1.5, "text": "context only"},
+            {"start": 2.1, "end": 3.0, "text": "region words"},
+        ]
+    }
+    assert _extract_region_text(result, prefix_s=2.0) == "region words"
+
+
+def test_extract_region_text_keeps_region_segment():
+    """A segment entirely after the prefix is kept whole."""
+    from backend.processing.live_transcribe import _extract_region_text
+
+    result = {"segments": [{"start": 2.5, "end": 4.0, "text": "the region"}]}
+    assert _extract_region_text(result, prefix_s=2.0) == "the region"
+
+
+def test_extract_region_text_straddle_with_words():
+    """A boundary-straddling segment with words keeps only post-prefix words."""
+    from backend.processing.live_transcribe import _extract_region_text
+
+    result = {
+        "segments": [
+            {
+                "start": 1.0,
+                "end": 3.0,
+                "text": "before before after after",
+                "words": [
+                    {"start": 1.0, "end": 1.5, "word": "before"},
+                    {"start": 1.5, "end": 2.0, "word": "before"},
+                    {"start": 2.2, "end": 2.6, "word": "after"},
+                    {"start": 2.6, "end": 3.0, "word": "after"},
+                ],
+            }
+        ]
+    }
+    assert _extract_region_text(result, prefix_s=2.0) == "after after"
+
+
+def test_extract_region_text_straddle_without_words_midpoint():
+    """A boundary-straddling segment without words uses the midpoint heuristic."""
+    from backend.processing.live_transcribe import _extract_region_text
+
+    # Midpoint 2.5 >= prefix 2.0 -> kept.
+    kept = {"segments": [{"start": 1.0, "end": 4.0, "text": "kept"}]}
+    assert _extract_region_text(kept, prefix_s=2.0) == "kept"
+
+    # Midpoint 1.5 < prefix 2.0 -> dropped.
+    dropped = {"segments": [{"start": 1.0, "end": 2.0, "text": "dropped"}]}
+    assert _extract_region_text(dropped, prefix_s=2.0) == ""
+
+
+def test_extract_region_text_prefix_zero_keeps_all():
+    """With prefix_s == 0, all segments belong to the region."""
+    from backend.processing.live_transcribe import _extract_region_text
+
+    result = {
+        "segments": [
+            {"start": 0.0, "end": 1.0, "text": "one"},
+            {"start": 1.0, "end": 2.0, "text": "two"},
+        ]
+    }
+    assert _extract_region_text(result, prefix_s=0.0) == "one two"
+
+
+def test_extract_region_text_no_segments_falls_back_to_text():
+    """Without segments, the top-level text is used only when prefix_s <= 0."""
+    from backend.processing.live_transcribe import _extract_region_text
+
+    assert _extract_region_text({"text": "plain"}, prefix_s=0.0) == "plain"
+    assert _extract_region_text({"text": "plain"}, prefix_s=1.5) == ""
+
+
+# --- _strip_repetition unit tests --------------------------------------------
+
+
+def test_strip_repetition_collapses_consecutive_words():
+    """Three or more identical consecutive words collapse to one."""
+    from backend.processing.live_transcribe import _strip_repetition
+
+    assert _strip_repetition("yes yes yes please") == "yes please"
+
+
+def test_strip_repetition_collapses_repeated_phrase():
+    """A short phrase repeated three or more times collapses to one."""
+    from backend.processing.live_transcribe import _strip_repetition
+
+    assert (
+        _strip_repetition("thank you thank you thank you bye")
+        == "thank you bye"
+    )
+
+
+def test_strip_repetition_leaves_legitimate_text_untouched():
+    """Ordinary text, including a single doubled word, is preserved."""
+    from backend.processing.live_transcribe import _strip_repetition
+
+    text = "the meeting starts at noon and we will review the budget"
+    assert _strip_repetition(text) == text
+    # A word repeated only twice is not collapsed.
+    assert _strip_repetition("very very good") == "very very good"
+
+
+# --- context.wav lifecycle test ---------------------------------------------
+
+
+def test_live_writes_context_wav_and_excludes_prefix_text(monkeypatch, tmp_path):
+    """A run writes live/context.wav, and a region's left-context prefix text
+    is excluded from the emitted provisional segment."""
+    from backend.models.recording import RecordingStatus
+    from backend.processing import live_transcribe as lt
+    from backend.processing import vad as vad_module
+    from backend.processing import transcribe as transcribe_module
+
+    temp_dir = tmp_path / "21"
+    temp_dir.mkdir()
+
+    monkeypatch.setattr(lt, "recording_upload_temp_dir", lambda rid, create=False: temp_dir)
+    monkeypatch.setattr(
+        vad_module, "detect_speech_segments",
+        lambda audio, *a, **k: [{"start": 1.0, "end": 2.0}],
+    )
+
+    # The clip handed to the engine is `left_context ++ region`. A 1.0 s
+    # context.wav plus the 1.0 s of `combined` preceding the region gives
+    # prefix_s == 2.0. The fake result carries a context-prefixed segment
+    # (PREFIX, ending inside the prefix) and a region segment (REGION); only
+    # the region text must survive _extract_region_text.
+    def fake_transcribe_audio(path, config=None):
+        return {
+            "text": "PREFIX REGION",
+            "language": None,
+            "segments": [
+                {"start": 0.0, "end": 0.5, "text": "PREFIX"},
+                {"start": 1.5, "end": 2.5, "text": "REGION"},
+            ],
+        }
+
+    monkeypatch.setattr(transcribe_module, "transcribe_audio", fake_transcribe_audio)
+
+    _make_segment_wav(temp_dir, 1, 3.0)
+
+    transcript = _FakeTranscript()
+    recording = _FakeRecording(RecordingStatus.UPLOADING, transcript)
+    session = _FakeSession(recording)
+
+    # Seed a 1.0 s context.wav so prefix_s is non-zero (2.0 s) and prefix
+    # exclusion is actually exercised.
+    import torch
+    import silero_vad
+
+    ctx = torch.zeros(1, int(1.0 * lt.LIVE_SAMPLE_RATE))
+    (temp_dir / "live").mkdir(parents=True, exist_ok=True)
+    silero_vad.save_audio(
+        str(temp_dir / "live" / "context.wav"), ctx, sampling_rate=lt.LIVE_SAMPLE_RATE
+    )
+
+    _run_live_task(monkeypatch, 21, 1, session)
+
+    # context.wav was rewritten with the consumed audio's tail.
+    assert (temp_dir / "live" / "context.wav").exists()
+    # One provisional segment emitted; the PREFIX segment (end 0.5 <= prefix
+    # 1.0+EPS) is dropped, only REGION survives.
+    assert len(transcript.segments) == 1
+    assert transcript.segments[0]["text"] == "REGION"
+    assert transcript.segments[0]["provisional"] is True
 
 
 # --- segment endpoint live-task dispatch tests ------------------------------

--- a/backend/tests/test_reprocess.py
+++ b/backend/tests/test_reprocess.py
@@ -1,0 +1,482 @@
+"""Tests for the reprocess endpoint and per-reprocess engine override."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.api.deps import get_current_user, get_db
+from backend.api.v1.api import api_router
+
+
+RECORDINGS_SCHEMA = """
+CREATE TABLE recordings (
+    id INTEGER PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    public_id VARCHAR(36) NOT NULL,
+    meeting_uid VARCHAR(36) NOT NULL,
+    audio_path VARCHAR(1024) NOT NULL,
+    proxy_path VARCHAR(1024),
+    celery_task_id VARCHAR(255),
+    duration_seconds FLOAT,
+    file_size_bytes INTEGER,
+    status VARCHAR(32) NOT NULL,
+    client_status VARCHAR(32),
+    upload_progress INTEGER NOT NULL,
+    processing_progress INTEGER NOT NULL,
+    processing_step VARCHAR(255),
+    processing_started_at DATETIME,
+    processing_completed_at DATETIME,
+    is_archived BOOLEAN NOT NULL,
+    is_deleted BOOLEAN NOT NULL,
+    user_id INTEGER
+)
+"""
+
+TRANSCRIPTS_SCHEMA = """
+CREATE TABLE transcripts (
+    id INTEGER PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    recording_id INTEGER NOT NULL UNIQUE,
+    text TEXT,
+    segments JSON,
+    notes TEXT,
+    user_notes TEXT,
+    notes_status VARCHAR(32) NOT NULL,
+    transcript_status VARCHAR(32) NOT NULL,
+    error_message TEXT
+)
+"""
+
+CHAT_MESSAGES_SCHEMA = """
+CREATE TABLE chat_messages (
+    id INTEGER PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    recording_id INTEGER NOT NULL,
+    role VARCHAR(32) NOT NULL,
+    content TEXT
+)
+"""
+
+CONTEXT_CHUNKS_SCHEMA = """
+CREATE TABLE context_chunks (
+    id INTEGER PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    recording_id INTEGER NOT NULL,
+    document_id INTEGER,
+    content TEXT,
+    embedding JSON
+)
+"""
+
+RECORDING_SPEAKERS_SCHEMA = """
+CREATE TABLE recording_speakers (
+    id INTEGER PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    recording_id INTEGER NOT NULL,
+    global_speaker_id INTEGER,
+    diarization_label VARCHAR(255),
+    local_name VARCHAR(255),
+    name VARCHAR(255),
+    snippet_start FLOAT,
+    snippet_end FLOAT,
+    voice_snippet_path VARCHAR(1024)
+)
+"""
+
+
+def build_test_user(user_id: int = 1, username: str = "alice"):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=user_id,
+        username=username,
+        force_password_change=False,
+    )
+
+
+@pytest.fixture
+async def test_session_maker() -> sessionmaker:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as connection:
+        await connection.execute(text(RECORDINGS_SCHEMA))
+        await connection.execute(text(TRANSCRIPTS_SCHEMA))
+        await connection.execute(text(CHAT_MESSAGES_SCHEMA))
+        await connection.execute(text(CONTEXT_CHUNKS_SCHEMA))
+        await connection.execute(text(RECORDING_SPEAKERS_SCHEMA))
+
+    try:
+        yield session_maker
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def api_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+async def client(api_app: FastAPI, test_session_maker: sessionmaker) -> AsyncClient:
+    async def override_get_db():
+        async with test_session_maker() as session:
+            yield session
+
+    api_app.dependency_overrides[get_db] = override_get_db
+    api_app.dependency_overrides[get_current_user] = lambda: build_test_user()
+
+    transport = ASGITransport(app=api_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+    api_app.dependency_overrides.clear()
+
+
+async def _insert_recording(
+    session_maker: sessionmaker,
+    *,
+    recording_id: int = 201,
+    public_id: str = "reprocess-rec-public-id",
+    user_id: int = 1,
+    status: str = "PROCESSED",
+) -> None:
+    """Insert a single recording row into the test DB."""
+    async with session_maker() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO recordings (
+                    id, created_at, updated_at, name, public_id, meeting_uid,
+                    audio_path, status, upload_progress, processing_progress,
+                    is_archived, is_deleted, user_id
+                ) VALUES (
+                    :id, :now, :now, :name, :public_id, :meeting_uid,
+                    :audio_path, :status, 0, 100, 0, 0, :user_id
+                )
+                """
+            ),
+            {
+                "id": recording_id,
+                "now": "2026-05-16 00:00:00",
+                "name": "Processed meeting",
+                "public_id": public_id,
+                "meeting_uid": f"meeting-uid-{recording_id}",
+                "audio_path": "/tmp/recording.wav",
+                "status": status,
+                "user_id": user_id,
+            },
+        )
+        await session.commit()
+
+
+def _patch_delay(monkeypatch):
+    """Patch process_recording_task.delay; return the captured-calls list."""
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    calls: list = []
+
+    class _FakeTask:
+        id = "fake-task-id"
+
+    monkeypatch.setattr(
+        recordings_module.process_recording_task,
+        "delay",
+        lambda *args, **kwargs: (calls.append((args, kwargs)), _FakeTask())[1],
+    )
+    return calls
+
+
+# --- endpoint tests ---------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reprocess_processed_recording_queues_with_override(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    monkeypatch,
+) -> None:
+    """POST /reprocess on a PROCESSED recording queues it with an engine override."""
+    await _insert_recording(test_session_maker, recording_id=201)
+    calls = _patch_delay(monkeypatch)
+
+    response = await client.post(
+        "/api/v1/recordings/reprocess-rec-public-id/reprocess",
+        json={"transcription_backend": "parakeet"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "QUEUED"
+    assert len(calls) == 1
+    assert calls[0][0] == (201, True, {"transcription_backend": "parakeet"})
+
+
+@pytest.mark.anyio
+async def test_reprocess_invalid_backend_rejected(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    monkeypatch,
+) -> None:
+    """An unknown transcription_backend is rejected with 400."""
+    await _insert_recording(test_session_maker, recording_id=202, public_id="rec-202")
+    calls = _patch_delay(monkeypatch)
+
+    response = await client.post(
+        "/api/v1/recordings/rec-202/reprocess",
+        json={"transcription_backend": "foobar"},
+    )
+
+    assert response.status_code == 400
+    assert calls == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("status", ["UPLOADING", "QUEUED", "PROCESSING"])
+async def test_reprocess_in_progress_recording_rejected(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    monkeypatch,
+    status: str,
+) -> None:
+    """Reprocessing a recording that is already in progress is rejected with 400."""
+    await _insert_recording(
+        test_session_maker,
+        recording_id=203,
+        public_id="rec-203",
+        status=status,
+    )
+    calls = _patch_delay(monkeypatch)
+
+    response = await client.post(
+        "/api/v1/recordings/rec-203/reprocess",
+        json={"transcription_backend": "whisper"},
+    )
+
+    assert response.status_code == 400
+    assert calls == []
+
+
+@pytest.mark.anyio
+async def test_reprocess_other_users_recording_rejected(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    monkeypatch,
+) -> None:
+    """Reprocessing a recording owned by another user is rejected (404)."""
+    await _insert_recording(
+        test_session_maker,
+        recording_id=204,
+        public_id="rec-204",
+        user_id=999,
+    )
+    calls = _patch_delay(monkeypatch)
+
+    response = await client.post(
+        "/api/v1/recordings/rec-204/reprocess",
+        json={"transcription_backend": "whisper"},
+    )
+
+    assert response.status_code == 404
+    assert calls == []
+
+
+@pytest.mark.anyio
+async def test_reprocess_optional_model_keys_only_when_provided(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    monkeypatch,
+) -> None:
+    """whisper_model_size / parakeet_model land in the override only when provided."""
+    await _insert_recording(test_session_maker, recording_id=205, public_id="rec-205")
+    calls = _patch_delay(monkeypatch)
+
+    response = await client.post(
+        "/api/v1/recordings/rec-205/reprocess",
+        json={
+            "transcription_backend": "whisper",
+            "whisper_model_size": "large-v3",
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+    override = calls[0][0][2]
+    assert override == {
+        "transcription_backend": "whisper",
+        "whisper_model_size": "large-v3",
+    }
+    assert "parakeet_model" not in override
+
+
+@pytest.mark.anyio
+async def test_retry_still_dispatches_without_override(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    monkeypatch,
+) -> None:
+    """Regression: /retry still dispatches process_recording_task with (id, True, None)."""
+    await _insert_recording(test_session_maker, recording_id=206, public_id="rec-206")
+    calls = _patch_delay(monkeypatch)
+
+    response = await client.post("/api/v1/recordings/rec-206/retry")
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+    assert calls[0][0] == (206, True, None)
+
+
+# --- task unit test ---------------------------------------------------------
+
+
+def test_process_recording_task_applies_engine_override(monkeypatch):
+    """process_recording_task merges engine_override into merged_config before
+    the transcription stage, so the engine keys reach transcribe_audio."""
+    from backend.models.recording import RecordingStatus
+    from backend.worker import tasks as tasks_module
+
+    captured: dict = {}
+
+    # Stop the pipeline right after the transcription stage by raising from a
+    # later mocked call; we only need to observe what transcribe_audio saw.
+    class _StopPipeline(Exception):
+        pass
+
+    def fake_transcribe_audio(path, config=None):
+        captured["config"] = dict(config or {})
+        raise _StopPipeline()
+
+    base_config = {
+        "transcription_backend": "whisper",
+        "whisper_model_size": "base",
+        "enable_vad": False,
+        "enable_diarization": False,
+    }
+
+    class _FakeLlmConfig:
+        merged_config = dict(base_config)
+
+    monkeypatch.setattr(
+        tasks_module, "resolve_llm_config", lambda *a, **k: _FakeLlmConfig()
+    )
+
+    class _FakeRecording:
+        id = 301
+        status = RecordingStatus.PROCESSED
+        user_id = None
+        audio_path = "/tmp/recording.wav"
+        proxy_path = None
+        duration_seconds = 60.0
+        processing_started_at = None
+        processing_completed_at = None
+        processing_progress = 0
+        processing_step = ""
+
+    class _FakeSession:
+        def get(self, model, recording_id):
+            return _FakeRecording()
+
+        def add(self, obj):
+            pass
+
+        def commit(self):
+            pass
+
+        def refresh(self, obj):
+            pass
+
+        def exec(self, *a, **k):
+            raise _StopPipeline()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(tasks_module.config_manager, "reload", lambda: None)
+    monkeypatch.setattr(
+        tasks_module.config_manager,
+        "get",
+        lambda key, default=None: default,
+    )
+
+    fake_session = _FakeSession()
+
+    # Patch the heavy processing imports the task pulls in lazily.
+    import sys
+    import types
+
+    def _install(module_name: str, **attrs):
+        mod = types.ModuleType(module_name)
+        for name, value in attrs.items():
+            setattr(mod, name, value)
+        monkeypatch.setitem(sys.modules, module_name, mod)
+
+    def _ok_preprocess(path):
+        return "/tmp/recording_vad.wav"
+
+    _install(
+        "backend.processing.vad",
+        mute_non_speech_segments=lambda *a, **k: (True, 10.0),
+    )
+    _install(
+        "backend.processing.audio_preprocessing",
+        convert_wav_to_mp3=lambda *a, **k: None,
+        preprocess_audio_for_vad=_ok_preprocess,
+        validate_audio_file=lambda *a, **k: None,
+        cleanup_temp_file=lambda *a, **k: None,
+        repair_audio_file=lambda *a, **k: None,
+    )
+    _install("backend.processing.transcribe", transcribe_audio=fake_transcribe_audio)
+    _install("backend.processing.diarize", diarize_audio=lambda *a, **k: None)
+    _install("backend.processing.embedding_core", extract_embeddings=lambda *a, **k: None)
+    _install(
+        "backend.processing.embedding",
+        cosine_similarity=lambda *a, **k: 0.0,
+        merge_embeddings=lambda *a, **k: None,
+        find_matching_global_speaker=lambda *a, **k: None,
+        AUTO_UPDATE_THRESHOLD=0.8,
+    )
+    _install(
+        "backend.utils.transcript_utils",
+        combine_transcription_diarization=lambda *a, **k: [],
+        consolidate_diarized_transcript=lambda *a, **k: [],
+    )
+    _install(
+        "backend.utils.audio",
+        get_audio_duration=lambda *a, **k: 60.0,
+        convert_to_mp3=lambda *a, **k: None,
+        convert_to_proxy_mp3=lambda *a, **k: None,
+    )
+    _install("backend.processing.llm_services", get_llm_backend=lambda *a, **k: None)
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+
+    engine_override = {"transcription_backend": "parakeet", "parakeet_model": "v3"}
+
+    # process_recording_task is a bound Celery task: task.run carries `self`
+    # implicitly. Inject the fake DB session and stub the progress callback.
+    task = tasks_module.process_recording_task
+    monkeypatch.setattr(task, "_session", fake_session, raising=False)
+    monkeypatch.setattr(task, "update_state", lambda *a, **k: None, raising=False)
+
+    with pytest.raises(_StopPipeline):
+        task.run(301, False, engine_override)
+
+    assert captured["config"]["transcription_backend"] == "parakeet"
+    assert captured["config"]["parakeet_model"] == "v3"

--- a/backend/tests/test_transcription_engines.py
+++ b/backend/tests/test_transcription_engines.py
@@ -1,0 +1,189 @@
+"""Tests for the pluggable transcription engine (config + dispatch + engine schema)."""
+
+import pytest
+
+# validate_config_value is a method on the ConfigManager singleton, not a
+# module-level function, so it is accessed via the exported config_manager instance.
+from backend.utils.config_manager import DEFAULT_SYSTEM_CONFIG, config_manager
+from backend.processing import transcribe
+
+validate_config_value = config_manager.validate_config_value
+
+
+def test_config_default_transcription_backend():
+    """The default config selects the whisper backend and the v3 parakeet model."""
+    assert DEFAULT_SYSTEM_CONFIG["transcription_backend"] == "whisper"
+    assert DEFAULT_SYSTEM_CONFIG["parakeet_model"] == "parakeet-tdt-0.6b-v3"
+
+
+def test_validate_config_value_transcription_backend():
+    """transcription_backend accepts known backends and rejects unknown values."""
+    assert validate_config_value("transcription_backend", "whisper") is True
+    assert validate_config_value("transcription_backend", "parakeet") is True
+    assert validate_config_value("transcription_backend", "bogus") is False
+
+
+@pytest.fixture(autouse=True)
+def _clean_engine_registry():
+    """Keep the dispatcher engine registry isolated between tests."""
+    transcribe._ENGINE_REGISTRY.clear()
+    yield
+    transcribe._ENGINE_REGISTRY.clear()
+
+
+class _FakeEngine:
+    """Minimal stand-in for a TranscriptionEngine used by dispatcher tests."""
+
+    def __init__(self, name="whisper"):
+        self.name = name
+        self.transcribe_called_with = None
+        self.released = False
+
+    def transcribe(self, audio_path, config):
+        self.transcribe_called_with = (audio_path, config)
+        return {"text": "fake", "language": "en", "segments": []}
+
+    def release(self):
+        self.released = True
+
+
+def test_dispatcher_selects_whisper():
+    """transcribe_audio routes to the whisper engine in the registry."""
+    fake = _FakeEngine("whisper")
+    transcribe._ENGINE_REGISTRY["whisper"] = fake
+    result = transcribe.transcribe_audio("meeting.wav", {"transcription_backend": "whisper"})
+    assert fake.transcribe_called_with is not None
+    assert fake.transcribe_called_with[0] == "meeting.wav"
+    assert result == {"text": "fake", "language": "en", "segments": []}
+
+
+def test_dispatcher_unknown_backend_returns_none():
+    """An unknown backend yields None instead of raising."""
+    result = transcribe.transcribe_audio("x.wav", {"transcription_backend": "bogus"})
+    assert result is None
+
+
+def test_whisper_engine_emits_canonical_schema(monkeypatch):
+    """WhisperEngine.transcribe returns the canonical dict schema."""
+    from backend.processing.engines import whisper_engine
+    from backend.processing.engines.whisper_engine import WhisperEngine
+
+    class _FakeModel:
+        def transcribe(self, audio_path, **kwargs):
+            return {
+                "text": "hi",
+                "language": "en",
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 1.0,
+                        "text": " hi",
+                        "words": [{"start": 0.0, "end": 1.0, "word": " hi"}],
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(whisper_engine.whisper, "load_model", lambda *a, **k: _FakeModel())
+    monkeypatch.setattr(whisper_engine, "ensure_ffmpeg_in_path", lambda: None, raising=False)
+    monkeypatch.setattr(whisper_engine.os.path, "exists", lambda p: True)
+    # Avoid leaking a fake model into the shared module-level cache.
+    monkeypatch.setattr(whisper_engine, "_model_cache", {})
+
+    engine = WhisperEngine()
+    result = engine.transcribe("meeting.wav", {})
+
+    assert isinstance(result["text"], str)
+    assert isinstance(result["segments"], list)
+    for segment in result["segments"]:
+        assert "start" in segment
+        assert "end" in segment
+        assert "text" in segment
+
+
+def test_release_model_cache_calls_engines():
+    """release_model_cache delegates to every instantiated engine."""
+    fake = _FakeEngine("whisper")
+    transcribe._ENGINE_REGISTRY["whisper"] = fake
+    transcribe.release_model_cache()
+    assert fake.released is True
+
+
+# --- Parakeet mapper tests (pure function, no onnx / no mocks needed) ---
+
+from backend.processing.engines.parakeet_engine import map_parakeet_result
+
+
+def test_parakeet_mapping_basic():
+    """Two close words map to one segment with correct word timings."""
+    result = map_parakeet_result(
+        text="hello world",
+        tokens=[" hello", " world"],
+        timestamps=[0.0, 0.5],
+        audio_duration=1.0,
+    )
+    assert len(result["segments"]) == 1
+    segment = result["segments"][0]
+    assert len(segment["words"]) == 2
+    assert "hello" in segment["text"]
+    assert "world" in segment["text"]
+    assert segment["words"][0]["start"] == 0.0
+    assert segment["words"][0]["end"] == 0.5
+    assert segment["words"][1]["start"] == 0.5
+    assert segment["words"][1]["end"] == 1.0
+    for word in segment["words"]:
+        assert word["word"].startswith(" ")
+
+
+def test_parakeet_mapping_subword_tokens():
+    """Subword tokens are joined into whole words at space-prefixed boundaries."""
+    result = map_parakeet_result(
+        text="unbelievable good",
+        tokens=[" un", "believ", "able", " good"],
+        timestamps=[0.0, 0.1, 0.2, 0.4],
+    )
+    words = result["segments"][0]["words"]
+    assert len(words) == 2
+    assert words[0]["word"] == " unbelievable"
+    assert words[1]["word"] == " good"
+
+
+def test_parakeet_mapping_segment_split_on_pause():
+    """A gap larger than the pause threshold splits words into two segments."""
+    result = map_parakeet_result(
+        text="hello world",
+        tokens=[" hello", " world"],
+        timestamps=[0.0, 2.0],
+        audio_duration=3.0,
+    )
+    assert len(result["segments"]) == 2
+
+
+def test_parakeet_mapping_word_leading_space():
+    """Every word in every segment carries a leading space."""
+    result = map_parakeet_result(
+        text="one two three four",
+        tokens=[" one", " two", " three", " four"],
+        timestamps=[0.0, 1.5, 3.0, 4.5],
+        audio_duration=5.0,
+    )
+    for segment in result["segments"]:
+        for word in segment["words"]:
+            assert word["word"].startswith(" ")
+
+
+def test_parakeet_mapping_fallback_no_timestamps():
+    """Missing timestamps yield a single fallback segment with no words."""
+    result = map_parakeet_result(text="some text", tokens=None, timestamps=None)
+    assert len(result["segments"]) == 1
+    assert result["segments"][0]["text"] == "some text"
+    assert "words" not in result["segments"][0] or not result["segments"][0]["words"]
+
+
+def test_dispatcher_selects_parakeet():
+    """transcribe_audio routes to the parakeet engine in the registry."""
+    fake = _FakeEngine("parakeet")
+    transcribe._ENGINE_REGISTRY["parakeet"] = fake
+    result = transcribe.transcribe_audio("meeting.wav", {"transcription_backend": "parakeet"})
+    assert fake.transcribe_called_with is not None
+    assert fake.transcribe_called_with[0] == "meeting.wav"
+    assert result == {"text": "fake", "language": "en", "segments": []}

--- a/backend/utils/config_manager.py
+++ b/backend/utils/config_manager.py
@@ -86,6 +86,10 @@ DEFAULT_SYSTEM_CONFIG = {
     "default_input_device_index": None, # None means system default
     "default_output_device_index": None, # None means system default
     "whisper_model_size": "turbo", # Default model size (e.g., tiny, base, small, medium, large)
+    "transcription_backend": "whisper",          # "whisper" | "parakeet"
+    "parakeet_model": "parakeet-tdt-0.6b-v3",
+    "enable_live_transcription": True,
+    "live_transcription_backend": "parakeet",
     "vad_parameters": {
         "threshold": 0.5,
         "min_speech_duration_ms": 250,
@@ -116,6 +120,7 @@ DEFAULT_USER_SETTINGS = {
 }
 
 WHISPER_MODEL_SIZES = ["turbo", "tiny", "base", "small", "medium", "large"]
+TRANSCRIPTION_BACKENDS = ["whisper", "parakeet"]
 APP_THEMES = ["dark", "light"] # Available UI themes
 
 def get_available_whisper_model_sizes():
@@ -233,6 +238,12 @@ class ConfigManager:
         """Validates a configuration value."""
         if key == "whisper_model_size" and value not in WHISPER_MODEL_SIZES:
             raise ValueError(f"Invalid whisper_model_size: {value}. Must be one of {WHISPER_MODEL_SIZES}")
+        if key == "transcription_backend":
+            return value in TRANSCRIPTION_BACKENDS
+        if key == "live_transcription_backend":
+            return value in TRANSCRIPTION_BACKENDS
+        if key == "enable_live_transcription":
+            return isinstance(value, bool)
         if key == "theme" and value not in APP_THEMES:
             raise ValueError(f"Invalid theme: {value}. Must be one of {APP_THEMES}")
         if key == "llm_provider" and value not in ["gemini", "openai", "anthropic", "ollama"]:

--- a/backend/utils/config_manager.py
+++ b/backend/utils/config_manager.py
@@ -90,6 +90,8 @@ DEFAULT_SYSTEM_CONFIG = {
     "parakeet_model": "parakeet-tdt-0.6b-v3",
     "enable_live_transcription": True,
     "live_transcription_backend": "parakeet",
+    "live_context_window_s": 5.0,
+    "live_speech_pad_ms": 300,
     "vad_parameters": {
         "threshold": 0.5,
         "min_speech_duration_ms": 250,

--- a/backend/worker/tasks.py
+++ b/backend/worker/tasks.py
@@ -306,7 +306,7 @@ class DatabaseTask(Task):
             self._session.close()
 
 @celery_app.task(base=DatabaseTask, bind=True, autoretry_for=(ConnectionError, urllib.error.URLError, requests.exceptions.RequestException), retry_backoff=True, max_retries=3)
-def process_recording_task(self, recording_id: int, force_title_regeneration: bool = False):
+def process_recording_task(self, recording_id: int, force_title_regeneration: bool = False, engine_override: dict | None = None):
     """
     Full processing pipeline: VAD -> Transcribe -> Diarize -> Save
     """
@@ -483,6 +483,11 @@ def process_recording_task(self, recording_id: int, force_title_regeneration: bo
         session.add(recording)
         session.commit()
         
+        # Apply per-reprocess transcription-engine override, if provided.
+        if engine_override:
+            merged_config.update(engine_override)
+            logger.info("Reprocess: engine override applied: %s", engine_override)
+
         # Run Whisper
         transcription_result = transcribe_audio(processed_audio_path, config=merged_config)
         

--- a/companion/src-tauri/build.rs
+++ b/companion/src-tauri/build.rs
@@ -1,5 +1,9 @@
 fn main() {
-    println!("cargo:rustc-link-search=/usr/lib/swift");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+    // Swift runtime linker flags are only valid for the Unix linker (macOS/Linux).
+    // They are invalid for the MSVC linker on Windows, so gate them out there.
+    if cfg!(not(windows)) {
+        println!("cargo:rustc-link-search=/usr/lib/swift");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+    }
     tauri_build::build()
 }

--- a/companion/src-tauri/src/audio.rs
+++ b/companion/src-tauri/src/audio.rs
@@ -396,7 +396,7 @@ fn start_segment(
 
     thread::spawn(move || {
         let run = || -> anyhow::Result<SegmentThreadOutcome> {
-            const MAX_SEGMENT_DURATION_SECS: u64 = 5 * 60;
+            const MAX_SEGMENT_DURATION_SECS: u64 = 2;
             let temp_dir = std::env::temp_dir().join("Nojoin").join("recordings");
             if let Err(e) = std::fs::create_dir_all(&temp_dir) {
                 log::error!("Failed to create temp directory {:?}: {}", temp_dir, e);
@@ -699,10 +699,10 @@ fn run_mixing_loop(
 
         // Record for up to MAX_SEGMENT_DURATION_SECS or until stopped
         while is_recording.load(Ordering::SeqCst) {
-            // Checks if maximum segment duration is exceeded.
+            // Flush the live segment once the ~2 second interval elapses.
             if segment_start.elapsed().as_secs() >= max_duration {
                 info!(
-                    "Segment {} reached maximum duration, starting new segment",
+                    "Segment {} reached live flush interval, starting new segment",
                     current_sequence
                 );
                 break;

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -37,6 +37,12 @@ RUN pip install --no-cache-dir -r requirements/worker.txt -c constraints.txt
 # Install pyannote.audio without dependencies to use system torch
 RUN pip install --no-cache-dir --no-deps pyannote.audio==4.0.2 -c constraints.txt
 
+# Parakeet ASR (onnx-asr) requires the CUDA build of ONNX Runtime. fastembed
+# pulls the CPU-only onnxruntime; replace it with onnxruntime-gpu, which is a
+# drop-in providing both the CPU and CUDA execution providers.
+RUN pip uninstall -y onnxruntime onnxruntime-gpu && \
+    pip install --no-cache-dir onnxruntime-gpu
+
 # Copy the rest of the application code
 COPY . .
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,6 +28,7 @@ Nojoin is a distributed meeting intelligence platform. The system records system
   - **Constraint**: Heavy libraries (torch, whisper, pyannote) must be imported **inside** the task function to keep the API lightweight and ensure fast startup times.
   - **Pipeline**: Validation -> VAD (Silero) -> Proxy Creation (Alignment) -> Transcribe (Whisper) -> Diarize (Pyannote) -> Phantom Speaker Filter -> Merge -> Voiceprint Extraction -> Deterministic Speaker Resolution (manual names, merge handling, global matches) -> Automatic Meeting Intelligence (one provider call for unresolved speaker suggestions, title, and Markdown notes when AI is configured).
   - **Manual AI Flows**: Automatic AI enhancement is provider-gated and no longer uses separate per-feature toggles. Manual `Generate Notes` remains notes-only, and manual `Retry Speaker Inference` remains speaker-only.
+  - **Transcription Engine**: The Transcribe step dispatches to a pluggable engine (`backend/processing/engines/`), selected by the `transcription_backend` config key. Whisper is the default; Parakeet (onnx-asr) is selectable.
   - **Phantom Speaker Filter**: Post-diarization stage (`backend/processing/phantom_filter.py`) that detects and reassigns segments caused by non-speech sounds (notifications, background noise). Uses heuristic detection (duration/segment count) followed by embedding-based validation. Thresholds are defined as named constants in `phantom_filter.py` (`PHANTOM_MAX_DURATION_S`, `PHANTOM_MAX_SEGMENTS`, `PHANTOM_EMBEDDING_FLOOR`, `PHANTOM_MERGE_THRESHOLD`).
   - **Speaker Identification Constants**: All speaker matching thresholds are centralised in `backend/processing/embedding.py`. Do not hardcode threshold values elsewhere; import and reference the named constants (`IDENTIFICATION_THRESHOLD`, `AUTO_UPDATE_THRESHOLD`, `MARGIN_OF_VICTORY`, `DRIFT_GUARD_THRESHOLD`, `SCAN_MATCH_THRESHOLD`, `UI_SHOW_MATCH_THRESHOLD`, `UI_STRONG_MATCH_THRESHOLD`).
   - **PyTorch 2.6+ & Safe Globals**: The project uses PyTorch 2.6+, which defaults `weights_only=True` in `torch.load` for security.
@@ -59,7 +60,7 @@ Nojoin is a distributed meeting intelligence platform. The system records system
   - **Audio Thread**: Captures audio using `cpal` and communicates via `crossbeam_channel`.
   - **Server/Upload Thread**: Uses the `tokio` runtime.
 - **Upload Strategy**:
-  - Segments are uploaded sequentially to `/recordings/{id}/segment`.
+  - Segments are numbered sequentially but uploaded concurrently (racing upload tasks plus retries) to `/recordings/{id}/segment`. The backend re-imposes order via a sequence-gated buffer in the live transcription task.
   - **Retries**: Implemented in `src-tauri/src/uploader.rs` with exponential backoff.
 - **UI**: The system tray is managed by Tauri.
 - **Configuration** (`config.json`):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ The normal backend processing path is:
 1. Validation.
 2. VAD and audio preprocessing.
 3. Proxy creation for web playback.
-4. Whisper transcription.
+4. Transcription via a pluggable engine (Whisper by default, Parakeet via onnx-asr selectable).
 5. Pyannote diarisation.
 6. Phantom speaker filtering.
 7. Merge, voiceprint extraction, and deterministic speaker resolution.
@@ -81,6 +81,34 @@ The normal backend processing path is:
 Manual user notes can be captured during recording or processing and are fed into both the automatic meeting-intelligence stage and the manual note-generation flow.
 
 If AI configuration is missing, the recording still completes with transcript, diarisation, and deterministic speaker resolution intact. Automatic AI enhancement is skipped rather than failing the meeting. Manual `Generate Notes` and `Retry Speaker Inference` remain available once AI is configured.
+
+### Live Transcription Lane
+
+While a recording is still uploading, a secondary lane produces provisional
+transcript text so the web client can show progress before the full pipeline
+runs:
+
+1. Each segment upload endpoint dispatches a live transcription task
+   (`backend/processing/live_transcribe.py`).
+2. The task slices completed speech regions, transcribes them with the engine
+   selected by `live_transcription_backend`, and appends provisional segments
+   to `Transcript.segments` (each flagged `"provisional": True`).
+3. The web client polls the transcript roughly every 3 seconds to render the
+   provisional text.
+
+Segments are numbered sequentially but uploaded concurrently, so the lane uses
+a **sequence-gated buffer**. Each task reads `next_expected` from a per-recording
+`live/state.json`; a task whose segment is ahead of `next_expected` returns
+immediately (its WAV waits on disk), and only the task holding `next_expected`
+drains the contiguous run of segments present on disk. Audio from the trailing,
+not-yet-complete utterance is **carried over** in `live/buffer.wav` and joined
+to the next run, so an utterance split across a segment boundary is transcribed
+once as a whole.
+
+The live lane is best-effort: any failure is logged, the lane still advances,
+and nothing is re-raised. When the recording finalises, `process_recording_task`
+runs the full pipeline against the source audio and overwrites the provisional
+segments with the final transcript.
 
 ## Calendar Flow
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,7 +92,11 @@ runs:
    (`backend/processing/live_transcribe.py`).
 2. The task slices completed speech regions, transcribes them with the engine
    selected by `live_transcription_backend`, and appends provisional segments
-   to `Transcript.segments` (each flagged `"provisional": True`).
+   to `Transcript.segments` (each flagged `"provisional": True`). VAD regions
+   are padded and each region clip is prepended with a short rolling audio
+   context window (`live/context.wav`) so the engine has acoustic run-up and
+   word edges are not clipped; the engine output is then sliced back to the
+   region. The final batch pipeline is unchanged.
 3. The web client polls the transcript roughly every 3 seconds to render the
    provisional text.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -200,6 +200,8 @@ cd companion
 npm run tauri build
 ```
 
+On Windows, `companion/src-tauri/build.rs` gates out the Swift runtime linker flags (`-Wl,-rpath`, `/usr/lib/swift`), which are only valid for the Unix linker on macOS/Linux and would otherwise break the MSVC linker.
+
 If you are building signed updates locally, ensure `TAURI_PRIVATE_KEY` and `TAURI_KEY_PASSWORD` are available in your environment.
 
 ### Testing and Switching Deployments

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -84,6 +84,10 @@ If live audio stays quiet for a while, Nojoin may show a low-key inline reminder
 
 Manual notes are captured with low-latency autosave behaviour so typing remains responsive while the meeting is live.
 
+### Live Transcription
+
+While a meeting is recording, provisional transcript segments appear in the transcript view roughly 3 seconds behind speech. These segments are read-only and marked with a `Live` badge. When the recording is stopped and processed, they are automatically replaced by the final diarized transcript.
+
 ## Importing Recordings
 
 You can import existing audio files directly through the web client.
@@ -132,6 +136,17 @@ Retry Processing:
 - Rebuilds the meeting from the original audio.
 - Preserves recording metadata, tags, uploaded documents, and user-authored notes.
 - Records a fresh processing timing sample for future ETA calculations.
+
+### Reprocess a Recording
+
+From the recording detail page you can **Reprocess at higher quality**. This re-runs the full pipeline like Retry Processing, but lets you pick the transcription engine for this run only.
+
+Reprocessing:
+
+- Lets you choose the transcription engine (for example a more accurate model) for this run.
+- Clears and rebuilds the transcript and generated artefacts, preserving metadata, tags, documents, and user-authored notes.
+- Asks for confirmation before discarding the existing transcript.
+- Does not change your default transcription settings; the chosen engine applies to this reprocess only.
 
 ## Transcript and Playback Workflow
 
@@ -206,6 +221,7 @@ Depending on permissions, users may also see or adjust:
 - LLM provider selection.
 - Provider model selection.
 - Provider API keys or Ollama URL.
+- Transcription engine selection (Whisper or Parakeet).
 - Whisper model settings.
 - Local Ollama configuration.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -86,7 +86,7 @@ Manual notes are captured with low-latency autosave behaviour so typing remains 
 
 ### Live Transcription
 
-While a meeting is recording, provisional transcript segments appear in the transcript view roughly 3 seconds behind speech. These segments are read-only and marked with a `Live` badge. When the recording is stopped and processed, they are automatically replaced by the final diarized transcript.
+While a meeting is recording, provisional transcript segments appear in the transcript view roughly 3 seconds behind speech. These segments are read-only and marked with a `Live` badge. Live segments are transcribed with padded speech regions plus a short rolling audio context window, so live quality tracks the final transcript more closely and word edges are not clipped. When the recording is stopped and processed, they are automatically replaced by the final diarized transcript.
 
 ## Importing Recordings
 

--- a/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
@@ -26,9 +26,10 @@ import NotesView from "@/components/NotesView";
 import DocumentsView from "@/components/DocumentsView";
 import RecordingStatusDisplay from "@/components/RecordingStatusDisplay";
 import ExportModal from "@/components/ExportModal";
+import ReprocessDialog from "@/components/ReprocessDialog";
 import RecordingTagEditor from "@/components/RecordingTagEditor";
 import Link from "next/link";
-import { Edit2, MessageSquare, X } from "lucide-react";
+import { Edit2, MessageSquare, RefreshCw, X } from "lucide-react";
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import {
   Recording,
@@ -124,6 +125,9 @@ export default function RecordingPage({ params }: PageProps) {
   // Export Modal State
   const [showExportModal, setShowExportModal] = useState(false);
 
+  // Reprocess Dialog State
+  const [showReprocessDialog, setShowReprocessDialog] = useState(false);
+
   // Mobile State
   const [isMobile, setIsMobile] = useState(false);
   const [isMobileChatOpen, setIsMobileChatOpen] = useState(false);
@@ -197,6 +201,13 @@ export default function RecordingPage({ params }: PageProps) {
         const { id } = await params;
         const data = await getRecording(id);
 
+        const segmentsSignature = (rec: Recording | null) => {
+          const segs = rec?.transcript?.segments;
+          if (!segs || segs.length === 0) return "0";
+          const last = segs[segs.length - 1];
+          return `${segs.length}|${last.end}|${last.text}`;
+        };
+
         if (
           data.status !== recording.status ||
           data.client_status !== recording.client_status ||
@@ -210,6 +221,7 @@ export default function RecordingPage({ params }: PageProps) {
           data.transcript?.notes_status !== recording.transcript?.notes_status ||
           data.transcript?.notes !== recording.transcript?.notes ||
           data.transcript?.user_notes !== recording.transcript?.user_notes ||
+          segmentsSignature(data) !== segmentsSignature(recording) ||
           JSON.stringify(data.speakers) !== JSON.stringify(recording.speakers)
         ) {
           setRecording(data);
@@ -831,6 +843,21 @@ export default function RecordingPage({ params }: PageProps) {
               />
             </div>
           </div>
+
+          {recording &&
+            (recording.status === RecordingStatus.PROCESSED ||
+              recording.status === RecordingStatus.ERROR) && (
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  onClick={() => setShowReprocessDialog(true)}
+                  className="flex items-center gap-2 px-3 py-2 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm"
+                  title="Reprocess this recording at higher quality"
+                >
+                  <RefreshCw className="w-4 h-4" />
+                  Reprocess
+                </button>
+              </div>
+            )}
         </div>
 
         {/* Audio Player in Header */}
@@ -1009,10 +1036,66 @@ export default function RecordingPage({ params }: PageProps) {
         {recording.status === RecordingStatus.UPLOADING ||
         recording.status === RecordingStatus.PROCESSING ||
         recording.status === RecordingStatus.QUEUED ? (
-          <RecordingStatusDisplay
-            recording={recording}
-            onSaveProcessingNotes={handleProcessingNotesChange}
-          />
+          recording.status === RecordingStatus.UPLOADING &&
+          recording.transcript?.segments &&
+          recording.transcript.segments.length > 0 ? (
+            <PanelGroup
+              direction="horizontal"
+              autoSaveId="recording-live-layout-persistence"
+              className="h-full flex-1 min-w-0"
+            >
+              <Panel defaultSize={60} minSize={30}>
+                <RecordingStatusDisplay
+                  recording={recording}
+                  onSaveProcessingNotes={handleProcessingNotesChange}
+                />
+              </Panel>
+
+              <PanelResizeHandle className="bg-gray-200 dark:bg-gray-900 border-l border-gray-400 dark:border-gray-800 w-2 hover:bg-orange-500 dark:hover:bg-orange-500 transition-colors flex items-center justify-center group">
+                <div className="h-8 w-1 bg-gray-400 dark:bg-gray-600 rounded-full group-hover:bg-white transition-colors" />
+              </PanelResizeHandle>
+
+              <Panel defaultSize={40} minSize={25}>
+                <div className="flex flex-col h-full min-h-0 bg-white dark:bg-gray-800">
+                  <div className="px-4 py-3 border-b-2 border-gray-200 dark:border-gray-700 shrink-0 bg-gray-50 dark:bg-gray-900">
+                    <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                      Live transcript
+                    </h2>
+                  </div>
+                  <div className="flex-1 min-h-0">
+                    <TranscriptView
+                      recordingId={recording.id}
+                      segments={recording.transcript.segments}
+                      currentTime={currentTime}
+                      onPlaySegment={handlePlaySegment}
+                      isPlaying={isPlaying}
+                      onPause={handlePause}
+                      onResume={handleResume}
+                      speakerMap={speakerMap}
+                      speakers={recording.speakers || []}
+                      globalSpeakers={globalSpeakers}
+                      onRenameSpeaker={handleRenameSpeaker}
+                      onUpdateSegmentSpeaker={handleUpdateSegmentSpeaker}
+                      onUpdateSegmentText={handleUpdateSegmentText}
+                      onFindAndReplace={handleGlobalFindAndReplace}
+                      speakerColors={speakerColors}
+                      onUndo={handleUndo}
+                      onRedo={handleRedo}
+                      canUndo={false}
+                      canRedo={false}
+                      onExport={() => setShowExportModal(true)}
+                      readOnly
+                    />
+                  </div>
+                </div>
+              </Panel>
+            </PanelGroup>
+          ) : (
+            <RecordingStatusDisplay
+              recording={recording}
+              onSaveProcessingNotes={handleProcessingNotesChange}
+            />
+          )
         ) : isMobile ? (
           <div className="h-full flex-1 flex flex-col min-w-0 relative">
             {renderMainContent()}
@@ -1117,6 +1200,23 @@ export default function RecordingPage({ params }: PageProps) {
         onExport={handleExport}
         hasNotes={!!recording?.transcript?.notes}
       />
+
+      {/* Reprocess Dialog */}
+      {recording && (
+        <ReprocessDialog
+          recordingId={recording.id}
+          isOpen={showReprocessDialog}
+          onClose={() => setShowReprocessDialog(false)}
+          onReprocessed={(updatedRecording) => {
+            setRecording(updatedRecording);
+            window.dispatchEvent(
+              new CustomEvent("recording-updated", {
+                detail: { id: updatedRecording.id },
+              }),
+            );
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ReprocessDialog.tsx
+++ b/frontend/src/components/ReprocessDialog.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X, RefreshCw, AlertTriangle } from "lucide-react";
+import { reprocessRecording } from "@/lib/api";
+import { Recording, RecordingId, ReprocessRequest } from "@/types";
+
+type TranscriptionBackend = "whisper" | "parakeet";
+
+const WHISPER_MODEL_SIZES = [
+  "turbo",
+  "large",
+  "medium",
+  "small",
+  "base",
+  "tiny",
+];
+
+const PARAKEET_MODEL = "parakeet-tdt-0.6b-v3";
+const DEFAULT_WHISPER_MODEL_SIZE = "turbo";
+
+interface ReprocessDialogProps {
+  recordingId: RecordingId;
+  isOpen: boolean;
+  onClose: () => void;
+  onReprocessed: (updatedRecording: Recording) => void;
+}
+
+export default function ReprocessDialog({
+  recordingId,
+  isOpen,
+  onClose,
+  onReprocessed,
+}: ReprocessDialogProps) {
+  const [backend, setBackend] = useState<TranscriptionBackend>("whisper");
+  const [whisperModelSize, setWhisperModelSize] = useState<string>(
+    DEFAULT_WHISPER_MODEL_SIZE,
+  );
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setBackend("whisper");
+      setWhisperModelSize(DEFAULT_WHISPER_MODEL_SIZE);
+      setIsSubmitting(false);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true);
+    setError(null);
+
+    const body: ReprocessRequest =
+      backend === "whisper"
+        ? {
+            transcription_backend: "whisper",
+            whisper_model_size: whisperModelSize,
+          }
+        : {
+            transcription_backend: "parakeet",
+            parakeet_model: PARAKEET_MODEL,
+          };
+
+    try {
+      const updatedRecording = await reprocessRecording(recordingId, body);
+      onReprocessed(updatedRecording);
+      onClose();
+    } catch (err) {
+      const message =
+        err && typeof err === "object" && "response" in err
+          ? ((err as { response?: { data?: { detail?: unknown } } }).response
+              ?.data?.detail as string | undefined)
+          : undefined;
+      setError(message || "Failed to start reprocessing. Please try again.");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={isSubmitting ? undefined : onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Reprocess at higher quality
+          </h2>
+          <button
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-4">
+          {/* Engine select */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Transcription engine
+            </label>
+            <select
+              value={backend}
+              onChange={(e) =>
+                setBackend(e.target.value as TranscriptionBackend)
+              }
+              disabled={isSubmitting}
+              className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50"
+            >
+              <option value="whisper">Whisper</option>
+              <option value="parakeet">Parakeet (NVIDIA)</option>
+            </select>
+          </div>
+
+          {/* Model selection */}
+          {backend === "whisper" ? (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Whisper Model Size
+              </label>
+              <select
+                value={whisperModelSize}
+                onChange={(e) => setWhisperModelSize(e.target.value)}
+                disabled={isSubmitting}
+                className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50"
+              >
+                {WHISPER_MODEL_SIZES.map((size) => (
+                  <option key={size} value={size}>
+                    {size.charAt(0).toUpperCase() + size.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Parakeet Model
+              </label>
+              <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
+                <div className="flex-1">
+                  <div className="font-semibold text-gray-900 dark:text-white">
+                    {PARAKEET_MODEL}
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Model used for transcription.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Destructive warning */}
+          <div className="flex gap-3 p-4 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+            <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+            <p className="text-sm text-amber-800 dark:text-amber-200">
+              Reprocessing replaces the current transcript, speaker labels and
+              meeting notes for this recording. Any manual edits to those will
+              be lost. Manual processing notes, tags and documents are kept.
+            </p>
+          </div>
+
+          {/* Error message */}
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
+          <button
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={isSubmitting}
+            className="flex items-center gap-2 px-4 py-2 bg-orange-600 text-white rounded-md hover:bg-orange-700 transition-colors disabled:opacity-50"
+          >
+            <RefreshCw
+              className={`w-4 h-4 ${isSubmitting ? "animate-spin" : ""}`}
+            />
+            {isSubmitting ? "Reprocessing..." : "Reprocess"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TranscriptView.tsx
+++ b/frontend/src/components/TranscriptView.tsx
@@ -53,6 +53,7 @@ interface TranscriptViewProps {
   canUndo: boolean;
   canRedo: boolean;
   onExport: () => void;
+  readOnly?: boolean;
 }
 
 const formatTime = (seconds: number) => {
@@ -81,6 +82,7 @@ export default function TranscriptView({
   canUndo,
   canRedo,
   onExport,
+  readOnly = false,
 }: TranscriptViewProps) {
   const activeSegmentRef = useRef<HTMLDivElement>(null);
   const { addNotification } = useNotificationStore();
@@ -345,6 +347,7 @@ export default function TranscriptView({
     e: React.MouseEvent,
   ) => {
     e.stopPropagation();
+    if (readOnly || segments[index]?.provisional === true) return;
     setEditingTextIndex(index);
     setEditValue(text);
     setEditingSpeaker(null);
@@ -439,7 +442,10 @@ export default function TranscriptView({
   }));
 
   const displaySegments = hasKnownSpeakers
-    ? indexedSegments.filter(({ segment }) => segment.speaker !== "UNKNOWN")
+    ? indexedSegments.filter(
+        ({ segment }) =>
+          segment.speaker !== "UNKNOWN" || segment.provisional === true,
+      )
     : indexedSegments;
 
   // --- Grouping Logic ---
@@ -495,6 +501,8 @@ export default function TranscriptView({
   const renderSegmentContent = (item: typeof displaySegments[0]) => {
     const { segment, index: originalIndex } = item;
     const isActive = currentTime >= segment.start && currentTime < segment.end;
+    const isProvisional = segment.provisional === true;
+    const isSegmentReadOnly = readOnly || isProvisional;
     const speakerName = speakerMap[segment.speaker] || segment.speaker;
     const isEditingSpeaker = editingSpeaker === segment.speaker;
     const isEditingSegmentSpeaker =
@@ -545,6 +553,7 @@ export default function TranscriptView({
               <button
                 onClick={(e) => {
                   e.stopPropagation();
+                  if (isSegmentReadOnly) return;
                   if (activePopover?.index === originalIndex) {
                     setActivePopover(null);
                   } else {
@@ -556,17 +565,27 @@ export default function TranscriptView({
                 }}
                 onDoubleClick={(e) => {
                   e.stopPropagation();
+                  if (isSegmentReadOnly) return;
                   setEditingSpeaker(segment.speaker);
                   setEditValue(speakerName);
                   setActivePopover(null);
                 }}
-                className="text-base font-bold text-gray-700 dark:text-gray-300 hover:text-orange-700 dark:hover:text-orange-400 transition-colors text-left"
-                title="Click to change speaker, Double-click to rename"
+                disabled={isSegmentReadOnly}
+                className={`text-base font-bold text-gray-700 dark:text-gray-300 transition-colors text-left ${
+                  isSegmentReadOnly
+                    ? "cursor-default"
+                    : "hover:text-orange-700 dark:hover:text-orange-400"
+                }`}
+                title={
+                  isSegmentReadOnly
+                    ? speakerName
+                    : "Click to change speaker, Double-click to rename"
+                }
               >
                 {speakerName}
               </button>
 
-              {activePopover?.index === originalIndex && (
+              {activePopover?.index === originalIndex && !isSegmentReadOnly && (
                 <SpeakerAssignmentPopover
                   availableSpeakers={speakers}
                   globalSpeakers={globalSpeakers}
@@ -589,8 +608,18 @@ export default function TranscriptView({
           id={`segment-${originalIndex}`}
           className={`p-3 rounded-2xl rounded-tl-none w-full transition-colors border ${bubbleColor} ${
             isEditingText ? "ring-2 ring-blue-500" : ""
+          } ${
+            isProvisional
+              ? "border-dashed border-2 opacity-70"
+              : ""
           }`}
         >
+          {isProvisional && (
+            <span className="mb-1.5 inline-flex items-center gap-1 rounded-full bg-orange-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-orange-700 dark:bg-orange-500/15 dark:text-orange-300">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-orange-500" />
+              Live
+            </span>
+          )}
           {isEditingText ? (
             <textarea
               autoFocus
@@ -603,9 +632,13 @@ export default function TranscriptView({
             />
           ) : (
             <p
-              className="leading-relaxed whitespace-pre-wrap text-gray-800 dark:text-gray-200 cursor-text hover:text-gray-900 dark:hover:text-white"
+              className={`leading-relaxed whitespace-pre-wrap text-gray-800 dark:text-gray-200 ${
+                isSegmentReadOnly
+                  ? ""
+                  : "cursor-text hover:text-gray-900 dark:hover:text-white"
+              }`}
               onClick={(e) => handleTextClick(originalIndex, segment.text, e)}
-              title="Click to edit text"
+              title={isSegmentReadOnly ? undefined : "Click to edit text"}
             >
               {renderHighlightedText(segment.text, originalIndex)}
             </p>

--- a/frontend/src/components/settings/AISettings.tsx
+++ b/frontend/src/components/settings/AISettings.tsx
@@ -329,6 +329,8 @@ export default function AISettings({
     "transcription",
     "whisper",
     "speech to text",
+    "parakeet",
+    "engine",
   ]);
   const showDependencies = fuzzyMatch(searchQuery, [
     "dependencies",
@@ -751,6 +753,50 @@ export default function AISettings({
         >
           <SettingsPanel className="mx-auto max-w-3xl space-y-4">
             <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <Tooltip
+                  content="Select the transcription engine used for speech to text."
+                  position="right"
+                >
+                  <span className="flex items-center gap-1 cursor-help">
+                    Transcription engine{" "}
+                    <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
+                  </span>
+                </Tooltip>
+              </label>
+              <select
+                value={settings.transcription_backend || "whisper"}
+                onChange={(e) =>
+                  onUpdate({
+                    ...settings,
+                    transcription_backend: e.target.value,
+                  })
+                }
+                disabled={!isAdmin}
+                className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
+              >
+                <option value="whisper">Whisper</option>
+                <option value="parakeet">Parakeet (NVIDIA)</option>
+              </select>
+            </div>
+            {(settings.transcription_backend || "whisper") === "parakeet" ? (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Parakeet Model
+                </label>
+                <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
+                  <div className="flex-1">
+                    <div className="font-semibold text-gray-900 dark:text-white">
+                      {settings.parakeet_model || "parakeet-tdt-0.6b-v3"}
+                    </div>
+                    <p className="mt-1 text-xs contrast-helper">
+                      Current active model for transcription.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : (
+            <div>
               <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
                 Whisper Model Size
                 <div className="group relative">
@@ -824,6 +870,7 @@ export default function AISettings({
                 model variant. You may need to download the new model.
               </p>
             </div>
+            )}
             <WhisperModelModal
               isOpen={showWhisperModal}
               onClose={() => setShowWhisperModal(false)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,6 +27,7 @@ import {
   SegmentSelection,
   TranscriptSpeakerAssignment,
   UserTask,
+  ReprocessRequest,
 } from "@/types";
 
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL
@@ -265,6 +266,17 @@ export const renameRecording = async (
 
 export const retryProcessing = async (id: RecordingId): Promise<Recording> => {
   const response = await api.post<Recording>(`/recordings/${id}/retry`);
+  return response.data;
+};
+
+export const reprocessRecording = async (
+  id: RecordingId,
+  body: ReprocessRequest,
+): Promise<Recording> => {
+  const response = await api.post<Recording>(
+    `/recordings/${id}/reprocess`,
+    body,
+  );
   return response.data;
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,6 +105,7 @@ export interface TranscriptSegment {
   text: string;
   speaker: string;
   overlapping_speakers?: string[];
+  provisional?: boolean;
 }
 
 export interface Transcript extends BaseDBModel {
@@ -156,6 +157,10 @@ export interface Recording extends Omit<BaseDBModel, "id"> {
 
 export interface Settings {
   whisper_model_size?: string;
+  transcription_backend?: string;
+  parakeet_model?: string;
+  enable_live_transcription?: boolean;
+  live_transcription_backend?: string;
   processing_device?: string;
   theme?: string;
   timezone?: string;
@@ -436,4 +441,10 @@ export interface SegmentSelection {
   recording_id: RecordingId;
   start: number;
   end: number;
+}
+
+export interface ReprocessRequest {
+  transcription_backend: "whisper" | "parakeet";
+  whisper_model_size?: string;
+  parakeet_model?: string;
 }

--- a/requirements/worker.txt
+++ b/requirements/worker.txt
@@ -1,6 +1,10 @@
 -r base.txt
 celery[redis]
 openai-whisper
+# Parakeet ASR engine (pluggable transcription backend)
+onnx-asr
+# onnxruntime-gpu (CUDA build) is installed in docker/Dockerfile.worker: it must
+# replace the CPU-only onnxruntime that fastembed pulls in, not coexist with it.
 silero-vad
 numpy
 pandas


### PR DESCRIPTION
## Summary

Improves the **live transcription lane** so live quality tracks the final transcript more closely — fixing the word-edge clipping ("loses info" during live recording).

This is **MR-B** of the v2 feature backlog (`_newdev/v2_feat/SPEC.md`).

> **Stacking note:** this PR stacks on **#10** (the live transcription lane was introduced there). Until #10 merges, the diff here also shows #10's commits. Review only the 4 commits authored by `feat/live-context-window` (`c09567e` … `cc35911`); merge after #10. Independent of #11 (Canary).

## Background — the investigation overturned the original framing

MR-B was scoped as "adopt a context/overlap-window approach like Meetily". Investigation of Meetily's source proved its live lane has **no** overlap windows, no left-context, no LocalAgreement and no hypothesis revision — it transcribes each VAD segment once, isolated. Meetily's real quality lever is **generous VAD padding** (300 ms pre / 400 ms post).

Nojoin's live lane instead sliced each VAD region with a hard, zero-margin cut and ran VAD with silero's ~30 ms default pad — that hard slice is the concrete cause of clipped word edges.

## What changed

- **Live VAD padding** — new system-config key `live_speech_pad_ms` (default 300), threaded through a new `speech_pad_ms` override on `detect_speech_segments`. This is the load-bearing fix for word-edge clipping.
- **Rolling audio context window** — new system-config key `live_context_window_s` (default 5.0); a rolling `live/context.wav` buffer. Each region is transcribed as `[left-context audio + region]` so the engine has acoustic/linguistic run-up; the engine output is sliced back to the region window by a pure, unit-tested helper.
- **Repetition guard** — a lightweight hallucination filter for the live lane (it had none).
- **Tests** — 12 new tests covering padding override, region-text extraction, the repetition guard and the context-buffer lifecycle.
- **Docs** — `USAGE.md` + `ARCHITECTURE.md`.

## Notes / non-goals

- **The batch transcription path is byte-for-byte unchanged** — `detect_speech_segments` with no `speech_pad_ms` argument behaves exactly as before.
- No `TranscriptionEngine` ABC change, no frontend change, no companion change, no DB migration.
- The emit-once segment lifecycle and the companion 2 s flush are unchanged.
- True overlap-windowing + LocalAgreement-2 (revise the unstable tail) is **deferred** — it needs a revise-by-position lifecycle Nojoin does not have today.
- The new config keys are internal tuning params (system config only — no UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
