### PR TITLE
ci: add Claude automated PR review workflow (running alongside Codex)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,55 @@
+name: Claude Review
+
+# Automatic pull-request review by Claude, replacing the former Codex connector.
+# Runs when a PR is opened or pushed to, posts inline comments plus a summary,
+# and authenticates against a Claude subscription via CLAUDE_CODE_OAUTH_TOKEN
+# (generate with `claude setup-token`, store as a repo secret of that name).
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# One review per PR: a new push cancels the review still running for the
+# previous commit so reviews never stack up on rapid pushes.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # read the diff and source; never push
+  pull-requests: write # post the review and inline comments
+  issues: read
+  id-token: write # OIDC token required by the subscription OAuth flow
+
+jobs:
+  review:
+    name: Claude review
+    runs-on: ubuntu-latest
+    # Skip drafts and anything Dependabot opens to avoid noisy/auth-limited runs.
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Review with Claude
+        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review the pull request #${{ github.event.pull_request.number }} in
+            ${{ github.repository }}. Focus, in priority order, on:
+              1. Correctness bugs, logic errors, and unhandled edge cases.
+              2. Security issues — injection, secret handling, auth, unsafe
+                 deserialisation, path traversal.
+              3. Concurrency, data-loss, and error-handling problems.
+              4. Reuse and simplification: duplicated logic, needless complexity.
+
+            Leave specific, actionable inline comments on the exact lines using the
+            inline comment tool. Then post one concise summary comment with an
+            overall assessment. Be direct and do not pad the review with praise.
+            Only raise issues you are confident about; if the diff looks clean,
+            say so briefly rather than inventing nitpicks.
+          # Read-only inspection tools only — the reviewer must not mutate the repo.
+          claude_args: |
+            --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,8 +24,15 @@ jobs:
   review:
     name: Claude review
     runs-on: ubuntu-latest
-    # Skip drafts and anything Dependabot opens to avoid noisy/auth-limited runs.
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    # Skip drafts and Dependabot (noisy/auth-limited), and skip PRs opened from
+    # forks: GitHub withholds repo secrets from pull_request runs whose head is a
+    # fork, so CLAUDE_CODE_OAUTH_TOKEN would be empty and the action would fail
+    # red. CONTRIBUTING.md routes external contributors through forks, and those
+    # PRs are instead covered by the Codex reviewer (a GitHub App, not secret-gated).
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Description

Adds `.github/workflows/claude-review.yml`, an automated PR reviewer using `anthropics/claude-code-action@v1` (pinned to commit `428971d`). It runs on every non-draft, **same-repo** PR (`opened`/`synchronize`/`reopened`), posts inline comments plus a summary, and authenticates against a Claude subscription via the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (already set).

**Claude runs alongside the existing `chatgpt-codex-connector` reviewer, not as a replacement.** The two are complementary: GitHub withholds repo secrets from `pull_request` runs whose head is a fork, so the Actions-based Claude reviewer is guarded to skip fork PRs; Codex (a server-side GitHub App, not secret-gated) continues to cover those external-contributor PRs.

Design notes:
- Job `if:` skips drafts, Dependabot, and **forked PRs** (`head.repo.full_name == github.repository`) so community PRs never get a red check from a withheld secret. `pull_request_target` is deliberately avoided — it would expose the secret to untrusted fork code.
- Permissions scoped to `contents: read` (never pushes) + `pull-requests: write` (post review) + `id-token: write` (OAuth/OIDC). Tighter than a marketplace app.
- `claude_args` restricts tools to read-only inspection (`gh pr view`/`gh pr diff`) plus the inline-comment tool — the reviewer cannot mutate the repo.
- A `concurrency` group cancels a superseded review when a new commit is pushed.
- Both actions are pinned to commit SHAs, matching existing CI hardening.
- No docs change required: `docs/DEVELOPMENT.md` describes the merge gate generically ("automated review comments") and never names a specific reviewer, so it stays accurate for both bots.

New dependencies: GitHub Action `anthropics/claude-code-action@v1` (external, SHA-pinned).

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checks run

CI-only change (one new workflow file). No backend/frontend/scripts/migration code paths touched; the repo's path-gated CI skips those suites for this diff. Cheap relevant validators run:

- [x] Docs validation: `python3 scripts/validate_docs.py` — passed (22 files)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — passed (head `b91f9c2d4e6a`, unchanged)
- [x] `git diff --check` — clean
- [x] Workflow YAML parses (`if:` folds to a single valid expression); action interface + SHA verified via GitHub API
- [ ] Backend tests / Python quality / Frontend lint/test/build — N/A, no such code changed

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required.

## Security impact

- [x] No security-sensitive change. CI reviewer with read-only repo scope; fork PRs excluded so the `CLAUDE_CODE_OAUTH_TOKEN` secret is never exposed to untrusted code. Introduces no auth/token/encryption/capture behaviour.

## Manual verification

None applicable (no capture or recording-context-menu changes). The workflow's first live execution is this PR's own CI run — its review appearing here is the end-to-end test.
