### PR TITLE
fix(deploy): own the bind-mounted data dir so non-root api/worker can start on a fresh install

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -86,6 +86,23 @@ services:
       - nojoin_net
     logging: *default-logging
 
+  init-perms:
+    container_name: nojoin-init-perms
+    image: busybox:stable
+    # One-shot, root-only: the api and worker run as non-root (uid 1000), but
+    # Docker creates a missing bind-mount source (./data) as root on first start,
+    # which would stop those containers from creating their data subdirectories.
+    # Ensure the data and recordings directories exist and are owned by uid 1000
+    # before the app services boot. This runs to completion and exits.
+    user: "0:0"
+    command: ["sh", "-c", "mkdir -p /app/data/recordings && chown -R 1000:1000 /app/data"]
+    volumes:
+      - ./data:/app/data
+    restart: "no"
+    networks:
+      - nojoin_net
+    logging: *default-logging
+
   api:
     container_name: nojoin-api
     image: ghcr.io/valtora/nojoin-api:latest
@@ -103,6 +120,8 @@ services:
       HF_HOME: /shared_model_cache/huggingface
       NOJOIN_TRUSTED_PROXIES: ${NOJOIN_TRUSTED_PROXIES:-127.0.0.1,::1,nginx}
     depends_on:
+      init-perms:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       redis:
@@ -155,6 +174,8 @@ services:
               count: 1
               capabilities: [gpu]
     depends_on:
+      init-perms:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       redis:


### PR DESCRIPTION
## Description

The `Image health & non-root smoke` job — new in v1.3.9 — caught that a fresh `docker compose up` leaves the bind-mounted `./data` directory owned by root (Docker creates a missing bind-mount source as root). The api and worker run as non-root (uid 1000), so `path_manager.ensure_directories_exist()` fails fatally at startup creating `/app/data/logs`:

```
PermissionError: [Errno 13] Permission denied: '/app/data/logs'
```

This affects any fresh first-run install on rootful/Linux Docker, not just CI — v1.3.8 never ran the smoke gate, so it was latent until now.

**Fix:** add a one-shot root `init-perms` service that ensures `./data` (and `./data/recordings`) exist and are owned by uid 1000 before the app services boot. The api and worker gain `depends_on: { init-perms: { condition: service_completed_successfully } }`. The app containers remain non-root; only the short-lived init container runs as root, and it is not one of the containers the smoke asserts non-root.

Fixes the v1.3.9 release `Image health & non-root smoke` failure.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checks run

- [x] `docker compose -f docker-compose.example.yml config` validates (YAML + depends_on merge).
- [x] Local reproduction of the smoke against the built api image (entrypoint bypassed to isolate the failing call):
  - Root-owned `/app/data` → `PermissionError: '/app/data/logs'` (reproduces the failure).
  - After the `init-perms` chown → `ensure_directories_exist` succeeds as uid 1000; `logs/` and `recordings/` created and owned by 1000.
- [ ] Backend/frontend suites run by CI (deployment-path change triggers both). The `Image health & non-root smoke` job itself only runs on a tag push, so it re-validates when v1.3.9 is re-cut after merge.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required. The new service carries an inline comment explaining its purpose; the data directory layout is unchanged (bind mount preserved for host access).

## Security impact

- [x] The `init-perms` container runs as root solely to `chown` the data directory, then exits. The api, worker, and frontend remain non-root, so the release's non-root assertion still holds.

## Manual verification

Reproduced the exact `Image health & non-root smoke` failure locally and confirmed the init service resolves it (before/after above), using the api image built as the release pipeline builds it.
