### PR TITLE
feat(frontend): redesign sidebar tag hierarchy with tree guide rails and persistent disclosure

### DIFF
--- a/frontend/src/components/MainNav.tsx
+++ b/frontend/src/components/MainNav.tsx
@@ -171,32 +171,46 @@ export default function MainNav() {
     setMobileNavOpen(false);
   }, [pathname, setMobileNavOpen]);
 
-  const renderTagTree = (nodes: TagWithChildren[], level = 0) => {
-    return nodes.map((node) => (
-      <React.Fragment key={node.id}>
-        <TagItem
-          tag={node}
-          isSelected={selectedTagIds.includes(node.id)}
-          onToggle={() => toggleTagFilter(node.id)}
-          onColorChange={(color) => handleColorChange(node.id, color)}
-          onDelete={() => handleDeleteTag(node.id)}
-          onRename={(name) => handleRenameTag(node.id, name)}
-          onAddChild={() => handleAddSubTag(node.id)}
-          onContextMenu={(e) => handleContextMenu(e, node.id)}
-          isEditing={editingTagId === node.id}
-          onStartEdit={() => setEditingTagId(node.id)}
-          onCancelEdit={() => setEditingTagId(null)}
-          collapsed={isNavCollapsed}
-          level={level}
-          hasChildren={node.children.length > 0}
-          isExpanded={expandedTagIds.has(node.id)}
-          onToggleExpand={() => toggleExpandedTag(node.id)}
-        />
-        {node.children.length > 0 &&
-          expandedTagIds.has(node.id) &&
-          renderTagTree(node.children, level + 1)}
-      </React.Fragment>
-    ));
+  // `parentLines` carries the tree-guide flags from the ancestors down to these
+  // nodes (see TagItem's TagGuides). Roots receive `null` and render no guides;
+  // each child appends its own "has sibling below" flag so the parent's
+  // connector becomes the child's ancestor rail.
+  const renderTagTree = (
+    nodes: TagWithChildren[],
+    parentLines: boolean[] | null = null,
+  ) => {
+    return nodes.map((node, index) => {
+      const hasSiblingBelow = index < nodes.length - 1;
+      const lines = parentLines === null ? [] : [...parentLines, hasSiblingBelow];
+      return (
+        <React.Fragment key={node.id}>
+          <TagItem
+            tag={node}
+            isSelected={selectedTagIds.includes(node.id)}
+            onToggle={() => toggleTagFilter(node.id)}
+            onColorChange={(color) => handleColorChange(node.id, color)}
+            onDelete={() => handleDeleteTag(node.id)}
+            onRename={(name) => handleRenameTag(node.id, name)}
+            onAddChild={() => handleAddSubTag(node.id)}
+            onContextMenu={(e) => handleContextMenu(e, node.id)}
+            isEditing={editingTagId === node.id}
+            onStartEdit={() => setEditingTagId(node.id)}
+            onCancelEdit={() => setEditingTagId(null)}
+            collapsed={isNavCollapsed}
+            lines={lines}
+            hasChildren={node.children.length > 0}
+            childCount={node.children.length}
+            isExpanded={expandedTagIds.has(node.id)}
+            onToggleExpand={() => toggleExpandedTag(node.id)}
+          />
+          {/* Collapsed sidebar shows root tags only, so stop recursing. */}
+          {!isNavCollapsed &&
+            node.children.length > 0 &&
+            expandedTagIds.has(node.id) &&
+            renderTagTree(node.children, lines)}
+        </React.Fragment>
+      );
+    });
   };
 
   const handleImportSuccess = () => {

--- a/frontend/src/components/MainNav.tsx
+++ b/frontend/src/components/MainNav.tsx
@@ -175,6 +175,12 @@ export default function MainNav() {
   // nodes (see TagItem's TagGuides). Roots receive `null` and render no guides;
   // each child appends its own "has sibling below" flag so the parent's
   // connector becomes the child's ancestor rail.
+  // Effective collapsed state: the persisted flag only applies on desktop, and
+  // we fall back to expanded until mounted to avoid a hydration mismatch. The
+  // tag tree must key off this (not the raw store value) so the mobile sidebar,
+  // which is always expanded, still renders sub-tags.
+  const collapsed = mounted ? (isDesktop ? isNavCollapsed : false) : false;
+
   const renderTagTree = (
     nodes: TagWithChildren[],
     parentLines: boolean[] | null = null,
@@ -196,7 +202,7 @@ export default function MainNav() {
             isEditing={editingTagId === node.id}
             onStartEdit={() => setEditingTagId(node.id)}
             onCancelEdit={() => setEditingTagId(null)}
-            collapsed={isNavCollapsed}
+            collapsed={collapsed}
             lines={lines}
             hasChildren={node.children.length > 0}
             childCount={node.children.length}
@@ -204,7 +210,7 @@ export default function MainNav() {
             onToggleExpand={() => toggleExpandedTag(node.id)}
           />
           {/* Collapsed sidebar shows root tags only, so stop recursing. */}
-          {!isNavCollapsed &&
+          {!collapsed &&
             node.children.length > 0 &&
             expandedTagIds.has(node.id) &&
             renderTagTree(node.children, lines)}
@@ -217,8 +223,6 @@ export default function MainNav() {
     window.dispatchEvent(new CustomEvent("recording-updated"));
   };
 
-  // Prevent hydration mismatch by using default state until mounted
-  const collapsed = mounted ? (isDesktop ? isNavCollapsed : false) : false;
   const isDashboardRoute = pathname === "/";
   const isTasksRoute = pathname === "/tasks";
   const isRecordingsRoute =

--- a/frontend/src/components/mainNav/TagItem.tsx
+++ b/frontend/src/components/mainNav/TagItem.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ChevronDown, ChevronRight, Plus, X } from "lucide-react";
+import { ChevronRight, Plus, X } from "lucide-react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 
@@ -7,6 +7,58 @@ import { getColorByKey } from "@/lib/constants";
 import { Tag } from "@/types";
 
 import { InlineColorPicker } from "../ColorPicker";
+
+// Horizontal space (px) reserved for each level of tag nesting. Each level draws
+// one guide column of this width, so the indent and the rails stay in lock-step.
+const INDENT = 18;
+
+const RAIL_CLASS = "bg-gray-300 dark:bg-gray-700";
+
+/**
+ * Renders the tree guide lines for a tag row.
+ *
+ * `lines[i]` answers "does the node that owns column i have a sibling below it?".
+ * The last entry is this node's own connector: when true the elbow continues
+ * downward to the next sibling (a "tee"), when false it stops at the row's
+ * midpoint (an "ell"), so a branch's rail ends at its last child. Root rows pass
+ * an empty array and therefore draw no guides.
+ */
+function TagGuides({ lines }: { lines: boolean[] }) {
+  if (lines.length === 0) return null;
+  const lastIndex = lines.length - 1;
+
+  return (
+    <div
+      className="flex shrink-0 self-stretch pointer-events-none"
+      aria-hidden="true"
+    >
+      {lines.map((hasSiblingBelow, i) => {
+        const isElbow = i === lastIndex;
+        return (
+          <div key={i} className="relative" style={{ width: INDENT }}>
+            {/* Ancestor rail: a continuous vertical line when this ancestor has
+                more siblings below the current branch. */}
+            {!isElbow && hasSiblingBelow && (
+              <span className={`absolute top-0 bottom-0 left-1/2 w-px ${RAIL_CLASS}`} />
+            )}
+            {isElbow && (
+              <>
+                {/* Down-stem from the parent into this row (top -> midpoint). */}
+                <span className={`absolute top-0 left-1/2 h-1/2 w-px ${RAIL_CLASS}`} />
+                {/* Continue the rail past this row only if a sibling follows. */}
+                {hasSiblingBelow && (
+                  <span className={`absolute top-1/2 bottom-0 left-1/2 w-px ${RAIL_CLASS}`} />
+                )}
+                {/* Elbow arm reaching toward the disclosure/colour slot. */}
+                <span className={`absolute top-1/2 left-1/2 right-0 h-px ${RAIL_CLASS}`} />
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 interface TagItemProps {
   tag: Tag;
@@ -21,8 +73,11 @@ interface TagItemProps {
   onStartEdit: () => void;
   onCancelEdit: () => void;
   collapsed: boolean;
-  level?: number;
+  /** Tree guide flags from root to this node; see {@link TagGuides}. */
+  lines: boolean[];
   hasChildren: boolean;
+  /** Number of direct children, shown as a badge when the sidebar is folded. */
+  childCount: number;
   isExpanded: boolean;
   onToggleExpand: () => void;
 }
@@ -40,8 +95,9 @@ export default function TagItem({
   onStartEdit,
   onCancelEdit,
   collapsed,
-  level = 0,
+  lines,
   hasChildren,
+  childCount,
   isExpanded,
   onToggleExpand,
 }: TagItemProps) {
@@ -88,13 +144,23 @@ export default function TagItem({
     return (
       <button
         onClick={onToggle}
-        title={tag.name}
+        title={hasChildren ? `${tag.name} (${childCount})` : tag.name}
         className={`
           w-full flex justify-center py-2 rounded-lg transition-all
           ${isSelected ? "bg-gray-100 dark:bg-gray-800" : "hover:bg-gray-50 dark:hover:bg-gray-800/50"}
         `}
       >
-        <span className={`w-3 h-3 rounded-full ${color.dot}`} />
+        <span className="relative inline-flex">
+          <span className={`w-3 h-3 rounded-full ${color.dot}`} />
+          {hasChildren && (
+            <span
+              className="absolute -top-1.5 -right-2 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-gray-200 px-1 text-[9px] font-medium leading-none text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+              title={`${childCount} sub-tag${childCount === 1 ? "" : "s"}`}
+            >
+              {childCount}
+            </span>
+          )}
+        </span>
       </button>
     );
   }
@@ -109,12 +175,31 @@ export default function TagItem({
         ${isDragging ? "opacity-50" : ""}
         ${isOver ? "bg-orange-50 dark:bg-orange-900/10 ring-2 ring-orange-400 dark:ring-orange-600" : ""}
       `}
-      style={{ paddingLeft: `${level * 12 + 12}px` }}
       onClick={() => {
         if (!isEditing) onToggle();
       }}
       onContextMenu={onContextMenu}
     >
+      <TagGuides lines={lines} />
+      {/* Reserved disclosure slot keeps colour dots aligned at every depth:
+          parents get a persistent chevron, leaves get an empty spacer. */}
+      {hasChildren ? (
+        <button
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            onToggleExpand();
+          }}
+          className="flex h-4 w-4 shrink-0 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+          title={isExpanded ? "Collapse" : "Expand"}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <ChevronRight
+            className={`w-3 h-3 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+          />
+        </button>
+      ) : (
+        <span className="h-4 w-4 shrink-0" aria-hidden="true" />
+      )}
       <InlineColorPicker
         selectedColor={tag.color || undefined}
         onColorSelect={onColorChange}
@@ -161,24 +246,6 @@ export default function TagItem({
           >
             <Plus className="w-3 h-3" />
           </button>
-
-          {hasChildren && (
-            <button
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation();
-                onToggleExpand();
-              }}
-              className="p-1 hover:text-gray-600 dark:hover:text-gray-300 transition-all"
-              title={isExpanded ? "Collapse" : "Expand"}
-              onPointerDown={(e) => e.stopPropagation()}
-            >
-              {isExpanded ? (
-                <ChevronDown className="w-3 h-3" />
-              ) : (
-                <ChevronRight className="w-3 h-3" />
-              )}
-            </button>
-          )}
 
           <button
             onClick={(e: React.MouseEvent) => {


### PR DESCRIPTION
## Description

Makes the sidebar tag hierarchy legible. Previously nesting was conveyed by left-padding alone and the expand/collapse chevron only appeared on hover, so depth and which tags are parents were both hard to read.

This change reworks the rendering in `MainNav.tsx` and `mainNav/TagItem.tsx`:

- **Tree guide lines** — vertical ancestor rails plus an elbow connector into each tag. A branch's rail stops at its last child. Implemented via a `TagGuides` helper driven by a `lines: boolean[]` array threaded through `renderTagTree`, where each entry means "the node owning this column has a sibling below it" and the final entry is the node's own connector. Indent is `18px` per level, sourced from the guide columns themselves (the inline `paddingLeft` was removed).
- **Persistent disclosure chevrons** — parent tags always show a chevron that rotates on expand; leaf rows reserve the same slot so colour dots align at every depth. The old hover-only chevron was removed.
- **Collapsed sidebar shows root tags only** — recursion stops while folded, and parents display a child-count badge that doubles as the has-children indicator.

All existing behaviour is preserved: dnd-kit drag-to-reparent, `InlineColorPicker`, inline rename, the tag context menu, and selection/filtering. The guide lines are `pointer-events-none` decorative siblings inside the existing draggable/droppable wrapper, so hit-testing and the `isOver` drop highlight are unaffected.

No new dependencies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [ ] Backend tests: `source .venv/bin/activate && pytest` — not completed locally (suite timed out after 8.5 min on this host; change is frontend-only with zero backend files touched). Relying on the CI `Backend tests` check.
- [ ] Python quality: `python scripts/check.py` — not run (no Python changes).
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (36 files, 164 tests passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Also ran `git diff --check` (clean).

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required.

## Security impact

- [x] No security-sensitive change.

## Manual verification

Browser smoke test passed:

- Expand/collapse a multi-level tag tree — rails are continuous, the elbow ends at each branch's last child, and the chevron rotates.
- Colour dots align across depths (leaf rows reserve the chevron slot).
- Folded sidebar shows root tags only, each parent showing a child-count badge.
- Drag-to-reparent, colour change, inline rename, context menu, and tag filtering all still work.

This area is not capture- or recording-context-menu-related, so those smoke sets do not apply.

## Screenshots (if relevant)

Available on request — can attach light/dark before-and-after captures.
