### PR TITLE
docs(config): fix stale repo-maintenance reference in the mypy comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ markers = [
 # Rather than type-checking the whole (largely untyped) backend at once, we
 # enforce types on a curated set of stable boundaries -- configuration, core
 # security/persistence contracts, and API-facing schemas -- and expand the
-# `files` list as more modules are annotated (see docs/repo-maintenance.md).
+# `files` list as more modules are annotated (see docs/DEVELOPMENT.md).
 python_version = "3.12"
 # The Pydantic plugin teaches mypy about SQLModel/Pydantic models, including
 # @computed_field stacked on @property.


### PR DESCRIPTION
## Description

Follow-up cleanup to the Phase 6 governance change (#39). When `docs/repo-maintenance.md` was removed in #39, one reference to it was missed: the `[tool.mypy]` comment in `pyproject.toml` still pointed at the deleted tracker. This repoints it to `docs/DEVELOPMENT.md`, where the incremental, boundary-first type-hint policy now lives ("Backend Coding Conventions → Type Hints"). `git grep` confirms no other references to the removed file remain in tracked files.

Comment-only change; no behaviour, configuration, or type-checking boundary is affected.

## Type of change

- [x] Documentation update (a code comment repointed to the correct guide)

## Checks run

- [x] Python quality: `python scripts/check.py lint format typecheck` — Ruff lint, Ruff format check, and mypy (22 files) all pass.
- [x] Docs validation: `python3 scripts/validate_docs.py` — 22 Markdown files, no findings.
- [x] `git diff --check` clean; trailing-whitespace check clean.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation guide change required (this only corrects a stale pointer in a config comment).

## Security impact

- [x] No security-sensitive change.

## Manual verification

`git grep "repo-maintenance"` over all tracked files returns no matches after the change.
