### PR TITLE
ci(release): render categorised, human-readable release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -562,10 +562,11 @@ jobs:
             echo "No previous tag found; using full history."
           fi
 
-          git log --no-merges --pretty=format:'- %s (%h)' "${range}" > changelog.txt
-          if [[ ! -s changelog.txt ]]; then
-            echo "- No notable changes." > changelog.txt
-          fi
+          # Render a categorised, human-readable changelog (grouped by Conventional
+          # Commit type, with internal churn folded away). The script emits a
+          # "No notable changes." line for an empty range, so the release never
+          # fails on changelog generation.
+          python3 scripts/render_release_notes.py "${range}" > changelog.txt
 
           # Resolve the published image digests for reproducible-pin guidance.
           : > image-digests.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -566,7 +566,17 @@ jobs:
           # Commit type, with internal churn folded away). The script emits a
           # "No notable changes." line for an empty range, so the release never
           # fails on changelog generation.
-          python3 scripts/render_release_notes.py "${range}" > changelog.txt
+          #
+          # The checkout is the release ref, so a workflow_dispatch backfill of a
+          # tag cut before this script existed will not contain it. Fall back to a
+          # flat commit list in that case rather than failing the notes job after
+          # the rolling image tags have already published.
+          if [[ -f scripts/render_release_notes.py ]]; then
+            python3 scripts/render_release_notes.py "${range}" > changelog.txt
+          else
+            git log --no-merges --pretty=format:'- %s (%h)' "${range}" > changelog.txt
+            [[ -s changelog.txt ]] || echo "- No notable changes." > changelog.txt
+          fi
 
           # Resolve the published image digests for reproducible-pin guidance.
           : > image-digests.txt

--- a/scripts/render_release_notes.py
+++ b/scripts/render_release_notes.py
@@ -36,7 +36,11 @@ OTHER = "Other changes"
 _SUBJECT = re.compile(
     r"^(?P<type>\w+)(?:\((?P<scope>[^)]*)\))?(?P<bang>!)?:\s*(?P<msg>.*)$"
 )
-_SECURITY_HINT = re.compile(r"CVE-\d|GHSA-", re.IGNORECASE)
+# Security markers used across this repo's history: CVE/GHSA advisory ids and the
+# internal SEC-NNN issue tags. The `\b` guards against matching inside words
+# (e.g. "msec-5"). The `sec` and `security` commit scopes are handled separately.
+_SECURITY_HINT = re.compile(r"\b(?:CVE-\d|GHSA-|SEC-\d)", re.IGNORECASE)
+_SECURITY_SCOPES = {"security", "sec"}
 
 
 def _commits(rng: str) -> list[tuple[str, str]]:
@@ -92,7 +96,7 @@ def _section_for(typ: str | None, scope: str | None, bang: bool, subject: str) -
     """
     if bang:
         return BREAKING
-    if scope == "security" or _SECURITY_HINT.search(subject):
+    if scope in _SECURITY_SCOPES or _SECURITY_HINT.search(subject):
         return SECURITY
     if scope == "maintenance":
         return OTHER

--- a/scripts/render_release_notes.py
+++ b/scripts/render_release_notes.py
@@ -55,40 +55,61 @@ def _commits(rng: str) -> list[tuple[str, str]]:
     return rows
 
 
+def _summarise(message: str) -> str:
+    """Keep only the headline summary, dropping any ` — detail` tail.
+
+    Conventional Commit subjects in this repo put a short summary before an
+    em-dash and the rationale after it; the release notes only need the summary.
+    """
+    return message.split("—", 1)[0].strip()
+
+
 def _format_entry(short: str, scope: str | None, message: str, raw_subject: str) -> str:
-    body = message or raw_subject
+    body = _summarise(message) or raw_subject
     body = body[:1].upper() + body[1:] if body else raw_subject
     prefix = f"**{scope}:** " if scope else ""
     return f"- {prefix}{body} (`{short}`)"
 
 
+def _parse(subject: str) -> tuple[str | None, str | None, bool, str]:
+    """Return (type, scope, is_breaking, message) for a commit subject."""
+    match = _SUBJECT.match(subject)
+    if not match:
+        return None, None, False, subject
+    return (
+        match.group("type").lower(),
+        match.group("scope"),
+        bool(match.group("bang")),
+        match.group("msg"),
+    )
+
+
+def _section_for(typ: str | None, scope: str | None, bang: bool, subject: str) -> str:
+    """Pick the changelog section a commit belongs in.
+
+    Breaking changes and security fixes win over type; `maintenance`-scoped
+    tracker churn is folded into the collapsed block.
+    """
+    if bang:
+        return BREAKING
+    if scope == "security" or _SECURITY_HINT.search(subject):
+        return SECURITY
+    if scope == "maintenance":
+        return OTHER
+    for name, types in TYPE_SECTIONS:
+        if typ in types:
+            return name
+    return OTHER
+
+
 def render(rng: str) -> str:
-    buckets: dict[str, list[str]] = {BREAKING: [], SECURITY: []}
-    for name, _ in TYPE_SECTIONS:
-        buckets[name] = []
-    buckets[OTHER] = []
+    names = [BREAKING, SECURITY, *(n for n, _ in TYPE_SECTIONS), OTHER]
+    buckets: dict[str, list[str]] = {name: [] for name in names}
 
     for short, subject in _commits(rng):
-        match = _SUBJECT.match(subject)
-        typ = match.group("type").lower() if match else None
-        scope = match.group("scope") if match else None
-        bang = bool(match.group("bang")) if match else False
-        message = match.group("msg") if match else subject
-
+        typ, scope, bang, message = _parse(subject)
         entry = _format_entry(short, scope, message, subject)
-
-        if bang:
-            buckets[BREAKING].append(entry)
-            continue
-        if scope == "security" or _SECURITY_HINT.search(subject):
-            buckets[SECURITY].append(entry)
-            continue
-        for name, types in TYPE_SECTIONS:
-            if typ in types:
-                buckets[name].append(entry)
-                break
-        else:
-            buckets[OTHER].append(entry)
+        buckets[_section_for(typ, scope, bang, subject)].append(entry)
 
     parts: list[str] = []
     for name in [BREAKING, SECURITY] + [n for n, _ in TYPE_SECTIONS]:

--- a/scripts/render_release_notes.py
+++ b/scripts/render_release_notes.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Render a categorised, human-readable changelog for a git revision range.
+
+Used by the `publish-release-notes` job in `.github/workflows/release.yml` to fill
+the `{{CHANGELOG}}` placeholder in `.github/release-notes-template.md`. Commits are
+grouped by their Conventional Commit type into readable sections; noisy internal
+churn (chore/refactor/test/ci/build/style and anything non-conventional) is folded
+into a collapsed "Other changes" block so the headline sections stay scannable.
+
+Usage:
+    python3 scripts/render_release_notes.py <git-range>      # e.g. v1.3.8..v1.3.9
+    python3 scripts/render_release_notes.py <single-ref>     # full history up to ref
+
+Prints the changelog markdown to stdout. Never fails the release on an empty range:
+it emits a "No notable changes." line instead.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# Section title -> the Conventional Commit types that map into it, in display order.
+# Breaking Changes and Security are routed by heuristics below, not by type.
+TYPE_SECTIONS: list[tuple[str, set[str]]] = [
+    ("New Features", {"feat"}),
+    ("Bug Fixes", {"fix"}),
+    ("Performance", {"perf"}),
+    ("Documentation", {"docs"}),
+]
+BREAKING = "Breaking Changes"
+SECURITY = "Security"
+OTHER = "Other changes"
+
+_SUBJECT = re.compile(
+    r"^(?P<type>\w+)(?:\((?P<scope>[^)]*)\))?(?P<bang>!)?:\s*(?P<msg>.*)$"
+)
+_SECURITY_HINT = re.compile(r"CVE-\d|GHSA-", re.IGNORECASE)
+
+
+def _commits(rng: str) -> list[tuple[str, str]]:
+    """Return [(short_hash, subject)] for non-merge commits in the range."""
+    result = subprocess.run(
+        ["git", "log", "--no-merges", "--pretty=format:%h\x1f%s", rng],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    rows: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        if "\x1f" in line:
+            short, subject = line.split("\x1f", 1)
+            rows.append((short, subject))
+    return rows
+
+
+def _format_entry(short: str, scope: str | None, message: str, raw_subject: str) -> str:
+    body = message or raw_subject
+    body = body[:1].upper() + body[1:] if body else raw_subject
+    prefix = f"**{scope}:** " if scope else ""
+    return f"- {prefix}{body} (`{short}`)"
+
+
+def render(rng: str) -> str:
+    buckets: dict[str, list[str]] = {BREAKING: [], SECURITY: []}
+    for name, _ in TYPE_SECTIONS:
+        buckets[name] = []
+    buckets[OTHER] = []
+
+    for short, subject in _commits(rng):
+        match = _SUBJECT.match(subject)
+        typ = match.group("type").lower() if match else None
+        scope = match.group("scope") if match else None
+        bang = bool(match.group("bang")) if match else False
+        message = match.group("msg") if match else subject
+
+        entry = _format_entry(short, scope, message, subject)
+
+        if bang:
+            buckets[BREAKING].append(entry)
+            continue
+        if scope == "security" or _SECURITY_HINT.search(subject):
+            buckets[SECURITY].append(entry)
+            continue
+        for name, types in TYPE_SECTIONS:
+            if typ in types:
+                buckets[name].append(entry)
+                break
+        else:
+            buckets[OTHER].append(entry)
+
+    parts: list[str] = []
+    for name in [BREAKING, SECURITY] + [n for n, _ in TYPE_SECTIONS]:
+        if buckets[name]:
+            parts.append(f"#### {name}\n\n" + "\n".join(buckets[name]))
+    if buckets[OTHER]:
+        parts.append(
+            f"<details>\n<summary>{OTHER} ({len(buckets[OTHER])})</summary>\n\n"
+            + "\n".join(buckets[OTHER])
+            + "\n</details>"
+        )
+
+    return "\n\n".join(parts) if parts else "- No notable changes."
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: render_release_notes.py <git-range>", file=sys.stderr)
+        return 2
+    print(render(sys.argv[1]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

The auto-published GitHub Release notes rendered `{{CHANGELOG}}` as a flat `git log` dump of every commit subject (91 lines for v1.3.9) — not human-readable.

This replaces that with a committed `scripts/render_release_notes.py` that groups commits by Conventional Commit type into readable sections (Breaking Changes, Security, New Features, Bug Fixes, Performance, Documentation) and folds internal churn (chore/refactor/test/ci/build/style and non-conventional commits) into a collapsed `<details>` block. Security routing also catches `*(security)`-scoped commits and any subject mentioning a CVE/GHSA. Output uses `####` headers so it nests under the template's existing `### Changes` heading.

`.github/workflows/release.yml` now calls the script for `{{CHANGELOG}}`; nothing else in the release pipeline changes — action SHA pins, base-image digests, and the gated job graph are untouched.

Fixes the unreadable auto-published release-notes format.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checks run

- [x] `python3 -m py_compile` + Ruff lint (`All checks passed!`) and Ruff format check on the new script.
- [x] `release.yml` parses as valid YAML; diff limited to the changelog command (pins/job graph unchanged).
- [x] Rendered the v1.3.8..v1.3.9 range and the empty-range edge case (`- No notable changes.`) locally.
- [ ] Backend/frontend suites run by CI (scripts/ + workflow paths trigger them).

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required. (The release-notes mechanism is described in `docs/DEVELOPMENT.md` REL-013/014; behaviour — categorised vs flat — is the only change, and the script is self-documented.)

## Security impact

- [x] No security-sensitive change. The release workflow's pinned actions, base-image digests, and gated publication ordering are unchanged; only the changelog text generation differs.

## Manual verification

Ran `scripts/render_release_notes.py v1.3.8..v1.3.9` and confirmed it produces categorised sections with the internal churn folded into a collapsed block, and `v1.3.9..v1.3.9` produces the empty-range fallback.
