### PR TITLE
fix(security): clear release-image Trivy findings (worker/api/frontend) and document local validation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,12 @@ LICENSE
 data/
 .env
 .env.*
+# Never bake TLS private keys or certificates into images. None are tracked;
+# this stops locally generated material (e.g. nginx/cert.key from
+# docker/init-ssl.sh) from leaking into a local build context. The **/ prefix is
+# required to match nested paths — a bare *.key only matches the context root.
+**/*.key
+**/*.crt
+**/*.pem
+**/*.p12
+**/*.pfx

--- a/.trivyignore
+++ b/.trivyignore
@@ -17,3 +17,24 @@
 # # CVE-XXXX-NNNNN: base-image-only, fix lands in next pytorch base bump.
 # #   Owner: maintainers. Review by: YYYY-MM-DD.
 # CVE-XXXX-NNNNN
+
+# linux-libc-dev kernel CVEs inherited from the pinned PyTorch/CUDA worker base
+# image. These flag the kernel *header* package version, not the running kernel:
+# a container shares the host's kernel, so the in-image linux-libc-dev version is
+# not a runtime exposure for the worker. Accepted until a newer pytorch base ships
+# patched headers.
+#   Owner: maintainers. Review by: 2026-09-24.
+CVE-2025-68263
+CVE-2026-22984
+CVE-2026-23111
+CVE-2026-23112
+CVE-2026-23172
+CVE-2026-23231
+CVE-2026-31431
+CVE-2026-43284
+CVE-2026-43500
+CVE-2026-46300
+CVE-2026-46323
+CVE-2026-46333
+CVE-2026-47331
+CVE-2026-47333

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -57,12 +57,31 @@ ENV PATH="/opt/venv/bin:$PATH"
 ENV MALLOC_ARENA_MAX=2
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    # Patch the base image's OpenSSL against CVE-2026-45447 (PKCS7_verify UAF);
+    # the pinned PyTorch base predates the Ubuntu fix (3.0.13-0ubuntu3.11).
+    apt-get install -y --no-install-recommends --only-upgrade openssl libssl3t64 && \
+    apt-get install -y --no-install-recommends \
     ffmpeg \
     libsndfile1 \
     libpq5 \
     libjemalloc2 \
-    && rm -rf /var/lib/apt/lists/*
+    && \
+    # The worker runs Celery and never invokes uv; remove the base image's uv
+    # binaries so their bundled rustls-webpki (GHSA-82j2-j2ch-gfr8) is absent
+    # from the published runtime image.
+    rm -f /usr/local/bin/uv /usr/local/bin/uvx && \
+    rm -rf /var/lib/apt/lists/*
+
+# The PyTorch base ships a system Python with vulnerable pillow/urllib3 in
+# /usr/local/lib/.../dist-packages. The venv (system-site-packages) shadows them
+# at import time with the patched versions from requirements, but the old files
+# remain on disk and are flagged by the image scan. Upgrade the system copies in
+# place (as root, before the USER switch) to the same patched versions:
+# pillow CVE-2026-40192/42311, urllib3 CVE-2026-44431/44432. Keep these versions
+# in step with the pins in requirements/base.txt.
+RUN /usr/bin/python3 -m pip install --no-cache-dir --break-system-packages \
+    --root-user-action=ignore --upgrade pillow==12.2.0 urllib3==2.7.0
 
 COPY --from=builder /opt/venv /opt/venv
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -519,6 +519,37 @@ Every published image is signed with cosign keyless (OIDC) signing and carries b
 
 The release flow publishes the immutable `version` and commit-`sha` tags during the build, then publishes the rolling `latest` and `major.minor` tags from a separate `publish-mutable-tags` job only after vulnerability scanning, the image health smoke, and signing all pass. This means a build that fails a gate can briefly expose an immutable `vX.Y.Z` tag (with the run visibly failing) but can never advance the `latest` tag that operators pull by default. Keep this ordering intact when editing the release workflow.
 
+### Validating Images Locally Before Cutting a Tag
+
+The scan gate fails on *fixable* CRITICAL/HIGH findings and always pulls a fresh vulnerability database, so a previously-green pinned base image can start failing as new CVEs are disclosed — a tag push is not guaranteed to publish even with no code change. Validate the three images locally before pushing (or re-pushing) a `vX.Y.Z` tag to avoid burning tag cycles on a blocked release.
+
+Install Trivy (the maintainer host keeps it at `~/.local/bin/trivy`, installed without sudo):
+
+```bash
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b "$HOME/.local/bin"
+```
+
+Build each image exactly as the release workflow does, then run the same gate against all three:
+
+```bash
+docker build -f docker/Dockerfile.api --build-arg NOJOIN_SERVER_VERSION=<version> -t nojoin-api:scan .
+docker build -f docker/Dockerfile.worker -t nojoin-worker:scan .
+docker build -f frontend/Dockerfile --build-arg NEXT_PUBLIC_API_URL=/api -t nojoin-frontend:scan frontend
+
+for img in nojoin-api:scan nojoin-worker:scan nojoin-frontend:scan; do
+  trivy image --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore --exit-code 1 "$img"
+done
+```
+
+These flags mirror the gate in [release.yml](../.github/workflows/release.yml). Building the worker pulls the large PyTorch/CUDA base on first run. Add `--scanners vuln` to focus on the CVE gate and skip Trivy's secret scanner, which can flag locally generated material (see below).
+
+**Remediation patterns the `requirements/` files and lockfiles do not cover.** Trivy scans files present in the built image, so several classes of finding live outside the dependency graph and need an image-level fix:
+
+- **Base-image system Python (worker).** The worker venv is created with `--system-site-packages` to reuse the base's torch, so the PyTorch base's own system interpreter (`/usr/bin/python3`, packages under `/usr/local/lib/pythonX.Y/dist-packages`) keeps its pre-installed copies of packages such as `pillow` and `urllib3` on disk even after those packages are pinned in [requirements/base.txt](../requirements/base.txt). Upgrade them in place, as root before the `USER` switch, with `pip install --break-system-packages --root-user-action=ignore --upgrade <pkg>==<version>`, keeping the versions in step with the requirements pins. See [docker/Dockerfile.worker](../docker/Dockerfile.worker).
+- **Build tooling in runtime images.** Remove toolchain the runtime never executes: `npm` (the node base bundles a vulnerable `undici`) from the frontend runner, and `uv`/`uvx` (which bundle `rustls-webpki`) from the worker runtime. Each removal eliminates an inherited finding without affecting the running service.
+- **Kernel headers (`linux-libc-dev`).** These flag the in-image kernel *header* package, not the running kernel; a container shares the host kernel, so they are not a runtime exposure. Accept them with dated, justified entries in [.trivyignore](../.trivyignore) rather than chasing base-kernel versions, and remove the entries when a newer base ships the fix.
+- **Secrets in the build context.** [.dockerignore](../.dockerignore) excludes TLS key and certificate material so locally generated files (for example `nginx/cert.key` from [docker/init-ssl.sh](../docker/init-ssl.sh)) are never copied into an image. `.dockerignore` patterns need a `**/` prefix to match nested paths — a bare `*.key` only matches the context root. A clean CI checkout never contains this material, but a local build can, which is why the secret scanner may flag it locally and not in CI.
+
 ### Health and Non-Root Smoke (REL-012)
 
 The `health-smoke` job brings up the freshly built api and frontend images with their real `docker-compose` dependencies (Postgres, Redis, the socket proxy) and waits for the production healthchecks to report `healthy`. It then asserts each running container's uid is non-root. The worker requires a GPU and preloaded models to boot, so its non-root `USER` is asserted from the published image config via `docker buildx imagetools inspect` (which reads the config without pulling the large layers) rather than by booting it. The rolling tags are not published unless this job passes.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,5 +8,12 @@ python-multipart==0.0.32
 aiofiles==25.1.0
 requests==2.34.2
 httpx==0.28.1
+# Security pins: force patched transitive dependencies across both images.
+# urllib3 (via requests/httpx): CVE-2026-44431 (sensitive header leak on
+#   cross-origin redirect), CVE-2026-44432 (DoS via response decompression).
+# pillow (via reportlab in the api image; matplotlib/fastembed in the worker):
+#   CVE-2026-40192 (FITS decompression-bomb DoS), CVE-2026-42311.
+urllib3==2.7.0
+pillow==12.2.0
 alembic==1.18.4
 pgvector==0.4.2


### PR DESCRIPTION
## Description

Clears the Trivy CRITICAL/HIGH findings that block the v1.3.9 release gate across all three published images, and documents how to validate images locally before cutting a tag. No application behaviour changes.

Image fixes:
- **Worker (PyTorch/Ubuntu 24.04 base):**
  - Patch the base OpenSSL in place against `CVE-2026-45447` (PKCS7_verify UAF) via a targeted `apt --only-upgrade openssl libssl3t64`.
  - Remove the base image's `uv`/`uvx` binaries (the worker runs Celery, never `uv`), eliminating the bundled `rustls-webpki` finding (`GHSA-82j2-j2ch-gfr8`).
  - Upgrade the base **system** Python's `pillow`/`urllib3` in place. The venv uses `--system-site-packages`, so the base's pre-installed `dist-packages` copies stayed vulnerable on disk even after the `requirements/` pins.
- **Shared Python (api + worker):** pin `urllib3==2.7.0` (`CVE-2026-44431`, `CVE-2026-44432`) and `pillow==12.2.0` (`CVE-2026-40192`, `CVE-2026-42311`) in `requirements/base.txt`. `pillow` enters the api via `reportlab`, so the pin belongs in the shared file, not `worker.txt`.
- **`.trivyignore`:** documented, dated exceptions for the inherited `linux-libc-dev` kernel-header CVEs (kernel headers, not the running kernel; containers share the host kernel). Review by 2026-09-24.
- **`.dockerignore`:** exclude TLS key/cert material (`**/*.key` etc.) so locally generated files (e.g. `nginx/cert.key` from `docker/init-ssl.sh`) cannot leak into a local build context. Audit confirms no cert/key has ever been committed to git history.

Docs: new "Validating Images Locally Before Cutting a Tag" section in `docs/DEVELOPMENT.md`.

Fixes # (n/a — unblocks the v1.3.9 release)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [ ] Backend tests (run by CI — `requirements/**` + `docker/**` paths trigger the backend suite)
- [ ] Python quality (run by CI)
- [ ] Frontend lint / unit tests / build (run by CI — deployment paths trigger the frontend suite)
- [x] Docs validation: `python3 scripts/validate_docs.py` (22 files, links resolve)
- [x] Alembic validation: not applicable (no migration)
- [x] **Local Trivy gate** (same flags as `release.yml`: `--severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore --exit-code 1`) on all three images built as CI builds them: **api, worker, frontend all exit 0.**

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR (`docs/DEVELOPMENT.md`).

## Security impact

- [x] Touches the image vulnerability posture and `.trivyignore` accepted-exception set. Documented exceptions are limited to non-exploitable kernel-header CVEs with a review-by date; `.dockerignore` hardened against key/cert leakage; git history audited — no private key ever committed.

## Manual verification

Built each image exactly as `release.yml` does and ran the Trivy gate locally:
- api (`python:3.14-slim`): OS 0, Python 0, no secret (cert excluded) — gate exit 0.
- frontend (`node:26-alpine`): gate exit 0 (npm/undici removed previously).
- worker (PyTorch/CUDA): OS 0; venv and system `pillow`/`urllib3` both patched — gate exit 0.
