### PR TITLE
ci: narrow test gating so scripts and non-CI workflow changes don't run the full suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      scripts: ${{ steps.filter.outputs.scripts }}
       deployment: ${{ steps.filter.outputs.deployment }}
 
     steps:
@@ -35,26 +36,31 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          # `deployment` covers infrastructure that the backend/frontend code
-          # filters do not (Dockerfiles, compose, nginx, and any workflow). A
-          # change to those runs the full backend and frontend suite, matching
-          # the deployment/release verification policy in CONTRIBUTING.md and
-          # ensuring a deployment-only PR is never validated by the cheap
-          # validators alone. Workflow changes land here too, so editing this
-          # file exercises everything.
+          # `deployment` covers infrastructure the code filters do not: Dockerfiles,
+          # compose, and nginx affect the built images, so a change runs the full
+          # backend and frontend suite. Only this CI workflow is included from
+          # `.github/workflows/` — it defines the suites, so editing it must
+          # re-exercise everything. Other workflows (e.g. the tag-driven release
+          # pipeline) cannot be validated by the unit suites and run on their own
+          # triggers, so they are not gated here.
+          #
+          # `scripts` runs only the Python quality gate (lint, format, mypy, and the
+          # validators) — not the full pytest suite — since scripts/ are standalone
+          # tooling the backend tests do not import.
           filters: |
             backend:
               - 'backend/**'
               - 'requirements/**'
               - 'pyproject.toml'
-              - 'scripts/**'
             frontend:
               - 'frontend/**'
+            scripts:
+              - 'scripts/**'
             deployment:
               - 'docker/**'
               - 'docker-compose*.yml'
               - 'nginx/**'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
 
   backend-tests:
     name: Backend tests
@@ -84,7 +90,7 @@ jobs:
   python-quality:
     name: Python quality
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.deployment == 'true'
+    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.scripts == 'true' || needs.detect-changes.outputs.deployment == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,11 @@ Minimum pull request verification is:
 
 The pull request workflow runs these checks, and the aggregate `CI gate` must be green to merge. The expensive jobs run only when their area changed; the cheap validators always run:
 
-- `Backend tests` and `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) — on backend or deployment changes.
+- `Backend tests` — on backend or deployment changes. `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) also runs on `scripts/**` changes, since it lints and type-checks the standalone tooling there.
 - `Frontend lint`, `Frontend unit tests`, and `Frontend build` — on frontend or deployment changes.
 - `Docs validation` and `Alembic validation` — always.
+
+A deployment change here means `docker/**`, `docker-compose*.yml`, `nginx/**`, or `.github/workflows/ci.yml`. Other workflow files (e.g. the tag-driven release pipeline) are not gated by the unit suites — they cannot be validated by them and run on their own triggers — though they remain a sensitive review scope (see below).
 
 See the [Merge Requirements](#merge-requirements) section for how `CI gate` aggregates these and the exact path rules.
 
@@ -148,7 +150,7 @@ Every pull request to `main` must have the required `CI gate` status check green
 
 - `Backend tests` and `Python quality` (Ruff lint, Ruff format check, mypy) — run when `backend/**`, `requirements/**`, `pyproject.toml`, or `scripts/**` changed.
 - `Frontend lint`, `Frontend unit tests`, and `Frontend build` — run when `frontend/**` changed.
-- A **deployment** change (`docker/**`, `docker-compose*.yml`, `nginx/**`, or `.github/workflows/**`) runs **both** the backend and frontend suites, since it can affect the built images or pipeline even without code changes. This is consistent with the deployment/release sensitive-scope rule below.
+- A **deployment** change (`docker/**`, `docker-compose*.yml`, `nginx/**`, or `.github/workflows/ci.yml`) runs **both** the backend and frontend suites, since it can affect the built images or the test pipeline even without code changes. Other workflow files (such as the release pipeline) are not gated by the unit suites — they run on their own triggers — but remain a sensitive review scope (see below). A `scripts/**` change runs `Python quality` only.
 - `Whitespace check`, `Docs validation`, and `Alembic validation` — always run (cheap). `Whitespace check` is the only trailing-whitespace guard for Markdown, YAML, shell, and config files, so it is never gated.
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#required-pull-request-checks) for the exact path rules and how `CI gate` works.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,8 +64,8 @@ The `CI` workflow runs these checks on pull requests and on pushes to `main`. To
 
 | Check | Runs when |
 | --- | --- |
-| `Backend tests` | `backend/**`, `requirements/**`, `pyproject.toml`, `scripts/**`, or a deployment path changed |
-| `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) | same as `Backend tests` |
+| `Backend tests` | `backend/**`, `requirements/**`, `pyproject.toml`, or a deployment path changed |
+| `Python quality` (Ruff lint, Ruff format check, and mypy on enforced boundaries) | as `Backend tests`, plus `scripts/**` |
 | `Frontend lint` | `frontend/**` or a deployment path changed |
 | `Frontend unit tests` | same as `Frontend lint` |
 | `Frontend build` | same as `Frontend lint` |
@@ -73,7 +73,7 @@ The `CI` workflow runs these checks on pull requests and on pushes to `main`. To
 | `Docs validation` | always |
 | `Alembic validation` | always |
 
-A `detect-changes` job (using `dorny/paths-filter`) classifies the diff into `backend`, `frontend`, and `deployment`. The deployment filter — `docker/**`, `docker-compose*.yml`, `nginx/**`, and `.github/workflows/**` — runs **both** the backend and frontend suites, because a Dockerfile, compose, nginx, or workflow change can break the built images or pipeline even when no application code changed; this also keeps CI consistent with the deployment/release verification policy in [CONTRIBUTING.md](../CONTRIBUTING.md#merge-requirements). Each heavy job gates on these outputs; a job that does not apply is **skipped**, not run. The single required status check is **`CI gate`**, an aggregate job that depends on all of the above and passes only when none of them failed — treating a skipped job as a pass. Because `CI gate` always reports a status, a documentation-only pull request (which skips the backend and frontend jobs) is never left waiting on a check that never runs. This is why branch protection requires `CI gate` rather than the individual job names.
+A `detect-changes` job (using `dorny/paths-filter`) classifies the diff into `backend`, `frontend`, `scripts`, and `deployment`. The deployment filter — `docker/**`, `docker-compose*.yml`, `nginx/**`, and `.github/workflows/ci.yml` — runs **both** the backend and frontend suites, because a Dockerfile, compose, nginx, or CI-workflow change can break the built images or the test pipeline even when no application code changed; this also keeps CI consistent with the deployment/release verification policy in [CONTRIBUTING.md](../CONTRIBUTING.md#merge-requirements). Only `ci.yml` is included from `.github/workflows/`: it defines the suites, so editing it must re-exercise them. Other workflows (such as the tag-driven [release pipeline](#release-workflow-and-version-detection)) cannot be validated by the unit suites and run on their own triggers — the release pipeline re-runs the full validation set on every tag push — so a change to them is not gated here and runs only the always-on validators. The `scripts` filter runs the `Python quality` job (which lints and type-checks scripts and runs the validators) without the full `Backend tests` suite, since the standalone tooling under `scripts/` is not imported by the backend tests. Each heavy job gates on these outputs; a job that does not apply is **skipped**, not run. The single required status check is **`CI gate`**, an aggregate job that depends on all of the above and passes only when none of them failed — treating a skipped job as a pass. Because `CI gate` always reports a status, a documentation-only pull request (which skips the backend and frontend jobs) is never left waiting on a check that never runs. This is why branch protection requires `CI gate` rather than the individual job names.
 
 Local equivalents:
 


### PR DESCRIPTION
## Description

Reduces CI over-triggering so simple changes don't run the full backend and frontend suites:

- **`scripts/**` no longer triggers `Backend tests`.** It moves to a new `scripts` filter that runs `Python quality` only (Ruff lint/format + mypy + validators already lint `scripts/`). The standalone tooling under `scripts/` is not imported by pytest, so running the full backend suite for it was wasted work.
- **Only `.github/workflows/ci.yml` triggers the suites**, not all of `.github/workflows/**`. `ci.yml` defines the suites, so editing it must re-exercise them; other workflows (e.g. the tag-driven release pipeline) cannot be validated by unit suites and run on their own triggers — the release pipeline already re-runs the full validation set on every tag push.

`docker/**`, `docker-compose*.yml`, and `nginx/**` still run both suites (real built-image impact). The non-CI workflows remain a sensitive review scope (pinned SHAs, gated ordering) per CONTRIBUTING.md — only the *test gating* is narrowed, not the review obligation.

Effect: a release-notes/script or `release.yml` change now runs only `Python quality` (for scripts) and the always-on validators, instead of the entire backend + frontend pipeline.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checks run

- [x] `ci.yml` and the new filter/output/`if` parse as valid YAML; expression names are hyphen-free (`scripts`) to avoid GitHub expression-parsing issues.
- [x] `Docs validation` passes (22 files, links resolve), including the new anchor link.
- [x] This PR edits `ci.yml`, so the deployment path runs the full backend + frontend suites here — the change validates itself.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated `docs/DEVELOPMENT.md` (Required Pull Request Checks table + detect-changes paragraph) and `CONTRIBUTING.md` (merge-requirements) to match. The sensitive-scope review rule still lists all `.github/workflows/**`.

## Security impact

- [x] No security-sensitive change. Pinned action SHAs, base-image digests, and the gated/signed release ordering are untouched; non-CI workflows remain a documented sensitive review scope.

## Manual verification

Traced each scenario: backend change → backend tests + quality; `scripts/**` → quality only; `release.yml` → always-on validators only; `ci.yml` or `docker/**` → full suites.
