### PR TITLE
docs(maintenance): complete Phase 4 documentation and contributor experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a problem to help us improve Nojoin
 title: ''
 labels: bug
 assignees: ''
@@ -8,25 +8,39 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what the bug is. For an intermittent test failure, prefix the title with `[flaky]` and include the test name and how often it fails.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+**Nojoin version**
+e.g. v1.3.8 (see `docs/VERSION` or the about/footer in the app).
+
+**Deployment mode**
+ - [ ] Docker Compose (recommended deployment)
+ - [ ] Local source / development checkout
+ - GPU or CPU: [e.g. NVIDIA GPU, CPU-only]
+
+**Browser and capture mode** (if the issue involves recording)
+ - Browser and version: [e.g. Chrome 137 on Windows 11]
+ - Capture mode: [e.g. desktop shared-audio, mobile microphone-only]
+
+**To reproduce**
+Steps to reproduce the behaviour:
 1. Go to '...'
 2. Click on '...'
-3. Scroll down to '...'
-4. See error
+3. See the error
 
-**Expected behavior**
+**Expected behaviour**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Reproduction data**
+If the issue depends on specific input (an audio file, a recording length, a calendar event, an imported file), describe it. Do not upload confidential recordings or transcripts; provide a minimal, non-sensitive sample where possible.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Windows]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Logs**
+Attach relevant logs. **Redact secrets and personal data first** — remove `FIRST_RUN_PASSWORD`, `DATA_ENCRYPTION_KEY`, API keys, tokens, `Authorization` headers, cookies, and meeting content you do not want public.
+- Browser: open DevTools and copy any relevant console or network errors.
+- Server: collect `docker compose logs api worker frontend`.
+
+**Screenshots**
+If applicable, add screenshots to help explain the problem (with sensitive content redacted).
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability (private)
+    url: https://github.com/Valtora/Nojoin/security/advisories/new
+    about: Report security vulnerabilities privately through GitHub Private Vulnerability Reporting. Do not open a public issue.
+  - name: Questions and support
+    url: https://github.com/Valtora/Nojoin/blob/main/.github/SUPPORT.md
+    about: Read the support guide for where to ask questions and what to expect from maintainers.
+  - name: Documentation
+    url: https://github.com/Valtora/Nojoin/blob/main/docs/README.md
+    about: Setup, deployment, capture, and usage guides answer most questions.

--- a/.github/ISSUE_TEMPLATE/platform_report.md
+++ b/.github/ISSUE_TEMPLATE/platform_report.md
@@ -1,40 +1,51 @@
 ---
 name: Platform Compatibility Report
-about: Report issues specific to browser capture on Windows or Linux
-title: '[Platform]: Browser Capture Issue on <Browser / OS>'
+about: Report a browser-capture issue specific to an OS, browser, or device
+title: '[Platform]: Browser capture issue on <Browser / OS>'
 labels: 'platform-issue, help wanted'
 assignees: ''
 
 ---
 
-**Operating System**
- - OS: [e.g. macOS Sequoia, Ubuntu 22.04]
- - Version: [e.g. 15.0, 22.04.3 LTS]
- - Desktop Environment (Linux only): [e.g. GNOME, KDE]
+**Operating system / device**
+ - Platform: [e.g. Windows 11, Ubuntu 22.04, macOS Sequoia, Android 14, iOS 17]
+ - Version: [e.g. 23H2, 22.04.3 LTS, 15.0]
+ - Desktop environment (Linux only): [e.g. GNOME, KDE, X11 or Wayland]
 
 **Browser**
- - Browser: [e.g. Chrome, Edge, Brave]
+ - Browser: [e.g. Chrome, Edge, Brave, Chromium]
  - Version: [e.g. 137.0.0.0]
 
-**Nojoin Version**
- - Version: [e.g. v0.1.0]
+**Capture mode**
+ - [ ] Desktop shared-audio (tab / window / entire screen)
+ - [ ] Mobile microphone-only (Chrome on Android or iOS)
 
-**Describe the bug**
+Supported targets for reference (see [docs/CAPTURE.md](../../docs/CAPTURE.md)):
+- Chrome on Windows, Linux, and macOS — shared-audio recording.
+- Other Chromium-family browsers on Windows and Linux — shared-audio recording.
+- Chromium-family browsers on macOS — best-effort shared-audio recording.
+- Chrome on Android and iOS — microphone-only recording.
+
+**Nojoin version**
+ - Version: [e.g. v1.3.8]
+
+**Describe the issue**
 A clear and concise description of what happened.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Open Nojoin in a supported Chromium browser
+**To reproduce**
+Steps to reproduce the behaviour:
+1. Open Nojoin in the browser above
 2. Start Meet Now or open Settings -> Capture
-3. See error
+3. Share a tab/window/screen with audio (desktop) or grant microphone access (mobile)
+4. See the issue
 
-**Expected behavior**
+**Expected behaviour**
 A clear and concise description of what you expected to happen.
 
 **Logs**
-Please attach any relevant logs.
-- Browser: Open DevTools and copy any relevant console or network errors
-- Docker: Collect `docker compose logs api worker frontend`
+Please attach any relevant logs, with personal data redacted.
+- Browser: open DevTools and copy any relevant console or network errors.
+- Server: collect `docker compose logs api worker frontend`.
 
 **Additional context**
-Add any other context about the problem here.
+Add any other context about the problem here, including whether the browser share picker exposed an audio toggle and whether a shared-audio track was granted.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,49 @@
-# Pull Request Template
+# Pull Request
 
 ## Description
 
-Please include a summary of the change and which issue is fixed or what feature is added. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Summarise the change, the motivation, and any context. List any new dependencies.
 
 Fixes # (issue)
 
 ## Type of change
 
-Please delete options that are not relevant.
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behaviour)
+- [ ] Documentation update
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+## Checks run
 
-## How Has This Been Tested?
+Tick the checks you ran for the areas you touched (see `CONTRIBUTING.md`).
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
+- [ ] Backend tests: `source .venv/bin/activate && pytest`
+- [ ] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
+- [ ] Frontend lint: `cd frontend && npm run lint`
+- [ ] Frontend unit tests: `cd frontend && npm run test`
+- [ ] Frontend build: `cd frontend && npm run build`
+- [ ] Docs validation: `python3 scripts/validate_docs.py`
+- [ ] Alembic validation: `python3 scripts/validate_alembic.py`
 
-## Impact
+## Migration impact
 
-Please describe the impact of this change on the project.
+- [ ] No database migration in this PR.
+- [ ] Adds an Alembic migration. Single checked-in head preserved; no committed revisions deleted or renamed. Upgrade and downgrade behaviour described above.
 
-## Screenshot (if relevant)
+## Documentation impact
 
-Please provide a screenshot of the change if relevant, you can drag and drop an image directly into the markdown box.
+- [ ] No documentation change required.
+- [ ] Updated the relevant guide(s) in the same PR (behaviour, setup, deployment, or support changes must update their guide — see CONTRIBUTING.md "Documentation Ownership").
 
-## To-Dos
+## Security impact
 
-- [ ] Successful npm build
-- [ ] Successful docker build
+- [ ] No security-sensitive change.
+- [ ] Touches auth, tokens, encryption, capture ownership, or exposure. `docs/SECURITY.md` boundaries preserved and updated where behaviour changed.
+
+## Manual verification
+
+Describe what you tested manually. Capture-related changes require browser smoke testing for start, pause/resume, stop/finalize, discard, unsupported-browser messaging, and selected-microphone behaviour. Recording context-menu changes must keep `RecordingCard.tsx` and `Sidebar.tsx` in sync.
+
+## Screenshots (if relevant)
+
+Drag and drop images directly into the markdown box (redact sensitive content).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,32 @@
+# Support
+
+How to get help with Nojoin, and what to realistically expect from the maintainers.
+
+## Before You Ask
+
+- Read the [documentation index](../docs/README.md); most setup, deployment, capture, and usage questions are answered there.
+- Search [existing issues](https://github.com/Valtora/Nojoin/issues) to avoid duplicates.
+- Reproduce the problem on the latest released version (see the **Supported Versions** note below).
+
+## Where to Go
+
+- **Bugs and regressions:** open a bug report.
+- **Browser-capture or platform problems:** open a platform compatibility report.
+- **Feature ideas:** open a feature request.
+- **Security vulnerabilities:** do not open a public issue. Use GitHub Private Vulnerability Reporting as described in the [security policy](../docs/SECURITY.md).
+- **Code of Conduct concerns:** follow the private reporting process in the [Code of Conduct](../docs/CODE_OF_CONDUCT.md).
+
+## Supported Versions
+
+Nojoin is in active development and should be considered pre-release. Only the latest released version is supported, matching the [security policy](../docs/SECURITY.md). Please reproduce and report issues against the latest version.
+
+## Maintainer Response and Triage
+
+Nojoin is maintained on a best-effort basis by a small team. To set honest expectations:
+
+- **Security reports:** initial acknowledgement within 48 hours, per the [security policy](../docs/SECURITY.md).
+- **Bug and platform reports:** triaged and labelled as maintainer time permits. Clear reproduction steps, version, deployment mode, and redacted logs speed this up considerably.
+- **Feature requests:** read and considered, but acceptance and scheduling are not guaranteed.
+- **Pull requests:** reviewed when maintainer time allows. PRs that pass all required checks and update the affected documentation are the easiest and fastest to merge.
+
+Outside the security acknowledgement window, there is no guaranteed response-time commitment. Well-scoped, reproducible reports and self-contained pull requests receive attention soonest.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,21 @@ Install the git pre-commit hook so linting and formatting run automatically:
 pre-commit install
 ```
 
+### Lightweight Contributor Paths
+
+You do not need the full GPU/ML stack for every change. The heavy inference dependencies (CUDA, Whisper, Pyannote) are only required to run the live processing pipeline locally. Match the setup to the surface you are changing.
+
+- **Documentation-only changes:** no Python virtual environment or Node toolchain is required. Edit the Markdown, then validate links with `python3 scripts/validate_docs.py`. That script has no third-party dependencies.
+- **Frontend-only changes:** install Node.js 20 or newer and the frontend dependencies only. You can develop and fully verify frontend work without CUDA or the ML requirements.
+
+  ```bash
+  cd frontend
+  npm install
+  npm run lint && npm run test && npm run build
+  ```
+
+- **Backend lint, test, and type-check without a GPU:** create the virtual environment and install `requirements/dev.txt` (CPU-only) instead of `requirements/local.txt`, then run `python scripts/check.py`. The full `requirements/local.txt` is only needed to exercise live transcription and diarisation on a GPU host.
+
 Minimum pull request verification is:
 
 - Backend/API/worker changes: `source .venv/bin/activate && pytest`
@@ -79,13 +94,37 @@ The pull request workflow requires these checks to pass on `main`:
 - `Docs validation`
 - `Alembic validation`
 
-Run the checks for every area you touched before opening a pull request. Capture-related changes also require manual browser smoke testing for start, pause/resume, stop/finalize, discard, unsupported-browser messaging, and selected-microphone behavior. Migration changes must keep a single checked-in Alembic head and must not delete or rename committed revision files.
+Run the checks for every area you touched before opening a pull request. Capture-related changes also require manual browser smoke testing for start, pause/resume, stop/finalize, discard, unsupported-browser messaging, and selected-microphone behaviour. Migration changes must keep a single checked-in Alembic head and must not delete or rename committed revision files.
 
 Additional scope rules:
 
 - Recording context-menu changes must keep `frontend/src/components/RecordingCard.tsx` and `frontend/src/components/Sidebar.tsx` in sync.
-- Security-sensitive changes must preserve the documented auth and token boundaries in `docs/SECURITY.md` and update that guide in the same pull request when behavior changes.
-- API changes must keep backend response schemas (`backend/models/*_public.py` and related Pydantic models) and the corresponding frontend interfaces in `frontend/src/types/index.ts` synchronized in the same pull request.
+- Security-sensitive changes must preserve the documented auth and token boundaries in `docs/SECURITY.md` and update that guide in the same pull request when behaviour changes.
+- API changes must keep backend response schemas (`backend/models/*_public.py` and related Pydantic models) and the corresponding frontend interfaces in `frontend/src/types/index.ts` synchronised in the same pull request.
+
+## Documentation Ownership
+
+Documentation is owned alongside the code it describes. Any change to behaviour, setup, deployment, or support must update the relevant guide in the same pull request:
+
+- Product or UI behaviour: `docs/USAGE.md`, and `docs/SCREENSHOTS.md` if a captured screen changes.
+- Browser capture behaviour: `docs/CAPTURE.md`.
+- Local setup or development workflow: `docs/DEVELOPMENT.md` and this file.
+- Deployment, configuration, or upgrade behaviour: `docs/DEPLOYMENT.md`.
+- Auth, token, or encryption behaviour: `docs/SECURITY.md`.
+- Architecture or pipeline contracts: `docs/ARCHITECTURE.md`.
+- Support, reporting, or supported-version expectations: `.github/SUPPORT.md` and `docs/SECURITY.md`.
+
+Reviewers should treat a behaviour or operational change with no corresponding documentation update as incomplete.
+
+## Reporting Issues
+
+Use the GitHub issue templates and choose the closest match. Route sensitive reports privately as noted below.
+
+- **Bugs:** open a bug report and include your Nojoin version, deployment mode, browser, capture mode, and redacted logs.
+- **Platform or browser-capture failures:** open a platform compatibility report with your operating system, browser, and versions. These are triaged under the `platform-issue` label.
+- **Flaky tests:** open a bug report titled `[flaky]`. Include the test name, the CI job or local command, how often it fails, and a link to a failing run if available. Note whether it reproduces locally or only in CI.
+- **Dependency issues:** open a bug report describing the dependency, the pinned and installed versions, the platform (CPU or CUDA, operating system, Python or Node version), and the exact install or runtime error. State whether it affects `requirements/local.txt`, `requirements/dev.txt`, or the frontend lockfile.
+- **Security vulnerabilities:** do not open a public issue. Use GitHub Private Vulnerability Reporting as described in the [security policy](docs/SECURITY.md).
 
 ## Code of Conduct
 

--- a/LEGAL.md
+++ b/LEGAL.md
@@ -1,5 +1,5 @@
 # Legal Disclaimer
 
-**Important:** You are responsible for complying with all applicable laws in your jurisdiction regarding the recording of conversations. Many jurisdictions require the consent of all parties before a conversation can be recorded.
+**Important:** Recording laws vary by jurisdiction, and many jurisdictions require the consent of all parties before a conversation can be recorded. You are responsible for complying with all applicable laws in your jurisdiction.
 
-By using Nojoin, you acknowledge that you will use this software in a lawful manner. The developers of Nojoin assume no liability for any unlawful use of this application.
+The full, canonical legal disclaimer and terms of use are maintained in [docs/LEGAL.md](docs/LEGAL.md). Review it before using Nojoin.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable -->
 <div align="center">
-    <h1><img src="https://iili.io/fueA2wB.png" alt="Nojoin Logo" height="45" width="45" style="vertical-align: middle; horizontal-align: middle;"/> <span style="color: #F36012;"><br>Nojoin</span></h1>
+    <h1><img src="assets/images/nojoin-mark.svg" alt="Nojoin Logo" height="45" width="45" style="vertical-align: middle; horizontal-align: middle;"/> <span style="color: #F36012;"><br>Nojoin</span></h1>
         <p>
            <strong>Self-Hosted Meeting Transcription and Notes</strong>
             </p>

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -116,7 +116,7 @@ Use **Settings > Updates** to see:
 
 Paused recordings are retained indefinitely and are not cleaned up automatically. This protects uploaded meeting data and prevents overlapping segment streams for the same user.
 
-Read [CAPTURE.md](CAPTURE.md) for the support matrix, browser picker behavior, and troubleshooting steps.
+Read [CAPTURE.md](CAPTURE.md) for the support matrix, browser picker behaviour, and troubleshooting steps.
 
 ## Related Docs
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ If the user refreshes, closes, or navigates away from the Nojoin tab while recor
 
 Switching focus to another browser tab, window, or application does not pause capture. Navigating between pages within the Nojoin app also does not pause capture. Only a real Nojoin tab unload (pagehide/beforeunload) invokes the guarded pause path.
 
-When a recording is active, a floating recording badge appears at the top-center of the viewport showing the recording status, elapsed time, and pause, resume, and stop controls. Clicking the badge navigates to the recording detail page. The badge remains visible on every page except the recording detail page so the user never loses visibility of the active recording while navigating the app.
+When a recording is active, a floating recording badge appears at the top-centre of the viewport showing the recording status, elapsed time, and pause, resume, and stop controls. Clicking the badge navigates to the recording detail page. The badge remains visible on every page except the recording detail page so the user never loses visibility of the active recording while navigating the app.
 
 ## Processing Pipeline
 
@@ -196,10 +196,10 @@ meetings rather than a frontend-driven migration workflow.
 3. That cutover acquires a database advisory lock, sweeps any recordings whose
    `pipeline_generation` marker is still unset, and classifies each one into a
    backend-only compatibility state.
-4. Successfully canonicalized historical meetings are marked `legacy_backfilled`
+4. Successfully canonicalised historical meetings are marked `legacy_backfilled`
    and remain viewable through the compatibility projection.
 5. Historical meetings that were still in flight during upgrade or that cannot
-   be canonicalized safely are marked `legacy_reprocess_required` and normalized
+   be canonicalised safely are marked `legacy_reprocess_required` and normalized
    for explicit reprocess instead of continuing to rely on legacy mutation
    paths.
 6. Only meetings created or explicitly rebuilt through the unified pipeline are

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -28,7 +28,7 @@ Live capture has two browser modes:
 
 Unsupported browsers can still review recordings, play audio, edit transcripts, manage speakers, use search, and administer Nojoin. They cannot start live capture.
 
-Chrome on macOS is a supported desktop capture path. Tab audio is the most reliable macOS option. Window and entire-screen audio should work on current Chrome and current macOS when the browser picker exposes and grants the audio toggle, but older browser or OS versions may return video without a shared-audio track. Other Chromium-family browsers on macOS are allowed by Nojoin but treated as best-effort because their picker behavior can lag Chrome.
+Chrome on macOS is a supported desktop capture path. Tab audio is the most reliable macOS option. Window and entire-screen audio should work on current Chrome and current macOS when the browser picker exposes and grants the audio toggle, but older browser or OS versions may return video without a shared-audio track. Other Chromium-family browsers on macOS are allowed by Nojoin but treated as best-effort because their picker behaviour can lag Chrome.
 
 ## What Nojoin Captures
 
@@ -41,7 +41,7 @@ On desktop shared-audio capture, the browser mixes those sources in the Nojoin t
 
 On mobile Chrome, Nojoin records only the phone microphone. The browser still uploads live segments into the same backend pipeline, but remote participants are captured only if the phone microphone can hear them from the room or device speaker. Keep the Nojoin tab open and the phone awake while recording.
 
-For support and debugging, browser recording segments are numbered from `0` and resume with the next sequence after the last uploaded segment. Finalization rejects missing sequence gaps. Live ASR and rolling speaker-window diarization are tracked separately in the backend, so a recording can have transcript coverage before every speaker-window pass has completed. Final processing reuses live text and speaker decisions only when they align by stable utterance id or clear time overlap; ambiguous spans keep the final pipeline output.
+For support and debugging, browser recording segments are numbered from `0` and resume with the next sequence after the last uploaded segment. Finalization rejects missing sequence gaps. Live ASR and rolling speaker-window diarisation are tracked separately in the backend, so a recording can have transcript coverage before every speaker-window pass has completed. Final processing reuses live text and speaker decisions only when they align by stable utterance id or clear time overlap; ambiguous spans keep the final pipeline output.
 
 ## Before Your First Recording
 
@@ -93,7 +93,7 @@ On macOS, entire-screen and window audio should work on current Chrome and curre
 The exact wording is browser-dependent:
 
 - Chrome on Windows usually shows **Also share system audio** for entire-screen sharing and **Share tab audio** for tab sharing.
-- Edge on Windows follows the same general behavior as Chrome.
+- Edge on Windows follows the same general behaviour as Chrome.
 - Chrome on macOS usually offers reliable tab audio. Window and entire-screen audio should work on latest Chrome and macOS when the picker shows the audio toggle.
 - Brave may require shields or site settings to allow capture prompts on hardened profiles.
 - Linux Chromium builds require working desktop capture through PipeWire for screen capture. PulseAudio-only environments are expected to fail for system or screen audio.
@@ -121,7 +121,7 @@ Switching to another browser tab, changing the active window, using another appl
 
 ## Floating Recording Badge
 
-While a recording is active, a floating badge appears at the top-center of the viewport. The badge shows:
+While a recording is active, a floating badge appears at the top-centre of the viewport. The badge shows:
 
 - A pulsing red dot and the word **Recording** (or **Paused** when paused).
 - The elapsed recording time.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -8,15 +8,15 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our community include:
+Examples of behaviour that contributes to a positive environment for our community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior include:
+Examples of unacceptable behaviour include:
 
 * The use of sexualized language or imagery, and sexual attention or advances of any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
@@ -26,12 +26,15 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement.
-All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported privately to the project maintainers for enforcement.
+
+Submit a report through GitHub's private reporting form at <https://github.com/Valtora/Nojoin/security/advisories/new>. This is the same private channel used for security disclosures, so clearly mark the report as a **Code of Conduct** matter in the title and description to ensure it is triaged correctly and not handled as a security vulnerability.
+
+All complaints will be reviewed and investigated promptly and fairly. The maintainers are obligated to respect the privacy and security of anyone who reports an incident.
 
 ## Attribution
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -271,12 +271,13 @@ location / {
   chmod -R 700 ./data
   ```
   If you have special host-integration requirements that require group or world read access, you can configure a custom umask using the `NOJOIN_UMASK` environment variable (e.g. `NOJOIN_UMASK=0022` or `NOJOIN_UMASK=0002`).
-- The browser-capture cutover retires the Windows desktop helper. Users start live recordings directly from the Nojoin web app in a supported browser.
-- Existing recordings remain viewable and process through the same backend pipeline. Existing native-helper installs are obsolete and should be removed from user machines.
-- Current pipeline-cutover releases run a blocking backend-only canonical transcript migration during container startup after Alembic completes. Expect the API container to take longer to become ready on the first boot after upgrade if the database still contains pre-cutover recordings.
-- During that startup cutover, existing recordings are classified entirely on the backend. Successfully migrated legacy meetings remain viewable, while legacy meetings that cannot be canonicalized safely are marked for explicit reprocess instead of being edited in place.
-- The supported rollback model for this cutover is code rollback only. Canonical rows created during startup migration are additive and are not converted back into legacy-only transcript state.
-- The live pipeline lane-state migration adds ASR and diarisation fields to `recording_audio_window_manifests` and backfills them from legacy window status plus completed diarisation window results. No operator action is required beyond allowing Alembic to run during the normal container startup, but take a database backup before upgrade and avoid downgrading after the migration unless you are prepared to restore from backup.
+### One-Time Migrations From Pre-Browser-Capture Releases
+
+The notes below describe one-time migrations that run automatically when you first upgrade across the relevant cutover. They apply only if your database or installation predates that cutover. On a clean install, or on any installation already past these cutovers, they require no action and can be treated as historical context.
+
+- Browser-capture cutover: the Windows desktop helper has been retired. Users start live recordings directly from the Nojoin web app in a supported browser. Existing recordings remain viewable and process through the same backend pipeline; any remaining native-helper installs are obsolete and should be removed from user machines.
+- Canonical-pipeline cutover (first upgrade only): if the database still contains pre-cutover recordings, the first upgrade across this cutover runs a blocking backend-only canonical transcript migration during container startup after Alembic completes. Expect the API container to take longer to become ready on that first boot. During the sweep, existing recordings are classified entirely on the backend: successfully migrated legacy meetings remain viewable, while legacy meetings that cannot be canonicalised safely are marked for explicit reprocess instead of being edited in place. The supported rollback model for this cutover is code rollback only; canonical rows created during the migration are additive and are not converted back into legacy-only transcript state.
+- Live-pipeline lane-state migration: this adds ASR and diarisation fields to `recording_audio_window_manifests` and backfills them from legacy window status plus completed diarisation window results. No operator action is required beyond allowing Alembic to run during normal container startup, but take a database backup before upgrade and avoid downgrading after the migration unless you are prepared to restore from backup.
 
 ### Live Pipeline Readiness Notes
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,7 +37,7 @@ Windows:
 - Chrome on Windows, Linux, or macOS, or another supported desktop Chromium browser, for manual shared-audio live-capture validation
 - Chrome on Android or iOS for manual microphone-only mobile capture validation
 - Browser microphone permission for local smoke tests
-- PipeWire screen capture support when validating Linux shared-screen or system audio behavior
+- PipeWire screen capture support when validating Linux shared-screen or system audio behaviour
 
 ## Fresh Checkout Setup
 
@@ -89,11 +89,11 @@ python3 scripts/validate_alembic.py
 
 - Backend or worker code: run `pytest`.
 - Frontend code: run `npm run lint`, `npm run test`, and `npm run build`.
-- Browser capture changes: run the frontend checks and perform manual smoke coverage for share picker behavior, selected microphone behavior, waveform/live state, pause/resume, stop/finalize, discard, and unsupported-browser messaging.
+- Browser capture changes: run the frontend checks and perform manual smoke coverage for share picker behaviour, selected microphone behaviour, waveform/live state, pause/resume, stop/finalize, discard, and unsupported-browser messaging.
 - Documentation-only changes: run `python3 scripts/validate_docs.py`.
 - Alembic migration changes: run `python3 scripts/validate_alembic.py` and keep exactly one checked-in head revision.
 - Deployment or release workflow changes: run the backend, frontend, docs, and Alembic validation set together before opening the pull request.
-- Security-sensitive changes: rerun the relevant backend and frontend checks for the affected auth/session path and update `docs/SECURITY.md` in the same pull request when behavior changes.
+- Security-sensitive changes: rerun the relevant backend and frontend checks for the affected auth/session path and update `docs/SECURITY.md` in the same pull request when behaviour changes.
 - Recording context-menu changes: update both `frontend/src/components/RecordingCard.tsx` and `frontend/src/components/Sidebar.tsx`, then run the full frontend lint, test, and build set.
 
 ## Compose Files
@@ -272,14 +272,14 @@ Development guardrails:
 
 Browser capture code lives under `frontend/src/lib/capture/` and is exercised by the recording page and capture settings surfaces.
 
-When changing capture behavior, validate the relevant parts of this path:
+When changing capture behaviour, validate the relevant parts of this path:
 
 - Supported-browser gating for desktop Chromium on Windows, Linux, and macOS.
 - Unsupported-browser messaging for Firefox, Safari, and mobile browsers other than Chrome.
 - Mobile Chrome microphone-only start, waveform, pause/resume, stop/finalize, and clear copy that shared app/tab/system audio is not captured.
 - Browser share picker flow for tab, window, and screen sharing.
 - Shared-audio track detection and missing-audio messaging.
-- Microphone permission and selected-device behavior.
+- Microphone permission and selected-device behaviour.
 - Per-source gain controls in **Settings > Capture**.
 - Segment creation, sequential upload, worker transcode, live transcript dispatch, stop/finalize, pause/resume, and discard.
 - The paused-recording lock after refresh or close (actual tab unload, not in-app navigation).
@@ -299,7 +299,7 @@ If you are validating through the containerised localhost stack, rebuild the fro
 docker compose up -d --build frontend
 ```
 
-Read [CAPTURE.md](CAPTURE.md) before changing support copy, browser compatibility behavior, or troubleshooting guidance.
+Read [CAPTURE.md](CAPTURE.md) before changing support copy, browser compatibility behaviour, or troubleshooting guidance.
 
 ### Spellcheck Dictionaries
 
@@ -335,9 +335,9 @@ Existing violators predate the gate and are **grandfathered**: the complexity/si
 These rules apply to all tracked source (backend, worker, and frontend), not just Python.
 
 - **Explain intent, not syntax**: A comment should document an invariant, constraint, risk, compatibility requirement, or other non-obvious intent. Do not narrate what the code already says line by line.
-- **No indecisive developer-thought comments**: Remove musings such as "we can commit here", "usually", "assume consistency", "maybe skipped?", or questions embedded in authorization rules. If the code's behaviour is a deliberate rule, state the rule.
-- **Rewrite uncertainty as a contract**: If something is genuinely uncertain or conditional, express it as an explicit invariant, a documented fallback policy, a tracked issue reference, or a testable assumption — not as a hedge. Where the rule is security- or authorization-sensitive, lock it with a test rather than a comment.
-- **Preserve load-bearing comments**: Keep comments that document live/final pipeline alignment, security and authorization boundaries, migration and backward-compatibility requirements, browser-capture contracts, and non-obvious build or runtime constraints. When in doubt, make such a comment more precise rather than deleting it.
+- **No indecisive developer-thought comments**: Remove musings such as "we can commit here", "usually", "assume consistency", "maybe skipped?", or questions embedded in authorisation rules. If the code's behaviour is a deliberate rule, state the rule.
+- **Rewrite uncertainty as a contract**: If something is genuinely uncertain or conditional, express it as an explicit invariant, a documented fallback policy, a tracked issue reference, or a testable assumption — not as a hedge. Where the rule is security- or authorisation-sensitive, lock it with a test rather than a comment.
+- **Preserve load-bearing comments**: Keep comments that document live/final pipeline alignment, security and authorisation boundaries, migration and backward-compatibility requirements, browser-capture contracts, and non-obvious build or runtime constraints. When in doubt, make such a comment more precise rather than deleting it.
 
 ### Local Checks From A Fresh Checkout
 Reproduce the CI Python checks locally with a single command:
@@ -365,8 +365,8 @@ Use `requirements/local.txt` instead of `dev.txt` for a full GPU host with the l
 ### Audio Processing & ML Operations
 - **Library Imports**: ML libraries (such as `torch`, `whisper`, `pyannote`) are computationally heavy and must be imported **inside** Celery task functions (under [backend/worker/tasks/](../backend/worker/tasks/)) to ensure quick backend API startup.
 - **Pluggable ASR Engines**: The ASR Transcribe step dispatches to a pluggable engine under [backend/processing/engines/](../backend/processing/engines/), determined by the `transcription_backend` configuration key. Pluggable engines (e.g. Whisper, or onnx-asr engines like Parakeet and Canary) share the `OnnxAsrEngine` base class. Note that Parakeet offers faster transcription on compatible NVIDIA systems but trades off accuracy and language coverage compared to Whisper.
-- **Diarization manifests**: `RecordingAudioWindowManifest.status` is a legacy compatibility projection. Use `asr_status` for live/catch-up ASR coverage and `diarization_status`, `diarization_config_hash`, and `diarization_window_result_id` for rolling or catch-up speaker-window coverage. Never treat legacy `live_processed` as diarization-complete.
-- **Phantom Speaker Filter**: The post-diarization stage [backend/processing/phantom_filter.py](../backend/processing/phantom_filter.py) filters and reassigns speech segments caused by non-speech notification sounds or background noise. It uses heuristic duration/segment count checks followed by embedding-based validation. Constant thresholds (`PHANTOM_MAX_DURATION_S`, `PHANTOM_MAX_SEGMENTS`, `PHANTOM_EMBEDDING_FLOOR`, and `PHANTOM_MERGE_THRESHOLD`) are defined in that file.
+- **Diarisation manifests**: `RecordingAudioWindowManifest.status` is a legacy compatibility projection. Use `asr_status` for live/catch-up ASR coverage and `diarization_status`, `diarization_config_hash`, and `diarization_window_result_id` for rolling or catch-up speaker-window coverage. Never treat legacy `live_processed` as diarisation-complete.
+- **Phantom Speaker Filter**: The post-diarisation stage [backend/processing/phantom_filter.py](../backend/processing/phantom_filter.py) filters and reassigns speech segments caused by non-speech notification sounds or background noise. It uses heuristic duration/segment count checks followed by embedding-based validation. Constant thresholds (`PHANTOM_MAX_DURATION_S`, `PHANTOM_MAX_SEGMENTS`, `PHANTOM_EMBEDDING_FLOOR`, and `PHANTOM_MERGE_THRESHOLD`) are defined in that file.
 - **Speaker Identification Constants**: All speaker matching thresholds are centralized in [backend/processing/embedding.py](../backend/processing/embedding.py). Do not hardcode threshold values elsewhere; import and reference the named constants (such as `IDENTIFICATION_THRESHOLD`, `AUTO_UPDATE_THRESHOLD`, `MARGIN_OF_VICTORY`, `DRIFT_GUARD_THRESHOLD`, `SCAN_MATCH_THRESHOLD`, `UI_SHOW_MATCH_THRESHOLD`, and `UI_STRONG_MATCH_THRESHOLD`).
 - **PyTorch 2.6+ safe globals**: PyTorch 2.6+ defaults to `weights_only=True` in `torch.load` for security, blocking loading of custom classes (like `pyannote.audio.core.task.Specifications` and `torch.torch_version.TorchVersion`) from model checkpoints. These classes must be explicitly registered prior to loading models via `torch.serialization.add_safe_globals([...])` at the module level in `embedding_core.py` and `diarize.py`.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -94,7 +94,7 @@ See [CAPTURE.md](CAPTURE.md) for browser-specific guidance, Linux PipeWire notes
 
 ## 6. Recommended Next Steps
 
-- Read [CAPTURE.md](CAPTURE.md) for browser capture setup, resume/discard behavior, and troubleshooting.
+- Read [CAPTURE.md](CAPTURE.md) for browser capture setup, resume/discard behaviour, and troubleshooting.
 - Read [USAGE.md](USAGE.md) for the dashboard, recordings workspace, notes, search, and speaker workflows.
 - Read [CALENDAR.md](CALENDAR.md) if you want Google or Outlook calendar integration.
 - Read [ADMIN.md](ADMIN.md) if you will manage users, invitations, or system settings.

--- a/docs/LEGAL.md
+++ b/docs/LEGAL.md
@@ -1,12 +1,20 @@
-# LEGAL DISCLAIMER AND TERMS OF USE
+# Legal Disclaimer and Terms of Use
 
-**1. COMPLIANCE WITH LAWS**
+This is the canonical legal disclaimer for Nojoin. The root [LEGAL.md](../LEGAL.md) points here.
+
+## 1. Compliance With Laws
+
 You acknowledge that many legal jurisdictions require the consent of all parties before a conversation can be recorded. It is your sole responsibility to ensure compliance with all applicable laws and regulations regarding audio recording and transcription in your jurisdiction.
 
-**2. DATA PRIVACY & LOCAL PROCESSING**
+## 2. Data Privacy and Local Processing
+
 Nojoin is designed with a privacy-first architecture.
 
 - Nojoin does not store or transmit audio data to third parties without your explicit consent.
-- All audio processing (transcription, diarization, etc.) is performed locally on your machine or your self-hosted server, unless you explicitly configure an external provider.
+- All audio processing (transcription, diarisation, and similar) is performed locally on your machine or your self-hosted server, unless you explicitly configure an external provider.
+
+## 3. Liability
+
+By using Nojoin, you acknowledge that you will use this software in a lawful manner. The developers of Nojoin assume no liability for any unlawful use of this application.
 
 By proceeding, you agree to these terms and accept full responsibility for the lawful use of this software.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Use the links below by task rather than treating the root README as the source o
 ## Start Here
 
 - [GETTING_STARTED.md](GETTING_STARTED.md): First deployment, first admin account, and the shortest path to your first recording.
-- [CAPTURE.md](CAPTURE.md): Browser capture setup, supported browsers, sharing audio, pause/resume behavior, and capture troubleshooting.
+- [CAPTURE.md](CAPTURE.md): Browser capture setup, supported browsers, sharing audio, pause/resume behaviour, and capture troubleshooting.
 - [DEPLOYMENT.md](DEPLOYMENT.md): Hosting, Docker, environment variables, reverse proxy, and updating.
 - [USAGE.md](USAGE.md): Day-to-day product usage for normal users.
 - [DEVELOPMENT.md](DEVELOPMENT.md): Local development prerequisites and main source-build commands.

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,21 +1,41 @@
-<img width="2560" height="1237" alt="recording-light" src="https://github.com/user-attachments/assets/2cce6497-ca27-4c30-853d-1c2d1cc4fc9e" />
+# Screenshots
 
----
+A visual tour of the Nojoin web app. Each view is shown in both the light and dark themes. These captures reflect the current browser-based release; exact layout may shift slightly between versions.
 
-<img width="2560" height="1237" alt="recording-dark" src="https://github.com/user-attachments/assets/f3aa3114-5964-42d5-8d7f-1469ad6c57fa" />
+For the workflows behind these screens, see the [User Guide](USAGE.md). For first deployment, see [Getting Started](GETTING_STARTED.md).
 
----
+## Recordings Dashboard
 
-<img width="2560" height="1237" alt="transcript-light" src="https://github.com/user-attachments/assets/7bb2de17-fdb5-4271-a4aa-503d6e585875" />
+The main workspace lists your recordings with status, calendar context, and quick actions. This is where you start a browser recording, import audio, and open a recording for review.
 
----
+### Light theme
 
-<img width="2560" height="1237" alt="transcript-dark" src="https://github.com/user-attachments/assets/9cc9e70d-7361-4f76-b2ed-3827e44561b7" />
+<img width="2560" height="1237" alt="Recordings dashboard in light theme" src="https://github.com/user-attachments/assets/2cce6497-ca27-4c30-853d-1c2d1cc4fc9e" />
 
----
+### Dark theme
 
-<img width="2560" height="1237" alt="notes-dark" src="https://github.com/user-attachments/assets/e7221fcb-c041-4ee2-8f2e-697d9c5bb3d6" />
+<img width="2560" height="1237" alt="Recordings dashboard in dark theme" src="https://github.com/user-attachments/assets/f3aa3114-5964-42d5-8d7f-1469ad6c57fa" />
 
----
+## Transcript View
 
-<img width="2560" height="1237" alt="notes-light" src="https://github.com/user-attachments/assets/edb13090-13af-47d2-a3c9-c54d00b29ec4" />
+The transcript view shows the diarised, speaker-attributed transcript alongside playback. Speakers can be renamed and matched against the global speaker library.
+
+### Light theme
+
+<img width="2560" height="1237" alt="Transcript view in light theme" src="https://github.com/user-attachments/assets/7bb2de17-fdb5-4271-a4aa-503d6e585875" />
+
+### Dark theme
+
+<img width="2560" height="1237" alt="Transcript view in dark theme" src="https://github.com/user-attachments/assets/9cc9e70d-7361-4f76-b2ed-3827e44561b7" />
+
+## Meeting Notes
+
+AI-generated meeting notes are produced from the transcript and can be regenerated, edited, and used as grounding for Meeting Chat.
+
+### Dark theme
+
+<img width="2560" height="1237" alt="Meeting notes in dark theme" src="https://github.com/user-attachments/assets/e7221fcb-c041-4ee2-8f2e-697d9c5bb3d6" />
+
+### Light theme
+
+<img width="2560" height="1237" alt="Meeting notes in light theme" src="https://github.com/user-attachments/assets/edb13090-13af-47d2-a3c9-c54d00b29ec4" />

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,7 +4,7 @@ The Nojoin team and community take all security vulnerabilities seriously. Thank
 
 ## Active Development
 
-Nojoin is still in active development and all releases should be considered pre-release. There may be security vulnerabilities in the application. Nojoin's maintainers are not responsible for any data loss or security breaches that may occur as a result of using the application. We also advise users to take additional security measures in general but especially when deploying Nojoin over a publically accessible URL. For example, we recommend using a VPN or a reverse proxy to secure your Nojoin instance.
+Nojoin is still in active development and all releases should be considered pre-release. There may be security vulnerabilities in the application. Nojoin's maintainers are not responsible for any data loss or security breaches that may occur as a result of using the application. We also advise users to take additional security measures in general but especially when deploying Nojoin over a publicly accessible URL. For example, we recommend using a VPN or a reverse proxy to secure your Nojoin instance.
 
 ## First-Run Bootstrap Protection
 
@@ -93,7 +93,7 @@ We use GitHub's Private Vulnerability Reporting feature to receive security disc
 
 ### Expected Workflow
 
-1. **Acknowledgment:** You will receive an initial response confirming receipt of your report within 48 hours.
+1. **Acknowledgement:** You will receive an initial response confirming receipt of your report within 48 hours.
 2. **Evaluation:** The maintainers will investigate the report and determine the severity and scope of the vulnerability.
 3. **Remediation:** If the vulnerability is confirmed, we will work on a patch. A security advisory will be drafted, and a fix will be released.
 4. **Disclosure:** Once a patch is available and deployed, we will coordinate public disclosure through a GitHub Security Advisory.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -76,7 +76,7 @@ Use it to manage your shared speaker library:
 
 - Review people records and stored voiceprints in one place.
 - Search and filter the library when you need to find a known speaker quickly.
-- Organize people with reusable people tags.
+- Organise people with reusable people tags.
 - Open batch editing and cleanup flows for broader speaker-library maintenance.
 
 ## Live Recording
@@ -103,7 +103,7 @@ On mobile and narrow tablet layouts, Nojoin uses compact navigation with a menu 
 
 You can switch to another browser tab, window, or application while recording. Nojoin only pauses automatically when the Nojoin tab is refreshed, closed, or navigated away from the active recording.
 
-While a recording is active, a floating badge appears at the top-center of the viewport on every page. The badge shows the recording status, elapsed time, and pause, resume, and stop controls. Clicking the badge navigates to the recording detail page. You can control the recording from any page without navigating back to the recording workspace first.
+While a recording is active, a floating badge appears at the top-centre of the viewport on every page. The badge shows the recording status, elapsed time, and pause, resume, and stop controls. Clicking the badge navigates to the recording detail page. You can control the recording from any page without navigating back to the recording workspace first.
 
 ### Pause, Resume, Stop, And Cancel
 
@@ -202,7 +202,7 @@ Settings are grouped by task.
 - **Capture**: microphone selection, shared-audio gain, microphone gain, browser audio-processing toggles, and a local mic input test for browser recording.
 - **AI**: provider configuration, model choices, automatic meeting intelligence, Meeting Edge model selection, and secondary LLM provider fallback.
 - **Transcription**: transcription backend and model choices.
-- **Calendar**: user calendar connections and timezone behavior.
+- **Calendar**: user calendar connections and timezone behaviour.
 - **Help**: tours and support surfaces.
 - **Admin**: user, system, provider, release, and maintenance settings for administrators.
 

--- a/docs/repo-maintenance.md
+++ b/docs/repo-maintenance.md
@@ -147,29 +147,29 @@ Large refactors must preserve behavior and begin with characterization tests.
 - [x] **DOC-001:** Publish this maintenance tracker and link it from the documentation index.
 - [x] **DOC-002:** Replace every machine-local `file:///home/...` documentation link with a repository-relative link.
 - [x] **DOC-003:** Add automated local-link checking for `README.md`, `CONTRIBUTING.md`, and `docs/*.md`.
-- [ ] **DOC-004:** Consolidate the root and `docs/` legal disclaimers into one canonical policy and update all links.
-- [ ] **DOC-005:** Correct spelling, grammar, punctuation, capitalization, and British/American terminology inconsistencies across public documentation. British English spelling and conventions takes priority and precedence.
-- [ ] **DOC-006:** Replace stale historical implementation notes in operator documentation with current behavior plus versioned migration notes where still required.
-- [ ] **DOC-007:** Add headings, captions, and context to the screenshots guide.
-- [ ] **DOC-008:** Host critical logos and documentation images in repository-controlled assets where practical.
-- [ ] **DOC-009:** Add a documentation ownership and review rule requiring behavior, setup, deployment, and support changes to update the relevant guide in the same pull request.
+- [x] **DOC-004:** Consolidate the root and `docs/` legal disclaimers into one canonical policy and update all links.
+- [x] **DOC-005:** Correct spelling, grammar, punctuation, capitalization, and British/American terminology inconsistencies across public documentation. British English spelling and conventions takes priority and precedence.
+- [x] **DOC-006:** Replace stale historical implementation notes in operator documentation with current behavior plus versioned migration notes where still required.
+- [x] **DOC-007:** Add headings, captions, and context to the screenshots guide.
+- [x] **DOC-008:** Host critical logos and documentation images in repository-controlled assets where practical.
+- [x] **DOC-009:** Add a documentation ownership and review rule requiring behavior, setup, deployment, and support changes to update the relevant guide in the same pull request.
 
 ### Contributor Onboarding
 
 - [x] **DOC-010:** Expand `CONTRIBUTING.md` with prerequisites, environment setup, test commands, lint commands, commit expectations, and pull-request verification requirements.
-- [ ] **DOC-011:** Add a short contributor path that does not require building every GPU/ML dependency for frontend-only or documentation-only changes.
+- [x] **DOC-011:** Add a short contributor path that does not require building every GPU/ML dependency for frontend-only or documentation-only changes.
 - [x] **DOC-012:** Document which checks are mandatory by change scope: backend, worker, frontend, capture, migration, documentation, and deployment.
 - [x] **DOC-013:** Add guidance for database migrations, security-sensitive changes, browser-capture manual testing, and recording context-menu duplication.
-- [ ] **DOC-014:** Document how contributors can report flaky tests, platform-specific failures, and dependency issues.
+- [x] **DOC-014:** Document how contributors can report flaky tests, platform-specific failures, and dependency issues.
 
 ### Community Files
 
-- [ ] **COMM-001:** Add an explicit private reporting contact or process to the Code of Conduct enforcement section.
-- [ ] **COMM-002:** Update the platform issue template to match the current Windows, Linux, macOS, Android, and iOS support boundaries.
-- [ ] **COMM-003:** Improve the bug template with Nojoin version, deployment mode, browser, capture mode, logs, reproduction data, and privacy-redaction guidance.
-- [ ] **COMM-004:** Improve the pull-request template with backend tests, frontend lint/test/build, migration impact, documentation impact, security impact, and manual verification.
-- [ ] **COMM-005:** Add issue-template configuration that directs security reports to private vulnerability reporting and support questions to the intended support channel.
-- [ ] **COMM-006:** Define maintainer response, triage, and supported-version expectations that can realistically be met.
+- [x] **COMM-001:** Add an explicit private reporting contact or process to the Code of Conduct enforcement section.
+- [x] **COMM-002:** Update the platform issue template to match the current Windows, Linux, macOS, Android, and iOS support boundaries.
+- [x] **COMM-003:** Improve the bug template with Nojoin version, deployment mode, browser, capture mode, logs, reproduction data, and privacy-redaction guidance.
+- [x] **COMM-004:** Improve the pull-request template with backend tests, frontend lint/test/build, migration impact, documentation impact, security impact, and manual verification.
+- [x] **COMM-005:** Add issue-template configuration that directs security reports to private vulnerability reporting and support questions to the intended support channel.
+- [x] **COMM-006:** Define maintainer response, triage, and supported-version expectations that can realistically be met.
 
 ## Phase 5: Harden Release And Supply-Chain Governance
 


### PR DESCRIPTION
## Description

Completes **Phase 4 (Improve Documentation and Contributor Experience)** of `docs/repo-maintenance.md`. Documentation and community-files only — no backend, frontend, or migration source changed.

**Documentation integrity**
- **DOC-004:** Consolidated the disclaimer into one canonical `docs/LEGAL.md` (merged the liability clause from the root file); reduced root `LEGAL.md` to a pointer.
- **DOC-005:** British-English sweep across public docs (`behaviour`, `organise`, `apologising`, `Acknowledgement`, `top-centre`, `synchronised`, `canonicalised`, `publicly`, prose `diarisation`). Preserved code-aligned terms (`finalize` API operation, the `Authorization` header, `diarization_*` identifiers).
- **DOC-006:** Reframed the desktop-helper / pipeline-cutover notes in `docs/DEPLOYMENT.md` as clearly one-time, version-anchored migration notes instead of relative-time phrasing.
- **DOC-007:** Rewrote `docs/SCREENSHOTS.md` with title, intro, per-view headings, theme sub-headings, descriptive alt text, and cross-links.
- **DOC-008:** Repointed the README logo from the third-party `iili.io` host to the existing repo asset `assets/images/nojoin-mark.svg`.
- **DOC-009:** Added a "Documentation Ownership" rule to `CONTRIBUTING.md`.

**Contributor onboarding**
- **DOC-011:** Added lightweight docs-only / frontend-only / CPU-only-backend contributor paths.
- **DOC-014:** Added a "Reporting Issues" section covering bugs, platform failures, flaky tests, and dependency issues.

**Community files**
- **COMM-001:** CoC enforcement now routes conduct reports through GitHub's private report form.
- **COMM-002/003/004:** Rewrote the platform and bug issue templates and the PR template.
- **COMM-005:** Added `.github/ISSUE_TEMPLATE/config.yml` routing security, support, and docs.
- **COMM-006:** Added `.github/SUPPORT.md` with realistic response/triage/supported-version expectations.

All Phase 4 items are now checked off in `docs/repo-maintenance.md`.

## Type of change

- [x] Documentation update

## Checks run

Only docs/community Markdown and one YAML file changed; no code under `backend/`, `frontend/`, or `backend/alembic/versions/`.

- [x] Docs validation: `python3 scripts/validate_docs.py` — passed (20 files)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — passed (head unchanged: `b91f9c2d4e6a`)
- [x] Whitespace/conflict-marker check: `git diff --check` — clean
- [ ] Backend tests — not applicable (no backend source changed)
- [ ] Python quality (`scripts/check.py`) — not applicable (no Python source changed)
- [ ] Frontend lint/test/build — not applicable (no `frontend/src` changed; README logo path edit only)

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guides in the same PR. This PR is itself the documentation work.

## Security impact

- [x] No security-sensitive code change. Added a CoC private-reporting channel and an issue-template config that routes vulnerability reports to GitHub Private Vulnerability Reporting; `docs/SECURITY.md` boundaries unchanged.

## Manual verification

No capture, auth/session, recording context-menu, or migration code changed, so no manual browser smoke testing is required. Verified `gh`-side that `assets/images/nojoin-mark.svg` exists and that all added local doc links resolve.

Note: `.github/ISSUE_TEMPLATE/config.yml` sets `blank_issues_enabled: false`, so new issues are funnelled through the templates plus the contact links.
