### PR TITLE
chore(release): Phase 5 — harden release and supply-chain governance (REL-006…REL-015)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+# Dependabot keeps Nojoin's supply chain current without manual tracking.
+#
+# Notes:
+# - GitHub Actions are pinned to commit SHAs in the workflows. Dependabot
+#   updates those SHAs in place and keeps the trailing `# vX.Y.Z` comment
+#   accurate, so SHA pinning does not mean the actions go stale.
+# - Docker base images are pinned by digest in the Dockerfiles. Dependabot
+#   bumps the digest (and tag comment) when a new image is published.
+# - Updates are grouped where practical to keep pull-request volume reviewable.
+version: 2
+
+updates:
+  # --- GitHub Actions used by CI and the release workflow ---
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # --- Python dependencies (split requirement files) ---
+  - package-ecosystem: pip
+    directory: /requirements
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  # --- Frontend npm dependencies ---
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+    groups:
+      npm-development:
+        dependency-type: development
+      npm-production:
+        dependency-type: production
+
+  # --- Container base images ---
+  - package-ecosystem: docker
+    directories:
+      - /docker
+      - /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"

--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -1,0 +1,39 @@
+## Nojoin {{VERSION}}
+
+Container images for this release. All images are cosign-signed and ship build-provenance and SBOM attestations; verification steps are in the [deployment guide](https://github.com/Valtora/Nojoin/blob/main/docs/DEPLOYMENT.md#verifying-an-image-before-deploying). Pin to a digest for reproducible deployments.
+
+{{IMAGE_DIGESTS}}
+
+### Upgrade
+
+Pull the new images and recreate the stack:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### Migration
+
+Database migrations run automatically on the first API start after upgrading. Back up your instance before upgrading.
+
+<!-- Maintainer: note any blocking first-boot migration, longer startup, or manual step. -->
+
+### Rollback
+
+<!-- Maintainer: state whether rollback is code-only or requires data steps. Default below. -->
+Rollback is code-only unless a migration note above says otherwise: redeploy the previous image tags.
+
+### Known Issues
+
+<!-- Maintainer: list known issues affecting this release, or leave the default. -->
+None known at release time.
+
+### Browser-Capture Compatibility
+
+<!-- Maintainer: note any change to supported browsers/OSes or capture behaviour. Default below. -->
+No changes to browser-capture support in this release unless noted above.
+
+### Changes
+
+{{CHANGELOG}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,25 @@ jobs:
 
       - name: Validate checked-in Alembic graph
         run: python scripts/validate_alembic.py
+
+  dependency-scan:
+    name: Dependency vulnerability scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      # Informational on pull requests: surfaces dependency and config CVEs in
+      # the repository without blocking merges. The release pipeline enforces
+      # the blocking image scan and severity policy (REL-008).
+      - name: Scan repository dependencies and config
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"
+          trivyignores: .trivyignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -76,10 +76,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: npm
@@ -99,10 +99,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: npm
@@ -122,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: npm
@@ -145,10 +145,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -161,10 +161,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     name: Validate release ref
     runs-on: ubuntu-latest
     outputs:
+      image_base: ${{ steps.release.outputs.image_base }}
       major_minor: ${{ steps.release.outputs.major_minor }}
       publish_latest: ${{ steps.release.outputs.publish_latest }}
       release_ref: ${{ steps.release.outputs.release_ref }}
@@ -77,11 +78,16 @@ jobs:
             exit 1
           fi
 
+          # Container repositories must be lowercase; github.repository can be
+          # mixed case, so derive a lowercase image base for every direct ref.
+          image_base="$(printf '%s/%s' "${REGISTRY}" "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+
           echo "tag_name=${tag_name}" >> "${GITHUB_OUTPUT}"
           echo "release_ref=${release_ref}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "major_minor=${version%.*}" >> "${GITHUB_OUTPUT}"
           echo "publish_latest=${publish_latest}" >> "${GITHUB_OUTPUT}"
+          echo "image_base=${image_base}" >> "${GITHUB_OUTPUT}"
 
   backend-tests:
     name: Backend tests
@@ -294,7 +300,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+          images: ${{ needs.validate-release-ref.outputs.image_base }}${{ matrix.image_suffix }}
           tags: |
             type=raw,value=${{ needs.validate-release-ref.outputs.version }}
             type=sha
@@ -332,7 +338,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@${{ steps.build.outputs.digest }}
+          image-ref: ${{ needs.validate-release-ref.outputs.image_base }}${{ matrix.image_suffix }}@${{ steps.build.outputs.digest }}
           format: table
           severity: CRITICAL,HIGH
           ignore-unfixed: true
@@ -341,7 +347,7 @@ jobs:
 
       - name: Sign image with cosign (keyless)
         env:
-          IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@${{ steps.build.outputs.digest }}
+          IMAGE_DIGEST: ${{ needs.validate-release-ref.outputs.image_base }}${{ matrix.image_suffix }}@${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
           # Keyless signing binds the signature to this workflow's OIDC identity;
@@ -374,11 +380,10 @@ jobs:
 
       - name: Prepare smoke-test environment
         env:
+          IMAGE_BASE: ${{ needs.validate-release-ref.outputs.image_base }}
           VERSION: ${{ needs.validate-release-ref.outputs.version }}
         run: |
           set -euo pipefail
-          image_base="$(printf '%s/%s' "${REGISTRY}" "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
-          echo "IMAGE_BASE=${image_base}" >> "${GITHUB_ENV}"
 
           # Minimal .env: FIRST_RUN_PASSWORD is required by the compose file; the
           # encryption key is generated fresh. All other secrets fall back to the
@@ -393,9 +398,9 @@ jobs:
           cat > docker-compose.ci.yml <<EOF
           services:
             api:
-              image: ${image_base}-api:${VERSION}
+              image: ${IMAGE_BASE}-api:${VERSION}
             frontend:
-              image: ${image_base}-frontend:${VERSION}
+              image: ${IMAGE_BASE}-frontend:${VERSION}
           EOF
 
       - name: Start backend stack (db, redis, socket-proxy, api)
@@ -436,6 +441,7 @@ jobs:
 
       - name: Assert containers run as non-root
         env:
+          IMAGE_BASE: ${{ needs.validate-release-ref.outputs.image_base }}
           VERSION: ${{ needs.validate-release-ref.outputs.version }}
         run: |
           set -euo pipefail
@@ -501,7 +507,7 @@ jobs:
       # these tags inherit the existing signature without re-signing.
       - name: Promote rolling tags from verified image
         env:
-          IMAGE_BASE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+          IMAGE_BASE: ${{ needs.validate-release-ref.outputs.image_base }}${{ matrix.image_suffix }}
           VERSION: ${{ needs.validate-release-ref.outputs.version }}
           MAJOR_MINOR: ${{ needs.validate-release-ref.outputs.major_minor }}
           PUBLISH_LATEST: ${{ needs.validate-release-ref.outputs.publish_latest }}
@@ -512,3 +518,83 @@ jobs:
             tags+=( "--tag" "${IMAGE_BASE}:latest" )
           fi
           docker buildx imagetools create "${tags[@]}" "${IMAGE_BASE}:${VERSION}"
+
+  publish-release-notes:
+    name: Publish release notes
+    needs:
+      - validate-release-ref
+      - publish-mutable-tags
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # Full history is required to compute the previous-tag..this-tag range.
+          fetch-depth: 0
+          ref: ${{ needs.validate-release-ref.outputs.release_ref }}
+
+      - name: Render release notes
+        id: notes
+        env:
+          IMAGE_BASE: ${{ needs.validate-release-ref.outputs.image_base }}
+          TAG: ${{ needs.validate-release-ref.outputs.tag_name }}
+          VERSION: ${{ needs.validate-release-ref.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Resolve the previous release tag reachable from this tag. The range is
+          # exactly previous-tag..this-tag (REL-013); fall back to full history
+          # for the very first release.
+          if prev_tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' "${TAG}^" 2>/dev/null)"; then
+            range="${prev_tag}..${TAG}"
+            echo "Changelog range: ${range}"
+          else
+            range="${TAG}"
+            echo "No previous tag found; using full history."
+          fi
+
+          git log --no-merges --pretty=format:'- %s (%h)' "${range}" > changelog.txt
+          if [[ ! -s changelog.txt ]]; then
+            echo "- No notable changes." > changelog.txt
+          fi
+
+          # Resolve the published image digests for reproducible-pin guidance.
+          : > image-digests.txt
+          for suffix in -api -worker -frontend; do
+            digest="$(docker buildx imagetools inspect "${IMAGE_BASE}${suffix}:${VERSION}" \
+              --format '{{ .Manifest.Digest }}' 2>/dev/null || echo unknown)"
+            printf -- '- `%s%s@%s`\n' "${IMAGE_BASE}" "${suffix}" "${digest}" >> image-digests.txt
+          done
+
+          python3 - <<'PY'
+          import os
+
+          version = os.environ["VERSION"]
+          template = open(".github/release-notes-template.md", encoding="utf-8").read()
+          changelog = open("changelog.txt", encoding="utf-8").read().strip()
+          digests = open("image-digests.txt", encoding="utf-8").read().strip()
+
+          body = (
+              template
+              .replace("{{VERSION}}", version)
+              .replace("{{IMAGE_DIGESTS}}", digests)
+              .replace("{{CHANGELOG}}", changelog)
+          )
+          with open("release-notes.md", "w", encoding="utf-8") as handle:
+              handle.write(body)
+          PY
+
+          echo "Rendered release notes:"
+          cat release-notes.md
+
+      - name: Create or update GitHub Release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          tag_name: ${{ needs.validate-release-ref.outputs.tag_name }}
+          name: Nojoin ${{ needs.validate-release-ref.outputs.version }}
+          body_path: release-notes.md
+          make_latest: ${{ needs.validate-release-ref.outputs.publish_latest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,11 +349,127 @@ jobs:
           # tag that resolves to this image (REL-009).
           cosign sign --yes "${IMAGE_DIGEST}"
 
+  health-smoke:
+    name: Image health & non-root smoke
+    needs:
+      - validate-release-ref
+      - server-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ needs.validate-release-ref.outputs.release_ref }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Prepare smoke-test environment
+        env:
+          VERSION: ${{ needs.validate-release-ref.outputs.version }}
+        run: |
+          set -euo pipefail
+          image_base="$(printf '%s/%s' "${REGISTRY}" "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          echo "IMAGE_BASE=${image_base}" >> "${GITHUB_ENV}"
+
+          # Minimal .env: FIRST_RUN_PASSWORD is required by the compose file; the
+          # encryption key is generated fresh. All other secrets fall back to the
+          # tracked example defaults, which match between services.
+          data_encryption_key="$(python3 -c 'import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())')"
+          cat > .env <<EOF
+          FIRST_RUN_PASSWORD=ci-smoke-first-run
+          DATA_ENCRYPTION_KEY=${data_encryption_key}
+          EOF
+
+          # Pin the api and frontend services to the freshly built version images.
+          cat > docker-compose.ci.yml <<EOF
+          services:
+            api:
+              image: ${image_base}-api:${VERSION}
+            frontend:
+              image: ${image_base}-frontend:${VERSION}
+          EOF
+
+      - name: Start backend stack (db, redis, socket-proxy, api)
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.example.yml -f docker-compose.ci.yml \
+            up -d db redis socket-proxy api
+
+      - name: Wait for API health
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            status="$(docker inspect --format '{{ .State.Health.Status }}' nojoin-api 2>/dev/null || echo starting)"
+            echo "api health: ${status} (attempt ${i})"
+            if [[ "${status}" == "healthy" ]]; then exit 0; fi
+            if [[ "${status}" == "unhealthy" ]]; then break; fi
+            sleep 10
+          done
+          echo "API did not become healthy in time" >&2
+          docker logs nojoin-api --tail 200 || true
+          exit 1
+
+      - name: Start frontend and wait for health
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.example.yml -f docker-compose.ci.yml \
+            up -d frontend
+          for i in $(seq 1 18); do
+            status="$(docker inspect --format '{{ .State.Health.Status }}' nojoin-frontend 2>/dev/null || echo starting)"
+            echo "frontend health: ${status} (attempt ${i})"
+            if [[ "${status}" == "healthy" ]]; then exit 0; fi
+            if [[ "${status}" == "unhealthy" ]]; then break; fi
+            sleep 10
+          done
+          echo "Frontend did not become healthy in time" >&2
+          docker logs nojoin-frontend --tail 200 || true
+          exit 1
+
+      - name: Assert containers run as non-root
+        env:
+          VERSION: ${{ needs.validate-release-ref.outputs.version }}
+        run: |
+          set -euo pipefail
+          # api and frontend are running: check the live runtime uid.
+          for c in nojoin-api nojoin-frontend; do
+            uid="$(docker exec "${c}" id -u)"
+            echo "${c} runtime uid: ${uid}"
+            if [[ "${uid}" -eq 0 ]]; then
+              echo "${c} is running as root" >&2
+              exit 1
+            fi
+          done
+          # The worker needs a GPU and models to boot, so assert its non-root
+          # USER from the published image config without pulling the large layers.
+          worker_user="$(docker buildx imagetools inspect \
+            --format '{{ (index .Image "linux/amd64").Config.User }}' \
+            "${IMAGE_BASE}-worker:${VERSION}")"
+          echo "worker image USER: ${worker_user:-<empty>}"
+          if [[ -z "${worker_user}" || "${worker_user}" == "root" || "${worker_user}" == "0" ]]; then
+            echo "worker image does not declare a non-root USER" >&2
+            exit 1
+          fi
+
+      - name: Tear down stack
+        if: always()
+        run: |
+          docker compose -f docker-compose.example.yml -f docker-compose.ci.yml down -v || true
+
   publish-mutable-tags:
     name: Publish rolling tags
     needs:
       - validate-release-ref
       - server-release
+      - health-smoke
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,24 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      # First-party severity gate (REL-008): fail the release on CRITICAL/HIGH
+      # vulnerabilities that have a fix available. ignore-unfixed keeps the
+      # CVE-heavy CUDA/PyTorch worker base releasable, because findings with no
+      # upstream fix cannot be actioned by us; documented exceptions for fixed
+      # findings we are temporarily accepting live in .trivyignore.
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@${{ steps.build.outputs.digest }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+
       - name: Sign image with cosign (keyless)
         env:
           IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@${{ steps.build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,9 +456,14 @@ jobs:
           done
           # The worker needs a GPU and models to boot, so assert its non-root
           # USER from the published image config without pulling the large layers.
-          worker_user="$(docker buildx imagetools inspect \
-            --format '{{ (index .Image "linux/amd64").Config.User }}' \
-            "${IMAGE_BASE}-worker:${VERSION}")"
+          # The published artifact is an OCI index (provenance + SBOM
+          # attestations), so `{{json .Image}}` is a platform-keyed map; the jq
+          # also handles a single-image config object so a shape change cannot
+          # turn this into a template error that aborts the release.
+          worker_image="$(docker buildx imagetools inspect \
+            "${IMAGE_BASE}-worker:${VERSION}" --format '{{json .Image}}')"
+          worker_user="$(printf '%s' "${worker_image}" | jq -r \
+            '(if has("config") then .config.User else (first(to_entries[] | select(.key|startswith("linux/")) | .value.config.User)) end) // empty')"
           echo "worker image USER: ${worker_user:-<empty>}"
           if [[ -z "${worker_user}" || "${worker_user}" == "root" || "${worker_user}" == "0" ]]; then
             echo "worker image does not declare a non-root USER" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
@@ -90,12 +90,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -116,12 +116,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: npm
@@ -142,12 +142,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: npm
@@ -168,12 +168,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: npm
@@ -194,12 +194,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -213,12 +213,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -257,7 +257,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: true
           android: true
@@ -267,12 +267,12 @@ jobs:
           swap-storage: true
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -280,7 +280,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
           tags: |
@@ -290,10 +290,10 @@ jobs:
             type=sha
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
         run: python scripts/validate_alembic.py
 
   server-release:
-    name: Build & Push Docker Images
+    name: Build, scan & sign images
     needs:
       - validate-release-ref
       - backend-tests
@@ -236,6 +236,12 @@ jobs:
       - docs-validation
       - alembic-validation
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      # Required for cosign keyless signing via the GitHub OIDC token.
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -278,21 +284,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Only immutable tags (exact version and commit SHA) are published here.
+      # The rolling latest/major.minor tags are published by publish-mutable-tags
+      # after scanning, the health smoke, and signing all pass.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
           tags: |
-            type=raw,value=latest,enable=${{ needs.validate-release-ref.outputs.publish_latest == 'true' }}
             type=raw,value=${{ needs.validate-release-ref.outputs.version }}
-            type=raw,value=${{ needs.validate-release-ref.outputs.major_minor }}
             type=sha
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ matrix.context }}
@@ -305,3 +316,65 @@ jobs:
             ${{ matrix.service == 'api' && format('NOJOIN_SERVER_VERSION={0}', needs.validate-release-ref.outputs.version) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Attach a signed build-provenance attestation and an SBOM to each
+          # published image so consumers can audit how it was built (REL-007).
+          provenance: mode=max
+          sbom: true
+
+      - name: Sign image with cosign (keyless)
+        env:
+          IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          # Keyless signing binds the signature to this workflow's OIDC identity;
+          # no long-lived private key is stored. Signing by digest covers every
+          # tag that resolves to this image (REL-009).
+          cosign sign --yes "${IMAGE_DIGEST}"
+
+  publish-mutable-tags:
+    name: Publish rolling tags
+    needs:
+      - validate-release-ref
+      - server-release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image_suffix:
+          - -api
+          - -worker
+          - -frontend
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Promote the verified immutable image to the rolling tags. major.minor
+      # always advances on a successful release; latest only advances when the
+      # release flow authorised it. cosign signatures attach to the digest, so
+      # these tags inherit the existing signature without re-signing.
+      - name: Promote rolling tags from verified image
+        env:
+          IMAGE_BASE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+          VERSION: ${{ needs.validate-release-ref.outputs.version }}
+          MAJOR_MINOR: ${{ needs.validate-release-ref.outputs.major_minor }}
+          PUBLISH_LATEST: ${{ needs.validate-release-ref.outputs.publish_latest }}
+        run: |
+          set -euo pipefail
+          tags=( "--tag" "${IMAGE_BASE}:${MAJOR_MINOR}" )
+          if [[ "${PUBLISH_LATEST}" == "true" ]]; then
+            tags+=( "--tag" "${IMAGE_BASE}:latest" )
+          fi
+          docker buildx imagetools create "${tags[@]}" "${IMAGE_BASE}:${VERSION}"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,19 @@
+# Trivy ignore file — documented vulnerability exceptions.
+#
+# Severity policy (see docs/SECURITY.md "Vulnerability Scanning and Severity Policy"):
+#   - The release pipeline fails on CRITICAL/HIGH findings that have a fix
+#     available (`ignore-unfixed: true`), scanning each image before its rolling
+#     tags are published.
+#   - Findings without an upstream fix are not actioned by us and do not block
+#     the release; this is unavoidable for the CUDA/PyTorch worker base image.
+#   - A *fixed* CRITICAL/HIGH finding may be temporarily accepted only by adding
+#     it below with the CVE id, the reason, the owner, and a review-by date.
+#     Remove the entry once the fix is pulled in (usually via a base-image or
+#     dependency bump from Dependabot).
+#
+# Format: one CVE id per line, with a justification comment above it.
+#
+# Example (do not leave stale entries here):
+# # CVE-XXXX-NNNNN: base-image-only, fix lands in next pytorch base bump.
+# #   Owner: maintainers. Review by: YYYY-MM-DD.
+# CVE-XXXX-NNNNN

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,5 +1,6 @@
 # --- Builder Stage ---
-FROM python:3.12-slim AS builder
+# Pinned by digest for reproducible builds; Dependabot keeps the tag comment current.
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -22,7 +23,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements/backend.txt
 
 # --- Runtime Stage ---
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,5 +1,6 @@
 # --- Builder Stage ---
-FROM pytorch/pytorch:2.11.0-cuda12.6-cudnn9-runtime AS builder
+# Pinned by digest for reproducible builds; Dependabot keeps the tag comment current.
+FROM pytorch/pytorch:2.11.0-cuda12.6-cudnn9-runtime@sha256:3bb77138e105723dd4ed760b82fb63d8310ae3a1afc58f76e0ecf0f776568d33 AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -47,7 +48,7 @@ RUN pip uninstall -y onnxruntime onnxruntime-gpu && \
 RUN pip install --no-cache-dir triton
 
 # --- Runtime Stage ---
-FROM pytorch/pytorch:2.11.0-cuda12.6-cudnn9-runtime AS runtime
+FROM pytorch/pytorch:2.11.0-cuda12.6-cudnn9-runtime@sha256:3bb77138e105723dd4ed760b82fb63d8310ae3a1afc58f76e0ecf0f776568d33 AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -259,6 +259,13 @@ location / {
 }
 ```
 
+## Image Trust and Supply Chain
+
+Published Nojoin images are built by a hardened, gated release pipeline. Operators with stricter assurance requirements can rely on the following properties.
+
+- **Reproducible bases:** Every image is built from base images pinned by immutable `@sha256:` digest, not mutable tags. The exact GitHub Actions used by the release workflow are pinned to commit SHAs.
+- **Update policy:** Pinned actions and base images are kept current automatically by Dependabot on a weekly cadence. Each update passes the full CI gate before it can merge, and a new release must be cut to publish updated images.
+
 ## Upgrading and Migration
 
 - When performing major upgrades, check release notes for breaking changes.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -267,6 +267,7 @@ Published Nojoin images are built by a hardened, gated release pipeline. Operato
 - **Update policy:** Pinned actions and base images are kept current automatically by Dependabot on a weekly cadence. Each update passes the full CI gate before it can merge, and a new release must be cut to publish updated images.
 - **Signed images:** Every published image is signed with [cosign](https://github.com/sigstore/cosign) using keyless (OIDC) signing. The signature is bound to the release workflow's identity rather than a stored key.
 - **Provenance and SBOM:** Every image carries a build-provenance attestation and a Software Bill of Materials (SBOM) attestation describing how it was built and what it contains.
+- **Pre-publication verification:** Before the rolling `latest` and `major.minor` tags are published, the api and frontend images are booted with their real dependencies and must pass their production healthchecks, and all images are asserted to run as a non-root user.
 
 ### Verifying an Image Before Deploying
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -265,6 +265,32 @@ Published Nojoin images are built by a hardened, gated release pipeline. Operato
 
 - **Reproducible bases:** Every image is built from base images pinned by immutable `@sha256:` digest, not mutable tags. The exact GitHub Actions used by the release workflow are pinned to commit SHAs.
 - **Update policy:** Pinned actions and base images are kept current automatically by Dependabot on a weekly cadence. Each update passes the full CI gate before it can merge, and a new release must be cut to publish updated images.
+- **Signed images:** Every published image is signed with [cosign](https://github.com/sigstore/cosign) using keyless (OIDC) signing. The signature is bound to the release workflow's identity rather than a stored key.
+- **Provenance and SBOM:** Every image carries a build-provenance attestation and a Software Bill of Materials (SBOM) attestation describing how it was built and what it contains.
+
+### Verifying an Image Before Deploying
+
+Verify the cosign signature (replace the tag as needed):
+
+```bash
+cosign verify ghcr.io/valtora/nojoin-api:latest \
+  --certificate-identity-regexp "^https://github.com/Valtora/Nojoin/.github/workflows/release.yml@.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Inspect the provenance and SBOM attestations:
+
+```bash
+# Provenance attestation
+cosign verify-attestation --type slsaprovenance ghcr.io/valtora/nojoin-api:latest \
+  --certificate-identity-regexp "^https://github.com/Valtora/Nojoin/.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# SBOM and image index (digests, platforms, attestations)
+docker buildx imagetools inspect ghcr.io/valtora/nojoin-api:latest
+```
+
+Pinning a deployment to an exact image digest (`ghcr.io/valtora/nojoin-api@sha256:...`) rather than a rolling tag guarantees you run the precise image you verified.
 
 ## Upgrading and Migration
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -390,16 +390,34 @@ Use `requirements/local.txt` instead of `dev.txt` for a full GPU host with the l
 ## Release Workflow and Version Detection
 
 ### Unified Release Process
-Nojoin uses a single Git Tag (`vX.Y.Z`) to trigger the API, Worker, and Frontend release builds in lock-step:
-1. **Update Version**: Update [VERSION](VERSION) to the new version string (e.g. `0.6.0`).
-2. **Commit and Tag**: Commit the version file change and create/push the tag:
+
+Nojoin uses a single Git tag (`vX.Y.Z`) to trigger the API, Worker, and Frontend release builds in lock-step. The maintainer steps are unchanged by the supply-chain hardening; what changed is that more happens automatically after the tag is pushed, and the release can now be blocked by a gate.
+
+**Maintainer steps (manual):**
+
+1. **Merge and sync**: Merge the work for the release into `main` and ensure your local `main` is up to date.
+2. **Update version**: Update [VERSION](VERSION) to the new version string (e.g. `0.6.0`). The tag must match this value exactly or the release fails fast.
+3. **Commit and tag**: Commit the version bump, then create and push the tag:
    ```bash
    git add docs/VERSION
    git commit -m "chore: bump version to 0.6.0"
    git tag v0.6.0
    git push origin v0.6.0
    ```
-3. **CI/CD Pipeline**: The push of a strict `vX.Y.Z` tag triggers [.github/workflows/release.yml](../.github/workflows/release.yml). Release publishing now re-runs the backend, frontend, docs, and Alembic validation set before any image push, verifies `docs/VERSION` matches the tag, and only publishes `latest` automatically from the tag-triggered release flow. Manual `workflow_dispatch` runs must target an existing release tag through `release_ref`; they only publish `latest` when `publish_latest=true` is set explicitly. Release notes are generated automatically by the `publish-release-notes` job (see [Automated Release Notes](#automated-release-notes-rel-013-rel-014) below); maintainers refine the editorial sections in the GitHub Releases interface afterward.
+4. **Refine release notes (after the run succeeds)**: The pipeline creates the GitHub Release automatically (see below). Edit its editorial sections — Migration, Rollback, Known Issues, Browser-Capture Compatibility — in the GitHub Releases interface where the release needs specific guidance. You no longer author release notes from scratch.
+
+**What the pipeline does automatically (on tag push):** The push of a strict `vX.Y.Z` tag triggers [.github/workflows/release.yml](../.github/workflows/release.yml), which runs in this order:
+
+1. Re-runs the full backend, frontend, docs, and Alembic validation set and verifies `docs/VERSION` matches the tag.
+2. Builds each image and publishes only the immutable `version` and commit-`sha` tags, with provenance and SBOM attestations.
+3. Scans each image with Trivy and **fails the release on fixable CRITICAL/HIGH vulnerabilities** (see [Image Provenance, SBOM, and Signing](#image-provenance-sbom-and-signing) and the severity policy in [SECURITY.md](SECURITY.md)).
+4. Signs each image with cosign, then runs the non-root and health smoke.
+5. Publishes the rolling `latest` and `major.minor` tags only after all the above pass.
+6. Generates and publishes the GitHub Release notes from the exact previous-tag-to-this-tag range (see [Automated Release Notes](#automated-release-notes-rel-013-rel-014)).
+
+Because of step 3, a tag push no longer guarantees published images: if scanning finds a fixable CRITICAL/HIGH vulnerability the run fails and the rolling tags are not moved. The usual fix is to merge the relevant Dependabot base-image or dependency update (or, for a justified unfixable case, add a documented, dated entry to [.trivyignore](../.trivyignore)) and cut the tag again.
+
+Manual `workflow_dispatch` runs must target an existing release tag through `release_ref`; they only publish `latest` when `publish_latest=true` is set explicitly.
 
 ### Runtime Version Detection
 The backend API resolves the running server version from image build metadata (checking `NOJOIN_SERVER_VERSION` environment variable and `/app/.build-version` file), falling back to local `docs/VERSION` in development/testing. User-facing release metadata is resolved from the GitHub Releases API first, with GHCR tags and raw `docs/VERSION` file used as fallbacks.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -404,6 +404,20 @@ Nojoin uses a single Git Tag (`vX.Y.Z`) to trigger the API, Worker, and Frontend
 ### Runtime Version Detection
 The backend API resolves the running server version from image build metadata (checking `NOJOIN_SERVER_VERSION` environment variable and `/app/.build-version` file), falling back to local `docs/VERSION` in development/testing. User-facing release metadata is resolved from the GitHub Releases API first, with GHCR tags and raw `docs/VERSION` file used as fallbacks.
 
+## Supply-Chain and Release Hardening
+
+The release pipeline is hardened to make published images reproducible, traceable, and verifiable. Contributors changing CI, the release workflow, or the Dockerfiles must keep the controls below intact.
+
+### Pinned Actions and Base Images
+
+- Every third-party GitHub Action in [.github/workflows/](../.github/workflows/) is pinned to a full commit SHA with a trailing `# vX.Y.Z` comment. Do not reintroduce floating tags such as `@v5`; a mutable tag can be repointed at malicious code after review.
+- Every container base image in the Dockerfiles is pinned by `@sha256:` digest with the human-readable tag kept as a comment. The digest is the immutable identity of the image; the tag alone is mutable.
+- When you intentionally upgrade an action or base image, update both the SHA/digest and the version comment in the same change.
+
+### Dependabot
+
+[.github/dependabot.yml](../.github/dependabot.yml) keeps four ecosystems current on a weekly cadence: GitHub Actions, Python (`requirements/`), npm (`frontend/`), and Docker base images. Dependabot rewrites pinned SHAs and digests in place and updates the version comment, so pinning does not cause drift. Review and merge these update pull requests like any other change; they run the full CI suite.
+
 ## Related Docs
 
 - [CAPTURE.md](CAPTURE.md)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -399,7 +399,7 @@ Nojoin uses a single Git Tag (`vX.Y.Z`) to trigger the API, Worker, and Frontend
    git tag v0.6.0
    git push origin v0.6.0
    ```
-3. **CI/CD Pipeline**: The push of a strict `vX.Y.Z` tag triggers [.github/workflows/release.yml](../.github/workflows/release.yml). Release publishing now re-runs the backend, frontend, docs, and Alembic validation set before any image push, verifies `docs/VERSION` matches the tag, and only publishes `latest` automatically from the tag-triggered release flow. Manual `workflow_dispatch` runs must target an existing release tag through `release_ref`; they only publish `latest` when `publish_latest=true` is set explicitly. Update release notes manually in the GitHub Releases interface.
+3. **CI/CD Pipeline**: The push of a strict `vX.Y.Z` tag triggers [.github/workflows/release.yml](../.github/workflows/release.yml). Release publishing now re-runs the backend, frontend, docs, and Alembic validation set before any image push, verifies `docs/VERSION` matches the tag, and only publishes `latest` automatically from the tag-triggered release flow. Manual `workflow_dispatch` runs must target an existing release tag through `release_ref`; they only publish `latest` when `publish_latest=true` is set explicitly. Release notes are generated automatically by the `publish-release-notes` job (see [Automated Release Notes](#automated-release-notes-rel-013-rel-014) below); maintainers refine the editorial sections in the GitHub Releases interface afterward.
 
 ### Runtime Version Detection
 The backend API resolves the running server version from image build metadata (checking `NOJOIN_SERVER_VERSION` environment variable and `/app/.build-version` file), falling back to local `docs/VERSION` in development/testing. User-facing release metadata is resolved from the GitHub Releases API first, with GHCR tags and raw `docs/VERSION` file used as fallbacks.
@@ -429,6 +429,10 @@ The release flow publishes the immutable `version` and commit-`sha` tags during 
 ### Health and Non-Root Smoke (REL-012)
 
 The `health-smoke` job brings up the freshly built api and frontend images with their real `docker-compose` dependencies (Postgres, Redis, the socket proxy) and waits for the production healthchecks to report `healthy`. It then asserts each running container's uid is non-root. The worker requires a GPU and preloaded models to boot, so its non-root `USER` is asserted from the published image config via `docker buildx imagetools inspect` (which reads the config without pulling the large layers) rather than by booting it. The rolling tags are not published unless this job passes.
+
+### Automated Release Notes (REL-013, REL-014)
+
+After the rolling tags publish, the `publish-release-notes` job creates the GitHub Release. It resolves the exact previous-tag→this-tag commit range with `git describe`, renders the changelog from that range, resolves the published image digests, and fills [.github/release-notes-template.md](../.github/release-notes-template.md). The template carries the required sections — Upgrade, Migration, Rollback, Known Issues, and Browser-Capture Compatibility — with sensible defaults that maintainers refine in the GitHub Releases UI when a release needs specific guidance. `make_latest` follows the same `publish_latest` decision as the image tags.
 
 ## Related Docs
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -418,6 +418,14 @@ The release pipeline is hardened to make published images reproducible, traceabl
 
 [.github/dependabot.yml](../.github/dependabot.yml) keeps four ecosystems current on a weekly cadence: GitHub Actions, Python (`requirements/`), npm (`frontend/`), and Docker base images. Dependabot rewrites pinned SHAs and digests in place and updates the version comment, so pinning does not cause drift. Review and merge these update pull requests like any other change; they run the full CI suite.
 
+### Image Provenance, SBOM, and Signing
+
+Every published image is signed with cosign keyless (OIDC) signing and carries build-provenance and SBOM attestations (`provenance: mode=max`, `sbom: true` in the build step). The signature is bound to the release workflow identity, so the `server-release` job requires `id-token: write`. Operator verification commands live in [DEPLOYMENT.md](DEPLOYMENT.md#verifying-an-image-before-deploying).
+
+### Gated Tag Publication
+
+The release flow publishes the immutable `version` and commit-`sha` tags during the build, then publishes the rolling `latest` and `major.minor` tags from a separate `publish-mutable-tags` job only after vulnerability scanning, the image health smoke, and signing all pass. This means a build that fails a gate can briefly expose an immutable `vX.Y.Z` tag (with the run visibly failing) but can never advance the `latest` tag that operators pull by default. Keep this ordering intact when editing the release workflow.
+
 ## Related Docs
 
 - [CAPTURE.md](CAPTURE.md)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -426,6 +426,10 @@ Every published image is signed with cosign keyless (OIDC) signing and carries b
 
 The release flow publishes the immutable `version` and commit-`sha` tags during the build, then publishes the rolling `latest` and `major.minor` tags from a separate `publish-mutable-tags` job only after vulnerability scanning, the image health smoke, and signing all pass. This means a build that fails a gate can briefly expose an immutable `vX.Y.Z` tag (with the run visibly failing) but can never advance the `latest` tag that operators pull by default. Keep this ordering intact when editing the release workflow.
 
+### Health and Non-Root Smoke (REL-012)
+
+The `health-smoke` job brings up the freshly built api and frontend images with their real `docker-compose` dependencies (Postgres, Redis, the socket proxy) and waits for the production healthchecks to report `healthy`. It then asserts each running container's uid is non-root. The worker requires a GPU and preloaded models to boot, so its non-root `USER` is asserted from the published image config via `docker buildx imagetools inspect` (which reads the config without pulling the large layers) rather than by booting it. The rolling tags are not published unless this job passes.
+
 ## Related Docs
 
 - [CAPTURE.md](CAPTURE.md)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -106,3 +106,26 @@ We use GitHub's Private Vulnerability Reporting feature to receive security disc
 2. **Evaluation:** The maintainers will investigate the report and determine the severity and scope of the vulnerability.
 3. **Remediation:** If the vulnerability is confirmed, we will work on a patch. A security advisory will be drafted, and a fix will be released.
 4. **Disclosure:** Once a patch is available and deployed, we will coordinate public disclosure through a GitHub Security Advisory.
+
+## Emergency Security Release and Artifact Revocation
+
+When a confirmed vulnerability requires an out-of-band fix, maintainers follow an expedited release path. The goal is to ship a patched, verifiable image quickly without bypassing the integrity controls that make a release trustworthy.
+
+### Expedited Release
+
+1. **Draft privately.** Develop the fix on a private branch or through a GitHub Security Advisory draft so the change is not disclosed before an image is available.
+2. **Bump and tag.** Update `docs/VERSION` and push a strict `vX.Y.Z` tag exactly as for a normal release. The same release pipeline runs: full test, lint, build, documentation, and migration gates, followed by image build, vulnerability scan, the health and non-root smoke, and cosign signing. The security urgency does not remove these gates; it only compresses the schedule.
+3. **Publish notes.** The automated release notes are generated for the tag. Add an explicit security section describing the affected versions, severity, and required operator action (for example, "upgrade immediately").
+4. **Advisory.** Publish or update the GitHub Security Advisory, request a CVE where appropriate, and credit the reporter per the coordinated-disclosure workflow above.
+
+### Artifact Revocation
+
+If a published image is found to be compromised or dangerously vulnerable, revoke it rather than relying on a newer tag alone, because deployments may still be pulling the old tag or digest.
+
+1. **Stop the bleeding.** Repoint the rolling tags (`latest`, `major.minor`) to the patched image immediately by cutting the patched release; never leave `latest` pointing at a known-bad image.
+2. **Remove or mark the bad version.** Delete the affected immutable version tag and its digest from the GitHub Container Registry package, or, where deletion would break audit history, mark the version as deprecated and document it in the advisory. Note that container digests cannot be silently rewritten — a removed digest fails to pull, which is the intended fail-closed behaviour.
+3. **Invalidate trust signals.** Because images are signed by digest, a revoked digest should be called out in the advisory as no-longer-to-be-trusted. Operators verifying signatures should treat the advisory's listed bad digests as untrusted even if a historical signature exists.
+4. **Notify operators.** Communicate the revocation through the GitHub Security Advisory and the release notes, including the bad digests, the fixed digest to upgrade to, and any data-safety steps. Operators who pin by digest must be told the exact digest to move to.
+5. **Rotate exposed secrets.** If the incident could have exposed signing material, deployment credentials, or registry tokens, rotate them and record the rotation in the advisory timeline.
+
+Operators should subscribe to repository releases and security advisories so that emergency releases and revocations reach them promptly.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -72,6 +72,15 @@ Live recording is initiated and controlled by the authenticated web app.
 
 For end-user capture setup and troubleshooting, see [CAPTURE.md](CAPTURE.md).
 
+## Vulnerability Scanning and Severity Policy
+
+Published container images are scanned for known vulnerabilities by [Trivy](https://github.com/aquasecurity/trivy) before their rolling tags are published. The policy balances strong assurance against the reality that the worker image is built on a large CUDA/PyTorch base with a slow-moving, inherited CVE surface.
+
+- The release pipeline scans each image and **fails the release on CRITICAL or HIGH findings that have a fix available** (`ignore-unfixed: true`). Such findings are addressable by us — usually by pulling in a patched base image or dependency — so they block publication.
+- Findings **without an upstream fix** do not block the release. They cannot be actioned by Nojoin and are unavoidable for the GPU worker base image. They remain visible in scan output for tracking.
+- A *fixed* CRITICAL/HIGH finding may be **temporarily accepted only by an explicit, documented exception** in [.trivyignore](../.trivyignore), recording the CVE id, the reason, the owner, and a review-by date. Exceptions are expected to be short-lived and are removed once the fix is pulled in, typically through a Dependabot base-image or dependency update.
+- Pull requests additionally run an informational dependency and configuration scan that surfaces CVEs without blocking merges.
+
 ## Supported Versions
 
 As Nojoin is in active development, only the latest version is supported. We encourage all users to use the most up-to-date version of the application.

--- a/docs/repo-maintenance.md
+++ b/docs/repo-maintenance.md
@@ -173,16 +173,16 @@ Large refactors must preserve behavior and begin with characterization tests.
 
 ## Phase 5: Harden Release And Supply-Chain Governance
 
-- [ ] **REL-006:** Pin third-party GitHub Actions to reviewed commit SHAs and use automated updates to keep them current.
-- [ ] **REL-007:** Generate build provenance and an SBOM for each published image.
-- [ ] **REL-008:** Add container and dependency vulnerability scanning with a documented severity policy.
-- [ ] **REL-009:** Publish checksums or signatures appropriate to every release artifact.
-- [ ] **REL-010:** Remove `npm install -g npm@latest` from Docker builds and use a deliberate, reproducible npm version.
-- [ ] **REL-011:** Pin or otherwise govern mutable container base images and document the update policy.
-- [ ] **REL-012:** Verify release images run as non-root and pass health checks before publication.
-- [ ] **REL-013:** Automate release-note generation or validation from the exact previous-tag-to-current-tag range.
-- [ ] **REL-014:** Publish release notes with upgrade, migration, rollback, known-issue, and browser-capture compatibility sections where applicable.
-- [ ] **REL-015:** Add a documented emergency security-release and artifact-revocation procedure.
+- [x] **REL-006:** Pin third-party GitHub Actions to reviewed commit SHAs and use automated updates to keep them current. Every action in `.github/workflows/ci.yml` and `release.yml` is pinned to a commit SHA with a version comment, and `.github/dependabot.yml` keeps github-actions, pip, npm, and docker ecosystems current weekly.
+- [x] **REL-007:** Generate build provenance and an SBOM for each published image. The build step sets `provenance: mode=max` and `sbom: true`; verification commands are documented in `docs/DEPLOYMENT.md`.
+- [x] **REL-008:** Add container and dependency vulnerability scanning with a documented severity policy. Trivy scans each image before its rolling tags publish (fail on fixable CRITICAL/HIGH), a non-blocking dependency scan runs on pull requests, exceptions live in `.trivyignore`, and the policy is recorded in `docs/SECURITY.md`.
+- [x] **REL-009:** Publish checksums or signatures appropriate to every release artifact. Every image is cosign-signed by digest using keyless OIDC signing; published image digests are listed in the release notes.
+- [x] **REL-010:** Remove `npm install -g npm@latest` from Docker builds and use a deliberate, reproducible npm version. `frontend/Dockerfile` now uses the npm bundled with the digest-pinned `node:20-alpine` base (npm 10, compatible with `lockfileVersion 3`).
+- [x] **REL-011:** Pin or otherwise govern mutable container base images and document the update policy. All three Dockerfiles pin their base images by `@sha256:` digest with tag comments; Dependabot governs updates and the policy is documented for contributors and operators.
+- [x] **REL-012:** Verify release images run as non-root and pass health checks before publication. The `health-smoke` job boots the api and frontend with their real dependencies, waits for the production healthchecks, asserts non-root runtime uids, and asserts the worker's non-root image `USER`; rolling tags are gated on it passing.
+- [x] **REL-013:** Automate release-note generation or validation from the exact previous-tag-to-current-tag range. The `publish-release-notes` job derives the changelog from `git describe`-resolved previous-tag..this-tag history.
+- [x] **REL-014:** Publish release notes with upgrade, migration, rollback, known-issue, and browser-capture compatibility sections where applicable. `.github/release-notes-template.md` carries those sections and is filled automatically, then refined by maintainers.
+- [x] **REL-015:** Add a documented emergency security-release and artifact-revocation procedure. `docs/SECURITY.md` documents the expedited gated-release path, advisory/CVE coordination, GHCR artifact revocation, digest untrusting, operator notification, and secret rotation.
 
 ## Phase 6: Establish Ongoing Repository Governance
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,10 @@ FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb836
 FROM base AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install -g npm@latest && npm ci
+# Use the npm bundled with the pinned node:20-alpine base for reproducible
+# installs. Do not reintroduce `npm install -g npm@latest`: it pulls an
+# unpinned npm over the network on every build and undermines reproducibility.
+RUN npm ci
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -16,7 +19,7 @@ COPY . .
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 
-RUN npm install -g npm@latest && npm run build
+RUN npm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-alpine AS base
+# Pinned by digest for reproducible builds; Dependabot keeps the tag comment current.
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
# Pull Request

## Description

Implements **Phase 5 of the repository maintenance plan — Harden Release and Supply-Chain Governance** (`docs/repo-maintenance.md`, items REL-006 through REL-015). The change is CI/release-workflow, Dockerfile, and documentation only; no application code is touched.

What it does:

- **REL-006 / REL-011 — Pinning + Dependabot:** every GitHub Action in `ci.yml` and `release.yml` is pinned to a commit SHA (with a version comment), and all three base images are pinned by `@sha256:` digest. New `.github/dependabot.yml` keeps github-actions, pip, npm, and docker current weekly.
- **REL-010 — Reproducible npm:** removed `npm install -g npm@latest` from `frontend/Dockerfile`; it now uses the npm bundled with the digest-pinned `node:20-alpine` (npm 10, `lockfileVersion 3` compatible).
- **REL-007 / REL-009 — Provenance, SBOM, signing:** the build attaches `provenance: mode=max` and SBOM attestations and signs each image by digest with cosign keyless (OIDC). The build publishes only immutable `version`/`sha` tags; rolling `latest`/`major.minor` tags are promoted by a separate gated job.
- **REL-008 — Vulnerability scanning:** Trivy scans each image before the rolling tags publish and fails on fixable CRITICAL/HIGH (`ignore-unfixed: true` keeps the CUDA/PyTorch worker base releasable); a non-blocking dependency scan runs on PRs; `.trivyignore` holds documented, dated exceptions; the severity policy is in `docs/SECURITY.md`.
- **REL-012 — Pre-publication verification:** a `health-smoke` job boots the api and frontend with their real Compose dependencies, waits for the production healthchecks, asserts non-root runtime uids, and asserts the worker's non-root image `USER` via `imagetools` (no large-layer pull). Rolling tags are gated on it.
- **REL-013 / REL-014 — Release notes:** a `publish-release-notes` job derives the changelog from the exact previous-tag..this-tag range and fills `.github/release-notes-template.md` (Upgrade / Migration / Rollback / Known Issues / Browser-Capture sections + image digests), then creates the GitHub Release.
- **REL-015 — Emergency runbook:** `docs/SECURITY.md` documents the expedited security-release path and container artifact-revocation procedure.

The release job graph now encodes the trust model: `server-release` (build → scan → sign) → `health-smoke` → `publish-mutable-tags` → `publish-release-notes`, so the rolling `latest` tag can never advance unless every gate passed.

New dependencies (CI only, all SHA-pinned): `sigstore/cosign-installer`, `aquasecurity/trivy-action`, `softprops/action-gh-release`.

Fixes # (n/a)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update
- [x] CI / release and supply-chain hardening (no application code change)

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 649 passed
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators) — passed
- [x] Frontend lint: `cd frontend && npm run lint` — passed
- [x] Frontend unit tests: `cd frontend && npm run test` — 164 passed
- [x] Frontend build: `cd frontend && npm run build` — passed
- [x] Docs validation: `python3 scripts/validate_docs.py` — passed (20 files)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — passed (head `b91f9c2d4e6a`)

Additional: a real `frontend/Dockerfile` image build succeeded with the digest-pinned base and no global npm upgrade, running as non-root `nextjs` (uid 1001).

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR. `docs/DEVELOPMENT.md` (hardened release runbook, supply-chain controls), `docs/DEPLOYMENT.md` (image trust and verification), `docs/SECURITY.md` (severity policy + emergency-release runbook), and `docs/repo-maintenance.md` (REL-006…015 marked complete).

## Security impact

- [x] No security-sensitive *code* change. Adds the documented vulnerability severity policy, image signing/provenance, and the emergency security-release and artifact-revocation runbook to `docs/SECURITY.md`; no auth, token, encryption, or capture-ownership behaviour changed.

## Manual verification

- Validated all three workflow YAML files parse; the release job graph resolves to `validate-release-ref → … → server-release → health-smoke → publish-mutable-tags → publish-release-notes`.
- `actionlint` reports only two intentional shellcheck notes (git format placeholders / globs in single quotes); no workflow errors.
- Built `frontend/Dockerfile` end to end (digest pin + npm removal); image runs as non-root `nextjs` (uid 1001).
- Resolved every pinned action SHA and base-image digest against the live registry/GitHub API at authoring time.

**Cannot be exercised locally (no GitHub OIDC / GHCR):** cosign signing, provenance/SBOM push, Trivy registry pull-scan, the api Compose health smoke, and GitHub Release creation. These first execute on the next `vX.Y.Z` tag. The worker (CUDA base) image was not built locally; its change is limited to the base-image digest pin.

**Follow-up after first green tagged run:** add the new release jobs to the required-status-checks set if you want them to gate at the GitHub level (REL-006 branch-protection step).
