### PR TITLE
ci: run heavy checks only when their area changes, behind a single CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,6 @@ jobs:
       - name: Ruff format check
         run: ruff format --check .
 
-      - name: Check trailing whitespace
-        run: python scripts/check_whitespace.py
-
       - name: Check source file size
         run: python scripts/check_file_size.py
 
@@ -227,6 +224,25 @@ jobs:
       - name: Validate checked-in Alembic graph
         run: python scripts/validate_alembic.py
 
+  whitespace:
+    # Always run: this is the only trailing-whitespace guard for Markdown, YAML,
+    # shell, and config files, which the path-gated Python quality job no longer
+    # covers on a non-backend change. The script is pure stdlib, so it is cheap.
+    name: Whitespace check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Check trailing whitespace
+        run: python scripts/check_whitespace.py
+
   dependency-scan:
     name: Dependency vulnerability scan
     runs-on: ubuntu-latest
@@ -266,6 +282,7 @@ jobs:
       - frontend-build
       - docs-validation
       - alembic-validation
+      - whitespace
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,47 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  # Classify the diff so the heavy jobs only run when their area changed. The
+  # expensive jobs below gate on these outputs; the cheap validators always run.
+  # `CI gate` (the single required status check) aggregates every result, so a
+  # skipped job never leaves a required check permanently pending.
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # Full history lets paths-filter diff push events (e.g. pushes to main)
+          # via git; pull_request events are diffed through the API.
+          fetch-depth: 0
+
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'requirements/**'
+              - 'pyproject.toml'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/ci.yml'
+
   backend-tests:
     name: Backend tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -35,6 +72,8 @@ jobs:
 
   python-quality:
     name: Python quality
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -72,6 +111,8 @@ jobs:
 
   frontend-lint:
     name: Frontend lint
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -95,6 +136,8 @@ jobs:
 
   frontend-unit-tests:
     name: Frontend unit tests
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -118,6 +161,8 @@ jobs:
 
   frontend-build:
     name: Frontend build
+    needs: detect-changes
+    if: needs.detect-changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -192,3 +237,37 @@ jobs:
           ignore-unfixed: true
           exit-code: "0"
           trivyignores: .trivyignore
+
+  # Single required status check. It depends on every meaningful job and passes
+  # only if none of them failed or were cancelled; a job that was skipped by the
+  # path filter counts as a pass. Branch protection requires this context (and
+  # only this one), so a required check is always reported even when the heavy
+  # jobs are skipped, which a per-job `paths` filter could never guarantee.
+  ci-gate:
+    name: CI gate
+    if: always()
+    needs:
+      - detect-changes
+      - backend-tests
+      - python-quality
+      - frontend-lint
+      - frontend-unit-tests
+      - frontend-build
+      - docs-validation
+      - alembic-validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify required jobs passed or were skipped
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          echo "dependency results: ${RESULTS}"
+          for result in ${RESULTS}; do
+            if [[ "${result}" == "failure" || "${result}" == "cancelled" ]]; then
+              echo "A required job did not pass (result: ${result})." >&2
+              exit 1
+            fi
+          done
+          echo "All required jobs passed or were skipped."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      deployment: ${{ steps.filter.outputs.deployment }}
 
     steps:
       - name: Checkout repository
@@ -34,21 +35,31 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
+          # `deployment` covers infrastructure that the backend/frontend code
+          # filters do not (Dockerfiles, compose, nginx, and any workflow). A
+          # change to those runs the full backend and frontend suite, matching
+          # the deployment/release verification policy in CONTRIBUTING.md and
+          # ensuring a deployment-only PR is never validated by the cheap
+          # validators alone. Workflow changes land here too, so editing this
+          # file exercises everything.
           filters: |
             backend:
               - 'backend/**'
               - 'requirements/**'
               - 'pyproject.toml'
               - 'scripts/**'
-              - '.github/workflows/ci.yml'
             frontend:
               - 'frontend/**'
-              - '.github/workflows/ci.yml'
+            deployment:
+              - 'docker/**'
+              - 'docker-compose*.yml'
+              - 'nginx/**'
+              - '.github/workflows/**'
 
   backend-tests:
     name: Backend tests
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend == 'true'
+    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.deployment == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -73,7 +84,7 @@ jobs:
   python-quality:
     name: Python quality
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend == 'true'
+    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.deployment == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -112,7 +123,7 @@ jobs:
   frontend-lint:
     name: Frontend lint
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend == 'true'
+    if: needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.deployment == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -137,7 +148,7 @@ jobs:
   frontend-unit-tests:
     name: Frontend unit tests
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend == 'true'
+    if: needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.deployment == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -162,7 +173,7 @@ jobs:
   frontend-build:
     name: Frontend build
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend == 'true'
+    if: needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.deployment == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,15 +84,13 @@ Minimum pull request verification is:
 - Documentation changes: `python3 scripts/validate_docs.py`
 - Alembic migration changes: `python3 scripts/validate_alembic.py`
 
-The pull request workflow requires these checks to pass on `main`:
+The pull request workflow runs these checks, and the aggregate `CI gate` must be green to merge. The expensive jobs run only when their area changed; the cheap validators always run:
 
-- `Backend tests`
-- `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries)
-- `Frontend lint`
-- `Frontend unit tests`
-- `Frontend build`
-- `Docs validation`
-- `Alembic validation`
+- `Backend tests` and `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) — on backend changes.
+- `Frontend lint`, `Frontend unit tests`, and `Frontend build` — on frontend changes.
+- `Docs validation` and `Alembic validation` — always.
+
+See the [Merge Requirements](#merge-requirements) section for how `CI gate` aggregates these and the exact path rules.
 
 Run the checks for every area you touched before opening a pull request. Capture-related changes also require manual browser smoke testing for start, pause/resume, stop/finalize, discard, unsupported-browser messaging, and selected-microphone behaviour. Migration changes must keep a single checked-in Alembic head and must not delete or rename committed revision files.
 
@@ -146,15 +144,13 @@ Review responsibility is recorded in [.github/CODEOWNERS](.github/CODEOWNERS). G
 
 ### Merge Requirements
 
-Every pull request to `main`, regardless of scope, must have all required status checks green before merge:
+Every pull request to `main` must have the required `CI gate` status check green before merge. `CI gate` is an aggregate that passes only when every applicable CI job passed. To save CI minutes, the expensive jobs run only when their area changed and are skipped (counted as a pass) otherwise:
 
-- `Backend tests`
-- `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries)
-- `Frontend lint`
-- `Frontend unit tests`
-- `Frontend build`
-- `Docs validation`
-- `Alembic validation`
+- `Backend tests` and `Python quality` (Ruff lint, Ruff format check, mypy) — run when `backend/**`, `requirements/**`, `pyproject.toml`, `scripts/**`, or the CI workflow changed.
+- `Frontend lint`, `Frontend unit tests`, and `Frontend build` — run when `frontend/**` or the CI workflow changed.
+- `Docs validation` and `Alembic validation` — always run (cheap).
+
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#required-pull-request-checks) for the exact path rules and how `CI gate` works.
 
 Sensitive scopes carry an additional review obligation that the maintainer (or, in future, a designated CODEOWNER) must satisfy before merging:
 
@@ -168,7 +164,7 @@ Sensitive scopes carry an additional review obligation that the maintainer (or, 
 Branch protection and required-reviewer enforcement cannot be applied from the repository tree; they are GitHub repository settings. The settings to apply on `main` are designed so the sole maintainer can always merge their own green pull request and are never an irreversible lockout:
 
 - Require a pull request before merging, with **0** required approvals while the project is single-maintainer. GitHub forbids approving your own pull request, so a non-zero count would make every merge impossible for a sole author; raise it to **1** and enable **Require review from Code Owners** only when a second maintainer joins.
-- Require the seven status checks listed above (their job names) to pass before merging, with branches required to be up to date. These are enforced for admins too, so nothing merges red.
+- Require the single `CI gate` status check to pass before merging, with branches required to be up to date. It is enforced for admins too, so nothing merges red. (Only `CI gate` is required, not the individual jobs, because those are skipped by the path filter when irrelevant and a skipped job would otherwise leave a required check pending forever.)
 - Require linear history and disallow force pushes and deletions.
 
 The exact `gh` command, the reasoning behind each value, and the guarantee that this cannot lock out a sole maintainer are recorded in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#branch-protection-maintainer-action). The release jobs are deliberately **not** part of this list: they only run on tag pushes, never on pull requests, so requiring them on `main` would block every merge. The release pipeline self-gates through its own job dependency graph instead, as documented in [ADR-0001](docs/adr/0001-gated-signed-release-model.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,8 @@ Minimum pull request verification is:
 
 The pull request workflow runs these checks, and the aggregate `CI gate` must be green to merge. The expensive jobs run only when their area changed; the cheap validators always run:
 
-- `Backend tests` and `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) — on backend changes.
-- `Frontend lint`, `Frontend unit tests`, and `Frontend build` — on frontend changes.
+- `Backend tests` and `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) — on backend or deployment changes.
+- `Frontend lint`, `Frontend unit tests`, and `Frontend build` — on frontend or deployment changes.
 - `Docs validation` and `Alembic validation` — always.
 
 See the [Merge Requirements](#merge-requirements) section for how `CI gate` aggregates these and the exact path rules.
@@ -146,8 +146,9 @@ Review responsibility is recorded in [.github/CODEOWNERS](.github/CODEOWNERS). G
 
 Every pull request to `main` must have the required `CI gate` status check green before merge. `CI gate` is an aggregate that passes only when every applicable CI job passed. To save CI minutes, the expensive jobs run only when their area changed and are skipped (counted as a pass) otherwise:
 
-- `Backend tests` and `Python quality` (Ruff lint, Ruff format check, mypy) — run when `backend/**`, `requirements/**`, `pyproject.toml`, `scripts/**`, or the CI workflow changed.
-- `Frontend lint`, `Frontend unit tests`, and `Frontend build` — run when `frontend/**` or the CI workflow changed.
+- `Backend tests` and `Python quality` (Ruff lint, Ruff format check, mypy) — run when `backend/**`, `requirements/**`, `pyproject.toml`, or `scripts/**` changed.
+- `Frontend lint`, `Frontend unit tests`, and `Frontend build` — run when `frontend/**` changed.
+- A **deployment** change (`docker/**`, `docker-compose*.yml`, `nginx/**`, or `.github/workflows/**`) runs **both** the backend and frontend suites, since it can affect the built images or pipeline even without code changes. This is consistent with the deployment/release sensitive-scope rule below.
 - `Docs validation` and `Alembic validation` — always run (cheap).
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#required-pull-request-checks) for the exact path rules and how `CI gate` works.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Every pull request to `main` must have the required `CI gate` status check green
 - `Backend tests` and `Python quality` (Ruff lint, Ruff format check, mypy) — run when `backend/**`, `requirements/**`, `pyproject.toml`, or `scripts/**` changed.
 - `Frontend lint`, `Frontend unit tests`, and `Frontend build` — run when `frontend/**` changed.
 - A **deployment** change (`docker/**`, `docker-compose*.yml`, `nginx/**`, or `.github/workflows/**`) runs **both** the backend and frontend suites, since it can affect the built images or pipeline even without code changes. This is consistent with the deployment/release sensitive-scope rule below.
-- `Docs validation` and `Alembic validation` — always run (cheap).
+- `Whitespace check`, `Docs validation`, and `Alembic validation` — always run (cheap). `Whitespace check` is the only trailing-whitespace guard for Markdown, YAML, shell, and config files, so it is never gated.
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#required-pull-request-checks) for the exact path rules and how `CI gate` works.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -110,12 +110,15 @@ gh api -X PUT repos/Valtora/Nojoin/branches/main/protection --input - <<'JSON'
     "required_approving_review_count": 0
   },
   "required_linear_history": true,
+  "required_conversation_resolution": true,
   "allow_force_pushes": false,
   "allow_deletions": false,
   "restrictions": null
 }
 JSON
 ```
+
+`required_conversation_resolution` makes unresolved review threads (including automated review comments) block the merge until they are resolved, so feedback is not lost. It is listed explicitly because `PUT` replaces the whole protection object: omitting it would silently disable it on the next apply.
 
 **This configuration cannot lock out a sole maintainer.** It is deliberately built so that a single person who is also the only code owner can always merge their own green pull request:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -69,6 +69,7 @@ The `CI` workflow runs these checks on pull requests and on pushes to `main`. To
 | `Frontend lint` | `frontend/**` or a deployment path changed |
 | `Frontend unit tests` | same as `Frontend lint` |
 | `Frontend build` | same as `Frontend lint` |
+| `Whitespace check` | always (the only trailing-whitespace guard for non-Python files) |
 | `Docs validation` | always |
 | `Alembic validation` | always |
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -60,14 +60,19 @@ If you are working on a narrower area, you can install a smaller Python dependen
 
 ## Required Pull Request Checks
 
-The `CI` workflow enforces these required checks on pull requests and on pushes to `main`:
+The `CI` workflow runs these checks on pull requests and on pushes to `main`. To avoid wasting minutes on irrelevant work, the expensive jobs only run when their area changed; the cheap validators always run:
 
-- `Backend tests`
-- `Frontend lint`
-- `Frontend unit tests`
-- `Frontend build`
-- `Docs validation`
-- `Alembic validation`
+| Check | Runs when |
+| --- | --- |
+| `Backend tests` | `backend/**`, `requirements/**`, `pyproject.toml`, `scripts/**`, or `.github/workflows/ci.yml` changed |
+| `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) | same as `Backend tests` |
+| `Frontend lint` | `frontend/**` or `.github/workflows/ci.yml` changed |
+| `Frontend unit tests` | same as `Frontend lint` |
+| `Frontend build` | same as `Frontend lint` |
+| `Docs validation` | always |
+| `Alembic validation` | always |
+
+A `detect-changes` job (using `dorny/paths-filter`) classifies the diff, and each heavy job gates on its output; a job that does not apply is **skipped**, not run. The single required status check is **`CI gate`**, an aggregate job that depends on all of the above and passes only when none of them failed — treating a skipped job as a pass. Because `CI gate` always reports a status, a documentation-only pull request (which skips the backend and frontend jobs) is never left waiting on a check that never runs. This is why branch protection requires `CI gate` rather than the individual job names.
 
 Local equivalents:
 
@@ -95,13 +100,7 @@ gh api -X PUT repos/Valtora/Nojoin/branches/main/protection --input - <<'JSON'
   "required_status_checks": {
     "strict": true,
     "contexts": [
-      "Backend tests",
-      "Python quality",
-      "Frontend lint",
-      "Frontend unit tests",
-      "Frontend build",
-      "Docs validation",
-      "Alembic validation"
+      "CI gate"
     ]
   },
   "enforce_admins": true,
@@ -121,13 +120,13 @@ JSON
 
 - `required_approving_review_count` is `0`: GitHub never allows approving your own pull request, so any value of `1` or more would make every merge impossible for a sole author. With `0`, a green pull request is mergeable by you alone.
 - `require_code_owner_reviews` is `false`: with it `true` and you as the only code owner, the required code-owner approval could never be supplied and your own pull requests would be permanently unmergeable. It stays `false` while the project is single-maintainer. You still get a review auto-requested on every pull request, because that comes from the [CODEOWNERS](../.github/CODEOWNERS) file itself, not from this setting — you keep the review prompt without the merge gate.
-- `enforce_admins` is `true` so the status checks apply to you too and nothing merges red. This is not a lockout: every required check runs on every pull request, so a green pull request is always mergeable, and as the repository owner you can edit or remove this protection in **Settings → Branches** at any time (for example to land a fix for a broken CI workflow). Protection is never an irreversible state.
+- `enforce_admins` is `true` so the status check applies to you too and nothing merges red. This is not a lockout: the `CI gate` check always reports on every pull request, so a green pull request is always mergeable, and as the repository owner you can edit or remove this protection in **Settings → Branches** at any time (for example to land a fix for a broken CI workflow). Protection is never an irreversible state.
 
 **When a second maintainer joins**, set `require_code_owner_reviews` to `true` and raise `required_approving_review_count` to `1` to turn this into a genuine second-reviewer gate.
 
 This step is maintainer-action-pending: it is documented here but not enforced from the repository tree.
 
-**Do not add the release jobs to this required-checks list.** The contexts above are exactly the seven checks the CI workflow runs on every pull request. The release jobs (`server-release`/`Build, scan & sign images`, `health-smoke`/`Image health & non-root smoke`, `publish-mutable-tags`/`Publish rolling tags`, `publish-release-notes`/`Publish release notes` in [release.yml](../.github/workflows/release.yml)) only run on a tag push or `workflow_dispatch`, never on a pull request. If they were added here, GitHub would leave them permanently "Expected" on every PR commit — they would never report, and **every merge to `main` would be blocked**. Branch protection on `main` also does not govern tag creation, so it cannot gate a release at all.
+**Do not add the release jobs to this required-checks list.** The required context is the single `CI gate` job, which the CI workflow reports on every pull request. The release jobs (`server-release`/`Build, scan & sign images`, `health-smoke`/`Image health & non-root smoke`, `publish-mutable-tags`/`Publish rolling tags`, `publish-release-notes`/`Publish release notes` in [release.yml](../.github/workflows/release.yml)) only run on a tag push or `workflow_dispatch`, never on a pull request. If they were added here, GitHub would leave them permanently "Expected" on every PR commit — they would never report, and **every merge to `main` would be blocked**. Branch protection on `main` also does not govern tag creation, so it cannot gate a release at all. The same reasoning is why the individual CI jobs are not required directly: they are skipped by the path filter when irrelevant, so only the always-reporting `CI gate` aggregate is safe to require.
 
 The release pipeline is instead self-gating through the workflow's own `needs:` dependency graph: `publish-mutable-tags` depends on `server-release` and `health-smoke`, and `publish-release-notes` depends on `publish-mutable-tags`. A failed scan, smoke, or signing step therefore stops the rolling tags from ever publishing, with no branch-protection setting required or possible. Keep that ordering intact when editing the release workflow (see [adr/0001-gated-signed-release-model.md](adr/0001-gated-signed-release-model.md)).
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,15 +64,15 @@ The `CI` workflow runs these checks on pull requests and on pushes to `main`. To
 
 | Check | Runs when |
 | --- | --- |
-| `Backend tests` | `backend/**`, `requirements/**`, `pyproject.toml`, `scripts/**`, or `.github/workflows/ci.yml` changed |
+| `Backend tests` | `backend/**`, `requirements/**`, `pyproject.toml`, `scripts/**`, or a deployment path changed |
 | `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) | same as `Backend tests` |
-| `Frontend lint` | `frontend/**` or `.github/workflows/ci.yml` changed |
+| `Frontend lint` | `frontend/**` or a deployment path changed |
 | `Frontend unit tests` | same as `Frontend lint` |
 | `Frontend build` | same as `Frontend lint` |
 | `Docs validation` | always |
 | `Alembic validation` | always |
 
-A `detect-changes` job (using `dorny/paths-filter`) classifies the diff, and each heavy job gates on its output; a job that does not apply is **skipped**, not run. The single required status check is **`CI gate`**, an aggregate job that depends on all of the above and passes only when none of them failed — treating a skipped job as a pass. Because `CI gate` always reports a status, a documentation-only pull request (which skips the backend and frontend jobs) is never left waiting on a check that never runs. This is why branch protection requires `CI gate` rather than the individual job names.
+A `detect-changes` job (using `dorny/paths-filter`) classifies the diff into `backend`, `frontend`, and `deployment`. The deployment filter — `docker/**`, `docker-compose*.yml`, `nginx/**`, and `.github/workflows/**` — runs **both** the backend and frontend suites, because a Dockerfile, compose, nginx, or workflow change can break the built images or pipeline even when no application code changed; this also keeps CI consistent with the deployment/release verification policy in [CONTRIBUTING.md](../CONTRIBUTING.md#merge-requirements). Each heavy job gates on these outputs; a job that does not apply is **skipped**, not run. The single required status check is **`CI gate`**, an aggregate job that depends on all of the above and passes only when none of them failed — treating a skipped job as a pass. Because `CI gate` always reports a status, a documentation-only pull request (which skips the backend and frontend jobs) is never left waiting on a check that never runs. This is why branch protection requires `CI gate` rather than the individual job names.
 
 Local equivalents:
 


### PR DESCRIPTION
## Description

Makes CI run intelligently by change scope so a small or docs-only pull request no longer pays for the full ~12-minute backend suite.

A new `detect-changes` job (pinned `dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1`) classifies the diff, and the expensive jobs gate on it:

- `Backend tests` and `Python quality` run only when `backend/**`, `requirements/**`, `pyproject.toml`, `scripts/**`, or `.github/workflows/ci.yml` changed.
- `Frontend lint`, `Frontend unit tests`, and `Frontend build` run only when `frontend/**` or `.github/workflows/ci.yml` changed.
- `Docs validation` and `Alembic validation` always run (they take seconds).

### Why a single `CI gate` instead of `paths:` filters on each required job

A required status check that is skipped by a path filter never reports, which leaves branch protection waiting on it forever and blocks the merge. To avoid that, a new `CI gate` job depends on every other job, runs with `if: always()`, and passes only when none of them failed or were cancelled — a path-skipped job counts as a pass. `CI gate` therefore always reports a status, so it is the single context branch protection requires. The individual jobs are intentionally **not** required directly.

### Branch-protection follow-up (maintainer action, applied with this change)

Branch protection on `main` is updated to require only the `CI gate` context (previously it required the seven individual job names, which is incompatible with skipping). This is applied via `gh api` as part of landing this change; the documented command in `docs/DEVELOPMENT.md` is updated to match.

## Type of change

- [x] CI / tooling change (no application code or runtime behaviour affected)

## Checks run

- [x] `actionlint` (Docker) on `.github/workflows/ci.yml` — no findings; YAML parses.
- [x] Docs validation: `python3 scripts/validate_docs.py` — 22 Markdown files, no findings.
- [x] Trailing-whitespace check and `git diff --check` — clean.
- [x] This PR edits `ci.yml`, so the path filter marks both backend and frontend changed; every job (and `CI gate`) runs on this PR, exercising the full matrix end to end.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated `CONTRIBUTING.md` and `docs/DEVELOPMENT.md` to describe the conditional jobs, the `CI gate` aggregate, the path rules, and the updated branch-protection command.

## Security impact

- [x] No security-sensitive change. The path filter only decides which checks run; the `detect-changes` job uses `pull-requests: read` to classify the diff. The release pipeline's gating is unchanged.

## Manual verification

After this lands I will confirm on a subsequent docs-only change that the backend and frontend jobs are skipped while `CI gate` still reports green.
