### PR TITLE
docs(readme): fix 'document' typo in the search feature bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Nojoin is built for people who want the usefulness of meeting assistants without
 - AI-powered Meeting Chat grounded in the transcript, notes, and uploaded documents
 - Global speaker library with voiceprints and speaker matching
 - Google and Outlook calendar sync with meeting context in the dashboard
-- Search across recordings, notes, and document
+- Search across recordings, notes, and documents
 - Dedicated Task workspace
 
 ## Supported Browsers and OSes


### PR DESCRIPTION
Fixes a small typo in the README feature list (`document` -> `documents`).

This is also a verification of the path-filtered CI from #41: it is a README-only change, so `detect-changes` should mark backend, frontend, and deployment all false, and the heavy jobs (`Backend tests`, `Python quality`, the frontend jobs) should be **skipped** while `Whitespace check`, `Docs validation`, `Alembic validation`, and the required `CI gate` still run and pass.

## Checks run
- [x] Docs validation, whitespace, and `git diff --check` clean locally.