### PR TITLE
feat(recordings): one-step Discard for in-flight and processing recordings

### DIFF
--- a/backend/api/v1/endpoints/recordings/routes_actions.py
+++ b/backend/api/v1/endpoints/recordings/routes_actions.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import backend.api.v1.endpoints.recordings as recordings_module
 from backend.api.deps import get_current_user, get_db
 from backend.models.calendar import CalendarEvent
-from backend.models.recording import ClientStatus, RecordingStatus, RecordingUpdate
+from backend.models.recording import RecordingStatus, RecordingUpdate
 from backend.models.recording_public import RecordingPublicRead, serialize_recording
 from backend.models.user import User
 
@@ -296,45 +296,3 @@ async def infer_speakers_for_recording(
         "status": "queued",
         "message": "Speaker suggestion refresh started in background.",
     }
-
-
-@router.post("/{recording_id}/cancel", response_model=RecordingPublicRead)
-async def cancel_processing(
-    recording_id: str,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """
-    Cancel the processing task for a recording.
-    """
-    recording = await _get_owned_recording(db, recording_id, current_user.id)
-
-    if recording.status not in [
-        RecordingStatus.PROCESSING,
-        RecordingStatus.QUEUED,
-        RecordingStatus.UPLOADING,
-    ]:
-        raise HTTPException(status_code=400, detail="Recording is not being processed")
-
-    if recording.celery_task_id:
-        try:
-            recordings_module.celery_app.control.revoke(
-                recording.celery_task_id, terminate=True
-            )
-        except Exception:  # noqa: BLE001
-            pass
-
-    recording.celery_task_id = None
-    recording.status = RecordingStatus.CANCELLED
-    recording.client_status = ClientStatus.IDLE
-    recording.upload_progress = 0
-    recording.processing_step = "Cancelled by user"
-    recording.processing_progress = 0
-    recording.processing_started_at = None
-    recording.processing_completed_at = None
-
-    db.add(recording)
-    await db.commit()
-    await db.refresh(recording)
-
-    return serialize_recording(recording, has_proxy=_recording_has_proxy(recording))

--- a/backend/api/v1/endpoints/recordings/routes_capture.py
+++ b/backend/api/v1/endpoints/recordings/routes_capture.py
@@ -504,31 +504,58 @@ async def discard_upload(
     current_user: User = Depends(get_current_recording_client_user),
 ):
     """
-    Discard an in-flight recording before it is finalised.
+    Discard a recording that has not yet completed.
+
+    This is the single graceful "give up on this meeting" path. It accepts any
+    in-flight state: an active or paused live capture (``UPLOADING``/``PAUSED``),
+    a meeting waiting in the processing queue (``QUEUED``), or one whose
+    pipeline is actively running (``PROCESSING``). Whatever stage it is at, the
+    backend revokes any running Celery task, removes every on-disk artefact, and
+    deletes the recording row so no manual cancel-then-delete is required.
     """
     recording = await recordings_module._get_owned_recording(
         db, recording_id, current_user.id
     )
 
-    if recording.status not in {RecordingStatus.UPLOADING, RecordingStatus.PAUSED}:
+    discardable_states = {
+        RecordingStatus.UPLOADING,
+        RecordingStatus.PAUSED,
+        RecordingStatus.QUEUED,
+        RecordingStatus.PROCESSING,
+    }
+    if recording.status not in discardable_states:
         raise HTTPException(
             status_code=400,
-            detail="Only in-flight uploads can be discarded",
+            detail="Only in-flight or processing recordings can be discarded",
         )
 
     if reason:
         logger.info(
-            "Discarding in-flight recording %s for user %s with reason=%s",
+            "Discarding recording %s (status=%s) for user %s with reason=%s",
             recording.public_id,
+            recording.status.value,
             current_user.id,
             reason,
         )
     else:
         logger.info(
-            "Discarding in-flight recording %s for user %s",
+            "Discarding recording %s (status=%s) for user %s",
             recording.public_id,
+            recording.status.value,
             current_user.id,
         )
+
+    # Revoke any in-flight processing task first so the worker stops touching the
+    # recording before its row and files disappear. terminate=True sends SIGTERM
+    # to a task that is already running; a queued-but-not-started task is simply
+    # dropped. Mirrors the permanent-delete path in routes_actions.py.
+    if recording.celery_task_id:
+        try:
+            recordings_module.celery_app.control.revoke(
+                recording.celery_task_id, terminate=True
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     recordings_module.delete_recording_artifacts(
         recording_id=recording.id,

--- a/backend/tests/test_recording_pause_resume.py
+++ b/backend/tests/test_recording_pause_resume.py
@@ -627,6 +627,80 @@ async def test_discard_allows_paused_recordings_and_cleans_temp_dir(
 
 
 @pytest.mark.anyio
+async def test_discard_cancels_processing_recording_and_revokes_task(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A discard issued while the pipeline is running must revoke the Celery task
+    and remove the recording, so the user does not have to cancel then delete."""
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    revoked: list[tuple[str, bool]] = []
+
+    def fake_revoke(task_id, terminate=False, **kwargs):
+        revoked.append((task_id, terminate))
+
+    monkeypatch.setattr(recordings_module.celery_app.control, "revoke", fake_revoke)
+
+    await insert_recording(
+        test_session_maker,
+        recording_id=4242,
+        public_id="discard-processing",
+        status="PROCESSING",
+    )
+    async with test_session_maker() as session:
+        await session.execute(
+            text("UPDATE recordings SET celery_task_id = :tid WHERE id = :id"),
+            {"tid": "task-9", "id": 4242},
+        )
+        await session.commit()
+
+    set_session_cookie(client)
+
+    discard_response = await client.post(
+        "/api/v1/recordings/discard-processing/discard",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    assert discard_response.status_code == 200
+    assert discard_response.json() == {"ok": True}
+
+    # The running pipeline task is revoked with terminate=True before deletion.
+    assert revoked == [("task-9", True)]
+
+    async with test_session_maker() as session:
+        remaining = (
+            await session.execute(
+                text("SELECT COUNT(*) FROM recordings WHERE id = :id"),
+                {"id": 4242},
+            )
+        ).scalar_one()
+        assert remaining == 0
+
+
+@pytest.mark.anyio
+async def test_discard_rejects_completed_recording(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+) -> None:
+    """Terminal recordings are removed through the delete flow, not discard."""
+    await insert_recording(
+        test_session_maker,
+        recording_id=4343,
+        public_id="discard-completed",
+        status="PROCESSED",
+    )
+
+    set_session_cookie(client)
+
+    discard_response = await client.post(
+        "/api/v1/recordings/discard-completed/discard",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    assert discard_response.status_code == 400
+
+
+@pytest.mark.anyio
 async def test_get_recording_hides_in_flight_transcript_content(
     client: AsyncClient,
     test_session_maker: sessionmaker,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,8 @@ The normal backend processing path is:
 10. Automatic meeting intelligence when an AI provider and model are configured.
   11. Persistence of unresolved speaker suggestions, meeting title, and Markdown meeting notes.
 
+A user can discard a recording at any in-flight stage: uploading, paused, queued, or processing. Discard is a single graceful operation that revokes the running Celery task with `terminate=True`, deletes every on-disk artefact, and removes the recording row, so no manual cancel-then-delete sequence is required. Terminating the task stops the worker from continuing the pipeline, and the worker's start-of-task cancellation guard prevents a revoked-but-requeued task from resuming work. Terminal recordings (processed, errored, or already removed) are deleted through the standard delete flow instead.
+
 Per-user language preferences are resolved once through the shared backend language registry. The effective transcription language is propagated to live, catch-up, final, imported, and reprocessed ASR calls and included in ASR result hashes. Whisper receives an explicit language only when one is selected; Canary receives its supported source-language parameter; Parakeet remains multilingual auto-detection and therefore hashes as automatic language.
 
 Generated-content language is independent from source-audio language. Manual notes generation, unified automatic meeting intelligence, standalone title generation, and secondary-provider fallback receive the same resolved output-language instruction. Prompt control text and JSON keys remain stable, while titles and Markdown content can be localized. The automatic intelligence contract accepts any non-empty top-level Markdown heading rather than requiring the English `# Meeting Notes` heading.

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -104,14 +104,16 @@ If the share button is disabled, select a source first and confirm that any requ
 
 Chrome on Android and iOS can start recording from the same **Start Meeting** button, but it records only the phone microphone. It does not capture another mobile app, browser tab, headset output, or system audio. For best results, keep the meeting audio audible to the phone microphone, keep Nojoin visible, and prevent the phone from locking.
 
-## Pause, Resume, Stop, And Cancel
+## Pause, Resume, Stop, And Discard
 
 - **Pause** keeps uploaded segments and stops new segment capture until you resume.
 - **Resume** reopens the browser share picker and continues with the next 0-based segment sequence.
 - **Stop** finalizes the recording after all uploaded segments finish transcoding, then queues final processing.
-- **Cancel** discards an uploading or paused recording and clears the capture lock.
+- **Discard** permanently removes a recording in one step. It works for any recording that has not finished: uploading, paused, queued, or processing. Discard revokes any running processing task, releases the capture lock, deletes the captured audio and derived files, and removes the meeting. Nojoin asks you to confirm first because this cannot be undone.
 
-Closing the browser share picker with **Cancel** is different from using Nojoin's in-app **Cancel** action. Picker cancel simply backs out of starting or resuming capture without creating a visible error in the UI.
+Discard is available from the live recording controls, the floating recording badge, the resume-or-discard modal, and the recordings menu.
+
+Closing the browser share picker with **Cancel** is different from Nojoin's in-app **Discard** action. Picker cancel simply backs out of starting or resuming capture without creating a visible error in the UI, and never deletes an existing recording.
 
 If you are recording in a shared-audio capture mode and click the browser's native **Stop sharing** button (or close the sharing indicator), Nojoin automatically detects that the sharing stream has ended. It will immediately stop and finalise the recording, saving all audio captured up to that point, and display a notification informing you that screen sharing ended and the recording was saved.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -105,12 +105,14 @@ You can switch to another browser tab, window, or application while recording. N
 
 While a recording is active, a floating badge appears at the top-centre of the viewport on every page. The badge shows the recording status, elapsed time, and pause, resume, and stop controls. Clicking the badge navigates to the recording detail page. You can control the recording from any page without navigating back to the recording workspace first.
 
-### Pause, Resume, Stop, And Cancel
+### Pause, Resume, Stop, And Discard
 
 - **Pause** temporarily stops capture while preserving uploaded segments.
 - **Resume** opens the browser share picker again and continues the same recording.
 - **Stop** finalises the recording and starts processing.
-- **Cancel** discards an in-progress recording.
+- **Discard** permanently removes an in-progress recording in one step. It stops capture, cancels any processing, deletes the captured audio, and removes the meeting. Nojoin asks you to confirm first because this cannot be undone.
+
+Discard is available from the live recording controls, the floating recording badge, the resume-or-discard modal, and the recordings menu, so you can abandon a recording from wherever you are.
 
 If the browser is closed, refreshed, or loses the active recording page during capture, Nojoin pauses the recording to protect already uploaded data. When you return, Nojoin requires you to resume or discard that recording before starting anything else.
 
@@ -136,15 +138,18 @@ Supported formats include WAV, MP3, M4A, AAC, WebM, OGG, FLAC, MP4, WMA, and OPU
 
 The import flow validates the file, builds the canonical media artifacts, and queues background processing. Imports skip the live capture workflow but share the same final processing pipeline as live recordings.
 
-### Cancel Processing
+### Discard Recording
 
-Use **Cancel Processing** from the recordings list or recording actions when a meeting is still uploading, queued, or processing.
+Use **Discard Recording** from the recordings list or recording actions when a meeting is still recording, paused, queued, or processing and you no longer want it.
 
-Cancel Processing:
+Discard Recording:
 
-- Stops backend processing for that recording.
-- Closes any active live upload or finalisation session for that meeting.
-- Leaves the recording marked `Cancelled` instead of silently requeueing more work.
+- Revokes any running processing task for that meeting.
+- Closes any active live upload or finalisation session.
+- Deletes the captured audio and derived files.
+- Removes the recording entirely, so there is no leftover `Cancelled` entry to clean up afterwards.
+
+Because it permanently deletes the meeting, Nojoin asks you to confirm before discarding. To remove a meeting that has already finished processing, use **Delete** instead.
 
 ### Retry Processing
 

--- a/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
@@ -162,6 +162,7 @@ export default function RecordingPage({ params }: PageProps) {
               onSaveMeetingEdgeContextLevel={handleMeetingEdgeContextLevelChange}
               showMeetingEdge={meetingEdgeEnabled}
               onBack={navigateToRecordings}
+              onDiscarded={navigateToRecordings}
               showMobileBackButton={isMobile}
             />
           </div>

--- a/frontend/src/components/LiveMeetingControls.tsx
+++ b/frontend/src/components/LiveMeetingControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pause, Play, Square } from "lucide-react";
+import { Pause, Play, Square, Trash2 } from "lucide-react";
 
 import { useCapture } from "@/lib/capture/CaptureProvider";
 import { useNotificationStore } from "@/lib/notificationStore";
@@ -8,7 +8,11 @@ import { useNotificationStore } from "@/lib/notificationStore";
 interface LiveMeetingControlsProps {
   size?: "compact" | "full";
   onMeetingEnd?: () => void;
+  onMeetingDiscard?: () => void;
 }
+
+const DISCARD_CONFIRM_MESSAGE =
+  "Discard this recording? This permanently deletes the in-progress meeting and its audio, and cannot be undone.";
 
 function formatTime(seconds: number) {
   const h = Math.floor(seconds / 3600);
@@ -23,8 +27,10 @@ function formatTime(seconds: number) {
 export default function LiveMeetingControls({
   size = "full",
   onMeetingEnd,
+  onMeetingDiscard,
 }: LiveMeetingControlsProps) {
   const {
+    cancel,
     controller,
     elapsedSeconds,
     pause,
@@ -37,6 +43,29 @@ export default function LiveMeetingControls({
   const { addNotification } = useNotificationStore();
   const isRecording = status === "recording";
   const disabled = !runtimeActive || status === "finalizing";
+
+  const handleDiscard = async () => {
+    if (!window.confirm(DISCARD_CONFIRM_MESSAGE)) {
+      return;
+    }
+    try {
+      await cancel();
+    } catch (err: unknown) {
+      if (!controller.getState().error) {
+        addNotification({
+          type: "error",
+          message:
+            err instanceof Error && err.message
+              ? err.message
+              : "Failed to discard the browser recording.",
+        });
+      }
+      return;
+    }
+    if (onMeetingDiscard) {
+      setTimeout(onMeetingDiscard, 300);
+    }
+  };
 
   const sendCommand = async (command: "stop" | "pause" | "resume") => {
     try {
@@ -124,6 +153,16 @@ export default function LiveMeetingControls({
           >
             <Square className="h-4 w-4 fill-current" />
           </button>
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={disabled}
+            className="rounded-xl border border-red-200 bg-white p-2 text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/30 dark:bg-gray-950/60 dark:text-red-300 dark:hover:bg-red-500/10"
+            title="Discard recording"
+            aria-label="Discard recording"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
         </div>
       </div>
     );
@@ -179,6 +218,17 @@ export default function LiveMeetingControls({
         >
           <Square className="h-4 w-4 fill-current" />
           Stop
+        </button>
+
+        <button
+          type="button"
+          onClick={handleDiscard}
+          disabled={disabled}
+          className="density-control-lg inline-flex flex-1 items-center justify-center gap-2 rounded-2xl border border-red-200 bg-white px-4 py-3 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/30 dark:bg-gray-950/60 dark:text-red-300 dark:hover:bg-red-500/10"
+          title="Discard recording"
+        >
+          <Trash2 className="h-4 w-4" />
+          Discard
         </button>
       </div>
     </div>

--- a/frontend/src/components/RecordingCard.tsx
+++ b/frontend/src/components/RecordingCard.tsx
@@ -194,9 +194,20 @@ export default function RecordingCard({ recording }: RecordingCardProps) {
     });
   };
 
-  const handleCancel = async () => {
-    await actions.cancel(recording.id, {
+  const handleDiscard = async () => {
+    if (
+      !confirm(
+        "Discard this recording? This permanently deletes the in-progress meeting and its audio, and cannot be undone.",
+      )
+    )
+      return;
+    await actions.discard(recording.id, {
       onSuccess: () => {
+        window.dispatchEvent(
+          new CustomEvent("recording-updated", {
+            detail: { id: recording.id },
+          }),
+        );
         router.refresh();
         // Force reload after short delay to ensure UI updates
         setTimeout(() => router.refresh(), 1000);
@@ -204,11 +215,12 @@ export default function RecordingCard({ recording }: RecordingCardProps) {
     });
   };
 
-  const showCancelOption =
-    recording.status === RecordingStatus.PROCESSING ||
+  const isInFlight =
+    recording.status === RecordingStatus.UPLOADING ||
+    recording.status === RecordingStatus.PAUSED ||
     recording.status === RecordingStatus.QUEUED ||
-    recording.status === RecordingStatus.UPLOADING;
-  const showRetryOption = !showCancelOption;
+    recording.status === RecordingStatus.PROCESSING;
+  const showRetryOption = !isInFlight;
 
   return (
     <>
@@ -305,12 +317,12 @@ export default function RecordingCard({ recording }: RecordingCardProps) {
               label: "Retry Speaker Inference",
               onClick: handleInferSpeakers,
             },
-            ...(showCancelOption
+            ...(isInFlight
               ? [
                   {
-                    label: "Cancel Processing",
-                    onClick: handleCancel,
-                    className: "text-amber-600 dark:text-amber-400",
+                    label: "Discard Recording",
+                    onClick: handleDiscard,
+                    className: "text-red-600 dark:text-red-400",
                   },
                 ]
               : []),

--- a/frontend/src/components/RecordingFloatingBadge.tsx
+++ b/frontend/src/components/RecordingFloatingBadge.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Pause, Play, Square } from "lucide-react";
+import { Pause, Play, Square, Trash2 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { useCapture } from "@/lib/capture/CaptureProvider";
 import { useNotificationStore } from "@/lib/notificationStore";
+
+const DISCARD_CONFIRM_MESSAGE =
+  "Discard this recording? This permanently deletes the in-progress meeting and its audio, and cannot be undone.";
 
 function formatTime(seconds: number) {
   const h = Math.floor(seconds / 3600);
@@ -20,6 +23,7 @@ export default function RecordingFloatingBadge() {
   const pathname = usePathname();
   const router = useRouter();
   const {
+    cancel,
     controller,
     elapsedSeconds,
     pause,
@@ -65,6 +69,25 @@ export default function RecordingFloatingBadge() {
             err instanceof Error && err.message
               ? err.message
               : `Failed to ${command} the browser recording.`,
+        });
+      }
+    }
+  };
+
+  const handleDiscard = async () => {
+    if (!window.confirm(DISCARD_CONFIRM_MESSAGE)) {
+      return;
+    }
+    try {
+      await cancel();
+    } catch (err: unknown) {
+      if (!controller.getState().error) {
+        addNotification({
+          type: "error",
+          message:
+            err instanceof Error && err.message
+              ? err.message
+              : "Failed to discard the browser recording.",
         });
       }
     }
@@ -131,6 +154,17 @@ export default function RecordingFloatingBadge() {
           aria-label="Stop recording"
         >
           <Square className="h-4 w-4 fill-current" />
+        </button>
+
+        <button
+          type="button"
+          onClick={handleDiscard}
+          disabled={disabled}
+          className="rounded-lg p-1.5 text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-red-500/10 dark:hover:text-red-300"
+          title="Discard recording"
+          aria-label="Discard recording"
+        >
+          <Trash2 className="h-4 w-4" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/RecordingStatusDisplay.test.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.test.tsx
@@ -25,6 +25,17 @@ vi.mock("./ProcessingNotesPanel", () => ({
   default: () => <div data-testid="processing-notes-panel" />,
 }));
 
+// RecordingStatusDisplay drives discard through useRecordingActions, which reads
+// capture state; stub the provider so the component renders without one.
+vi.mock("@/lib/capture/CaptureProvider", () => ({
+  useCapture: () => ({
+    cancel: vi.fn(),
+    recordingId: null,
+    pausedRecording: null,
+    runtimeActive: false,
+  }),
+}));
+
 const buildRecording = (overrides: Partial<Recording> = {}): Recording => ({
   id: "rec-1",
   created_at: "2026-05-26T10:00:00Z",

--- a/frontend/src/components/RecordingStatusDisplay.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.tsx
@@ -1,14 +1,20 @@
 "use client";
 
-import { ArrowLeft, Loader2, Mic, Pause } from "lucide-react";
+import { useState } from "react";
+import { ArrowLeft, Loader2, Mic, Pause, Trash2 } from "lucide-react";
 
 import { ClientStatus, Recording, RecordingStatus } from "@/types";
+import { discardRecordingCapture } from "@/lib/api";
+import { useNotificationStore } from "@/lib/notificationStore";
 
 import AmbientWorkspace from "./AmbientWorkspace";
 import LiveAudioWaveform from "./LiveAudioWaveform";
 import LiveMeetingControls from "./LiveMeetingControls";
 import MeetingEdgePanel from "./MeetingEdgePanel";
 import ProcessingNotesPanel from "./ProcessingNotesPanel";
+
+const DISCARD_CONFIRM_MESSAGE =
+  "Discard this recording? This permanently deletes the in-progress meeting and its audio, and cannot be undone.";
 
 function formatClock(seconds: number) {
   const hours = Math.floor(seconds / 3600);
@@ -50,6 +56,7 @@ interface RecordingStatusDisplayProps {
   onSaveMeetingEdgeContextLevel?: (level: number) => Promise<void>;
   showMeetingEdge?: boolean;
   onBack?: () => void;
+  onDiscarded?: () => void;
   showMobileBackButton?: boolean;
 }
 
@@ -61,8 +68,34 @@ export default function RecordingStatusDisplay({
   onSaveMeetingEdgeContextLevel,
   showMeetingEdge = true,
   onBack,
+  onDiscarded,
   showMobileBackButton = false,
 }: RecordingStatusDisplayProps) {
+  const { addNotification } = useNotificationStore();
+  const [isDiscarding, setIsDiscarding] = useState(false);
+
+  // Discard path for a recording that is queued or already processing: there is
+  // no live capture runtime to tear down, so call the discard endpoint directly.
+  // It revokes the worker task and removes the meeting server-side.
+  const handleProcessingDiscard = async () => {
+    if (isDiscarding || !window.confirm(DISCARD_CONFIRM_MESSAGE)) {
+      return;
+    }
+    setIsDiscarding(true);
+    try {
+      await discardRecordingCapture(recording.id, "user_discarded");
+      addNotification({ message: "Recording discarded.", type: "success" });
+      onDiscarded?.();
+    } catch (e: unknown) {
+      console.error("Failed to discard recording", e);
+      addNotification({
+        message: "Failed to discard recording.",
+        type: "error",
+      });
+      setIsDiscarding(false);
+    }
+  };
+
   const isActiveRecording =
     recording.status === RecordingStatus.PAUSED ||
     (recording.status === RecordingStatus.UPLOADING &&
@@ -176,6 +209,7 @@ export default function RecordingStatusDisplay({
                     onMeetingEnd={() => {
                       window.dispatchEvent(new Event("recording-updated"));
                     }}
+                    onMeetingDiscard={onDiscarded}
                   />
                 </>
               ) : (
@@ -210,6 +244,23 @@ export default function RecordingStatusDisplay({
                     <div className="mt-2 text-2xl font-semibold text-gray-950 dark:text-white">
                       {formatClock(Math.round(recording.duration_seconds || 0))}
                     </div>
+                  </div>
+
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      onClick={handleProcessingDiscard}
+                      disabled={isDiscarding}
+                      className="inline-flex items-center justify-center gap-2 rounded-2xl border border-red-200 bg-white px-4 py-2.5 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/30 dark:bg-gray-950/60 dark:text-red-300 dark:hover:bg-red-500/10"
+                      title="Discard this recording and stop processing"
+                    >
+                      {isDiscarding ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-4 w-4" />
+                      )}
+                      Discard Recording
+                    </button>
                   </div>
                 </>
               )}

--- a/frontend/src/components/RecordingStatusDisplay.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.tsx
@@ -4,14 +4,13 @@ import { useState } from "react";
 import { ArrowLeft, Loader2, Mic, Pause, Trash2 } from "lucide-react";
 
 import { ClientStatus, Recording, RecordingStatus } from "@/types";
-import { discardRecordingCapture } from "@/lib/api";
-import { useNotificationStore } from "@/lib/notificationStore";
 
 import AmbientWorkspace from "./AmbientWorkspace";
 import LiveAudioWaveform from "./LiveAudioWaveform";
 import LiveMeetingControls from "./LiveMeetingControls";
 import MeetingEdgePanel from "./MeetingEdgePanel";
 import ProcessingNotesPanel from "./ProcessingNotesPanel";
+import { useRecordingActions } from "./recordings/_hooks/useRecordingActions";
 
 const DISCARD_CONFIRM_MESSAGE =
   "Discard this recording? This permanently deletes the in-progress meeting and its audio, and cannot be undone.";
@@ -71,29 +70,23 @@ export default function RecordingStatusDisplay({
   onDiscarded,
   showMobileBackButton = false,
 }: RecordingStatusDisplayProps) {
-  const { addNotification } = useNotificationStore();
+  const actions = useRecordingActions();
   const [isDiscarding, setIsDiscarding] = useState(false);
 
-  // Discard path for a recording that is queued or already processing: there is
-  // no live capture runtime to tear down, so call the discard endpoint directly.
-  // It revokes the worker task and removes the meeting server-side.
+  // Discard path for a recording shown on the processing/queued screen. Routed
+  // through the shared action so that, if this browser still owns the capture
+  // (e.g. an upload finalising), the controller tears down the recorder,
+  // uploader, and paused context too; otherwise it falls back to a plain
+  // server-side discard that revokes the worker task and removes the meeting.
   const handleProcessingDiscard = async () => {
     if (isDiscarding || !window.confirm(DISCARD_CONFIRM_MESSAGE)) {
       return;
     }
     setIsDiscarding(true);
-    try {
-      await discardRecordingCapture(recording.id, "user_discarded");
-      addNotification({ message: "Recording discarded.", type: "success" });
-      onDiscarded?.();
-    } catch (e: unknown) {
-      console.error("Failed to discard recording", e);
-      addNotification({
-        message: "Failed to discard recording.",
-        type: "error",
-      });
-      setIsDiscarding(false);
-    }
+    await actions.discard(recording.id, {
+      onSuccess: onDiscarded,
+      onError: () => setIsDiscarding(false),
+    });
   };
 
   const isActiveRecording =

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -48,6 +48,15 @@ vi.mock("@/lib/api", () => ({
   getRecordingsCalendar: (...args: unknown[]) => getRecordingsCalendar(...args),
 }));
 
+vi.mock("@/lib/capture/CaptureProvider", () => ({
+  useCapture: () => ({
+    cancel: vi.fn(),
+    recordingId: null,
+    pausedRecording: null,
+    runtimeActive: false,
+  }),
+}));
+
 vi.mock("@/lib/timezone", () => ({
   getUserTimeZone: () => Promise.resolve("Europe/London"),
   localDayRangeToUtc: () => ({

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -44,7 +44,7 @@ vi.mock("@/lib/api", () => ({
   softDeleteRecording: vi.fn(),
   permanentlyDeleteRecording: vi.fn(),
   getTags: (...args: unknown[]) => getTags(...args),
-  cancelProcessing: vi.fn(),
+  discardRecordingCapture: vi.fn(),
   getRecordingsCalendar: (...args: unknown[]) => getRecordingsCalendar(...args),
 }));
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -460,8 +460,26 @@ export default function Sidebar() {
     });
   };
 
-  const handleCancel = async (id: RecordingId) => {
-    await actions.cancel(id, { onSuccess: fetchRecordings });
+  const handleDiscard = (id: RecordingId) => {
+    setConfirmModal({
+      isOpen: true,
+      title: "Discard Recording",
+      message:
+        "Discard this recording? This permanently deletes the in-progress meeting and its audio, and cannot be undone.",
+      isDangerous: true,
+      confirmText: "Discard",
+      onConfirm: async () => {
+        setRecordings((prev) => prev.filter((r) => r.id !== id));
+        await actions.discard(id, {
+          onSuccess: () => {
+            if (pathname === `/recordings/${id}`) {
+              router.push("/recordings");
+            }
+          },
+          onError: fetchRecordings,
+        });
+      },
+    });
   };
 
   const handleRecordingClick = (
@@ -518,18 +536,20 @@ export default function Sidebar() {
         },
         ...(recording.status === RecordingStatus.PROCESSING ||
         recording.status === RecordingStatus.QUEUED ||
-        recording.status === RecordingStatus.UPLOADING
+        recording.status === RecordingStatus.UPLOADING ||
+        recording.status === RecordingStatus.PAUSED
           ? [
               {
-                label: "Cancel Processing",
-                onClick: () => handleCancel(recording.id),
-                className: "text-amber-600 dark:text-amber-400",
+                label: "Discard Recording",
+                onClick: () => handleDiscard(recording.id),
+                className: "text-red-600 dark:text-red-400",
               },
             ]
           : []),
         ...(recording.status !== RecordingStatus.PROCESSING &&
         recording.status !== RecordingStatus.QUEUED &&
-        recording.status !== RecordingStatus.UPLOADING
+        recording.status !== RecordingStatus.UPLOADING &&
+        recording.status !== RecordingStatus.PAUSED
           ? [
               {
                 label: "Retry Processing",

--- a/frontend/src/components/recordings/_hooks/sharedRecordingActions.test.ts
+++ b/frontend/src/components/recordings/_hooks/sharedRecordingActions.test.ts
@@ -52,9 +52,9 @@ describe("shared recording action model (FE-015)", () => {
     }
 
     // The two menus exercise overlapping core actions (rename, infer speakers,
-    // cancel) plus their view-specific lifecycle actions; the rename/infer/
-    // cancel trio is the synchronised behaviour FE-015 protects.
-    for (const shared of ["rename", "inferSpeakers", "cancel"] as const) {
+    // discard) plus their view-specific lifecycle actions; the rename/infer/
+    // discard trio is the synchronised behaviour FE-015 protects.
+    for (const shared of ["rename", "inferSpeakers", "discard"] as const) {
       expect(sidebarActions).toContain(shared);
       expect(cardActions).toContain(shared);
     }

--- a/frontend/src/components/recordings/_hooks/useRecordingActions.test.tsx
+++ b/frontend/src/components/recordings/_hooks/useRecordingActions.test.tsx
@@ -10,7 +10,7 @@ const addNotification = vi.fn();
 const api = {
   renameRecording: vi.fn(),
   inferSpeakers: vi.fn(),
-  cancelProcessing: vi.fn(),
+  discardRecordingCapture: vi.fn(),
   deleteRecording: vi.fn(),
   archiveRecording: vi.fn(),
   restoreRecording: vi.fn(),
@@ -21,7 +21,8 @@ const api = {
 vi.mock("@/lib/api", () => ({
   renameRecording: (...a: unknown[]) => api.renameRecording(...a),
   inferSpeakers: (...a: unknown[]) => api.inferSpeakers(...a),
-  cancelProcessing: (...a: unknown[]) => api.cancelProcessing(...a),
+  discardRecordingCapture: (...a: unknown[]) =>
+    api.discardRecordingCapture(...a),
   deleteRecording: (...a: unknown[]) => api.deleteRecording(...a),
   archiveRecording: (...a: unknown[]) => api.archiveRecording(...a),
   restoreRecording: (...a: unknown[]) => api.restoreRecording(...a),
@@ -70,7 +71,7 @@ describe("useRecordingActions", () => {
     });
   });
 
-  it("notifies on inferSpeakers and cancel success", async () => {
+  it("notifies on inferSpeakers and discard success", async () => {
     const { result } = renderHook(() => useRecordingActions());
 
     await act(async () => {
@@ -84,11 +85,14 @@ describe("useRecordingActions", () => {
     });
 
     await act(async () => {
-      await result.current.cancel("rec-1");
+      await result.current.discard("rec-1");
     });
-    expect(api.cancelProcessing).toHaveBeenCalledWith("rec-1");
+    expect(api.discardRecordingCapture).toHaveBeenCalledWith(
+      "rec-1",
+      "user_discarded",
+    );
     expect(addNotification).toHaveBeenCalledWith({
-      message: "Processing cancelled.",
+      message: "Recording discarded.",
       type: "success",
     });
   });

--- a/frontend/src/components/recordings/_hooks/useRecordingActions.test.tsx
+++ b/frontend/src/components/recordings/_hooks/useRecordingActions.test.tsx
@@ -31,6 +31,22 @@ vi.mock("@/lib/api", () => ({
     api.permanentlyDeleteRecording(...a),
 }));
 
+const captureState: {
+  cancel: ReturnType<typeof vi.fn>;
+  recordingId: string | null;
+  pausedRecording: { id: string } | null;
+  runtimeActive: boolean;
+} = {
+  cancel: vi.fn(),
+  recordingId: null,
+  pausedRecording: null,
+  runtimeActive: false,
+};
+
+vi.mock("@/lib/capture/CaptureProvider", () => ({
+  useCapture: () => captureState,
+}));
+
 vi.mock("@/lib/notificationStore", () => ({
   useNotificationStore: () => ({ addNotification }),
 }));
@@ -39,6 +55,10 @@ describe("useRecordingActions", () => {
   beforeEach(() => {
     addNotification.mockReset();
     Object.values(api).forEach((fn) => fn.mockReset().mockResolvedValue(undefined));
+    captureState.cancel.mockReset().mockResolvedValue(undefined);
+    captureState.recordingId = null;
+    captureState.pausedRecording = null;
+    captureState.runtimeActive = false;
   });
 
   it("exposes exactly the shared recording action set", () => {
@@ -91,10 +111,61 @@ describe("useRecordingActions", () => {
       "rec-1",
       "user_discarded",
     );
+    expect(captureState.cancel).not.toHaveBeenCalled();
     expect(addNotification).toHaveBeenCalledWith({
       message: "Recording discarded.",
       type: "success",
     });
+  });
+
+  it("routes discard through the capture controller when this browser owns the live capture", async () => {
+    captureState.runtimeActive = true;
+    captureState.recordingId = "rec-live";
+    const { result } = renderHook(() => useRecordingActions());
+
+    await act(async () => {
+      await result.current.discard("rec-live");
+    });
+
+    // The controller tears down the recorder/uploader/paused context and still
+    // performs the backend discard, so the bare API call must not be used.
+    expect(captureState.cancel).toHaveBeenCalledWith("rec-live");
+    expect(api.discardRecordingCapture).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith({
+      message: "Recording discarded.",
+      type: "success",
+    });
+  });
+
+  it("routes discard through the capture controller when this browser owns the paused capture", async () => {
+    captureState.pausedRecording = { id: "rec-paused" };
+    const { result } = renderHook(() => useRecordingActions());
+
+    await act(async () => {
+      await result.current.discard("rec-paused");
+    });
+
+    expect(captureState.cancel).toHaveBeenCalledWith("rec-paused");
+    expect(api.discardRecordingCapture).not.toHaveBeenCalled();
+  });
+
+  it("uses a plain backend discard for a recording owned by another capture session", async () => {
+    // An active capture exists for a different recording (e.g. recording A is
+    // live in this tab while the user discards queued recording B). Discarding B
+    // must not tear down A's runtime.
+    captureState.runtimeActive = true;
+    captureState.recordingId = "rec-A";
+    const { result } = renderHook(() => useRecordingActions());
+
+    await act(async () => {
+      await result.current.discard("rec-B");
+    });
+
+    expect(api.discardRecordingCapture).toHaveBeenCalledWith(
+      "rec-B",
+      "user_discarded",
+    );
+    expect(captureState.cancel).not.toHaveBeenCalled();
   });
 
   it("runs onSuccess for the lifecycle actions (delete/archive/restore/softDelete/permanentDelete)", async () => {

--- a/frontend/src/components/recordings/_hooks/useRecordingActions.ts
+++ b/frontend/src/components/recordings/_hooks/useRecordingActions.ts
@@ -12,6 +12,7 @@ import {
   restoreRecording,
   softDeleteRecording,
 } from "@/lib/api";
+import { useCapture } from "@/lib/capture/CaptureProvider";
 import { useNotificationStore } from "@/lib/notificationStore";
 import { RecordingId } from "@/types";
 
@@ -94,6 +95,12 @@ export interface RecordingActions {
 
 export function useRecordingActions(): RecordingActions {
   const { addNotification } = useNotificationStore();
+  const {
+    cancel: cancelCapture,
+    recordingId: captureRecordingId,
+    pausedRecording,
+    runtimeActive,
+  } = useCapture();
 
   return useMemo<RecordingActions>(() => {
     return {
@@ -132,7 +139,21 @@ export function useRecordingActions(): RecordingActions {
 
       discard: async (id, callbacks) => {
         try {
-          await discardRecordingCapture(id, "user_discarded");
+          // If this browser owns the live or paused capture for this recording,
+          // route through the capture controller so the MediaRecorder, uploader,
+          // and persisted paused context/capture lock are torn down before (and
+          // as part of) the backend discard. A bare POST /discard would delete
+          // the row while the client kept recording to a missing recording or
+          // stayed blocked behind a stale paused lock. For a queued/processing
+          // recording, or one owned by another tab, a plain discard is correct.
+          const ownsLiveCapture =
+            runtimeActive && captureRecordingId === id;
+          const ownsPausedCapture = pausedRecording?.id === id;
+          if (ownsLiveCapture || ownsPausedCapture) {
+            await cancelCapture(id);
+          } else {
+            await discardRecordingCapture(id, "user_discarded");
+          }
           addNotification({
             message: "Recording discarded.",
             type: "success",
@@ -202,5 +223,11 @@ export function useRecordingActions(): RecordingActions {
         }
       },
     };
-  }, [addNotification]);
+  }, [
+    addNotification,
+    cancelCapture,
+    captureRecordingId,
+    pausedRecording,
+    runtimeActive,
+  ]);
 }

--- a/frontend/src/components/recordings/_hooks/useRecordingActions.ts
+++ b/frontend/src/components/recordings/_hooks/useRecordingActions.ts
@@ -4,8 +4,8 @@ import { useMemo } from "react";
 
 import {
   archiveRecording,
-  cancelProcessing,
   deleteRecording,
+  discardRecordingCapture,
   inferSpeakers,
   permanentlyDeleteRecording,
   renameRecording,
@@ -38,7 +38,7 @@ import { RecordingId } from "@/types";
 export const RECORDING_ACTION_IDS = [
   "rename",
   "inferSpeakers",
-  "cancel",
+  "discard",
   "delete",
   "archive",
   "restore",
@@ -66,7 +66,7 @@ export interface RecordingActions {
     id: RecordingId,
     callbacks?: RecordingActionCallbacks,
   ) => Promise<void>;
-  cancel: (
+  discard: (
     id: RecordingId,
     callbacks?: RecordingActionCallbacks,
   ) => Promise<void>;
@@ -130,18 +130,18 @@ export function useRecordingActions(): RecordingActions {
         }
       },
 
-      cancel: async (id, callbacks) => {
+      discard: async (id, callbacks) => {
         try {
-          await cancelProcessing(id);
+          await discardRecordingCapture(id, "user_discarded");
           addNotification({
-            message: "Processing cancelled.",
+            message: "Recording discarded.",
             type: "success",
           });
           callbacks?.onSuccess?.();
         } catch (e: unknown) {
-          console.error("Failed to cancel processing", e);
+          console.error("Failed to discard recording", e);
           addNotification({
-            message: "Failed to cancel processing.",
+            message: "Failed to discard recording.",
             type: "error",
           });
           callbacks?.onError?.();

--- a/frontend/src/lib/api.contract.test.ts
+++ b/frontend/src/lib/api.contract.test.ts
@@ -45,7 +45,6 @@ describe("api public surface", () => {
         "batchRemoveTagFromRecordings",
         "batchRestoreRecordings",
         "batchSoftDeleteRecordings",
-        "cancelProcessing",
         "checkFFmpeg",
         "clearChatHistory",
         "createGlobalSpeaker",

--- a/frontend/src/lib/api/recordings.ts
+++ b/frontend/src/lib/api/recordings.ts
@@ -111,11 +111,6 @@ export const reprocessRecording = async (
   return response.data;
 };
 
-export const cancelProcessing = async (id: RecordingId): Promise<Recording> => {
-  const response = await api.post<Recording>(`/recordings/${id}/cancel`);
-  return response.data;
-};
-
 export const getRecordingStreamUrl = (id: RecordingId): string => {
   return `${API_BASE_URL}/recordings/${id}/stream`;
 };


### PR DESCRIPTION
## Description

Adds a single graceful **Discard** action for recordings that have not finished, replacing the previous awkward flow where a user had to stop the recording, manually cancel processing, and then delete the meeting.

Discard now works across the entire in-flight lifecycle — `UPLOADING`, `PAUSED`, `QUEUED`, and `PROCESSING`. In one confirmed step it:

- revokes any running Celery processing task (`terminate=True`),
- stops live capture and releases the per-user capture lock,
- deletes all on-disk artefacts (audio, proxy, temp/live files, chunks, window manifests, transcript), and
- removes the recording row.

This unifies two previously partial mechanisms: the old `/discard` endpoint (which only handled `UPLOADING`/`PAUSED`) and the `/cancel` endpoint (which revoked the task but left a `CANCELLED` ghost row plus files behind). The `/cancel` endpoint and its "Cancel Processing" menu action are retired in favour of Discard. Ownership enforcement is unchanged (`_get_owned_recording` + the existing recording-client session auth).

Discard is surfaced everywhere an in-flight recording appears: the live recording controls, the floating recording badge, the resume-or-discard modal, the recordings detail/processing screen, and the recordings context menus (kept in sync across `RecordingCard.tsx` and `Sidebar.tsx`). Every entry point confirms first because the deletion is permanent.

No new dependencies.

Fixes # (n/a)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (651 passed)
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, whitespace, mypy, doc and Alembic validators, file-size budget — all green)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (164 passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR: `docs/USAGE.md`, `docs/CAPTURE.md`, and `docs/ARCHITECTURE.md` now describe the unified Discard behaviour.

## Security impact

- [x] No security-sensitive change. The discard endpoint reuses the existing recording-client session auth and `_get_owned_recording` ownership check; only the set of discardable states was widened. No auth/token/encryption/exposure boundary changed.

## Manual verification

Browser smoke testing performed by the maintainer:

- Discard during an active live recording (in-flight) — capture stops, capture lock clears, meeting removed.
- Discard a finalised recording that was queued/processing — the worker task is revoked and the meeting is removed with no leftover `Cancelled` entry.

Not separately re-tested in this pass (unchanged by this PR): share-picker selection, selected-microphone behaviour, waveform/live state, pause/resume, stop/finalize, and unsupported-browser messaging. Recording context-menu changes are mirrored in both `RecordingCard.tsx` and `Sidebar.tsx`.
