### PR TITLE
build(deps): combined Dependabot updates (docker, actions, npm, python)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
           cache: pip
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
           cache: pip
@@ -207,7 +207,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -223,7 +223,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -242,7 +242,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 1
 
       - name: Review with Claude
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
           cache: pip
@@ -205,7 +205,7 @@ jobs:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -224,7 +224,7 @@ jobs:
           ref: ${{ needs.validate-release-ref.outputs.release_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,6 +1,6 @@
 # --- Builder Stage ---
 # Pinned by digest for reproducible builds; Dependabot keeps the tag comment current.
-FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061 AS builder
+FROM python:3.14-slim@sha256:63a4c7f612a00f92042cbdcc7cdc6a306f38485af0a200b9c89de7d9b1607d15 AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -23,7 +23,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements/backend.txt
 
 # --- Runtime Stage ---
-FROM python:3.14-slim@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061 AS runtime
+FROM python:3.14-slim@sha256:63a4c7f612a00f92042cbdcc7cdc6a306f38485af0a200b9c89de7d9b1607d15 AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Pinned by digest for reproducible builds; Dependabot keeps the tag comment current.
-FROM node:26-alpine@sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606 AS base
+FROM node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "babel-plugin-react-compiler": "1.0.0",
-        "baseline-browser-mapping": "^2.9.2",
+        "baseline-browser-mapping": "^2.10.40",
         "eslint": "^9",
         "eslint-config-next": "16.2.9",
         "jsdom": "^29.1.1",
@@ -3041,9 +3041,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4105,9 +4105,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "date-fns-tz": "^3.2.0",
         "dictionary-en": "^4.0.0",
         "dictionary-en-gb": "^3.0.0",
-        "driver.js": "^1.5.0",
+        "driver.js": "^1.6.0",
         "fuse.js": "^7.4.2",
         "lucide-react": "^1.21.0",
         "next": "16.2.9",
@@ -4629,9 +4629,9 @@
       "peer": true
     },
     "node_modules/driver.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.5.0.tgz",
-      "integrity": "sha512-j31Yi1V3/fTCI6+JmS6Z30bHE3YbpT5+UlrsN0o5aswCuZVDwfaZKsMSN0tMCQbWk99RNXxEyAhALC1otj31/w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.6.0.tgz",
+      "integrity": "sha512-gryo9QS7AZhz8J0bmdf42dwaTzcd1BgSJLnaSM7cPJbu8bTW8wIEuiGDy4MoCvB4Sr8wA9g5o2G9EFNVYZGeVQ==",
       "license": "MIT"
     },
     "node_modules/dunder-proto": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
-    "baseline-browser-mapping": "^2.9.2",
+    "baseline-browser-mapping": "^2.10.40",
     "eslint": "^9",
     "eslint-config-next": "16.2.9",
     "jsdom": "^29.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "date-fns-tz": "^3.2.0",
     "dictionary-en": "^4.0.0",
     "dictionary-en-gb": "^3.0.0",
-    "driver.js": "^1.5.0",
+    "driver.js": "^1.6.0",
     "fuse.js": "^7.4.2",
     "lucide-react": "^1.21.0",
     "next": "16.2.9",

--- a/requirements/backend.txt
+++ b/requirements/backend.txt
@@ -1,13 +1,13 @@
 -r base.txt
-fastapi==0.138.0
+fastapi==0.138.1
 uvicorn[standard]==0.49.0
 # Backend specific dependencies
 docker==7.1.0
 celery[redis]==5.6.3
 numpy==2.4.6
-openai==2.43.0
-anthropic==0.111.0
-google-genai==2.9.0
+openai==2.44.0
+anthropic==0.112.0
+google-genai==2.10.0
 reportlab==5.0.0
 python-docx==1.2.0
 Markdown==3.10.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-sqlmodel==0.0.38
+sqlmodel==0.0.39
 psycopg2-binary==2.9.12
 asyncpg==0.31.0
 python-dotenv==1.2.2
@@ -15,5 +15,5 @@ httpx==0.28.1
 #   CVE-2026-40192 (FITS decompression-bomb DoS), CVE-2026-42311.
 urllib3==2.7.0
 pillow==12.2.0
-alembic==1.18.4
+alembic==1.18.5
 pgvector==0.4.2

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -4,7 +4,7 @@
 # install it quickly. Ruff needs no project dependencies; mypy follows imports
 # for the typed boundaries it checks and ignores the heavy ML stack via config
 # in pyproject.toml.
-ruff==0.15.18
+ruff==0.15.20
 mypy==2.1.0
 pre-commit==4.6.0
 

--- a/requirements/worker.txt
+++ b/requirements/worker.txt
@@ -8,20 +8,20 @@ onnx-asr==0.11.0
 silero-vad==6.2.1
 numpy==2.4.6
 pandas==3.0.3
-openai==2.43.0
-anthropic==0.111.0
-google-genai==2.9.0
+openai==2.44.0
+anthropic==0.112.0
+google-genai==2.10.0
 watchdog==6.0.0
 PyMuPDF==1.27.2.3
 
 # pyannote.audio dependencies (installed manually to avoid torch downgrade)
 asteroid-filterbanks==0.4.0
 einops==0.8.2
-huggingface_hub==1.20.1
+huggingface_hub==1.21.0
 lightning==2.6.5
-opentelemetry-api==1.42.1
-opentelemetry-sdk==1.42.1
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-api==1.43.0
+opentelemetry-sdk==1.43.0
+opentelemetry-exporter-otlp==1.43.0
 pyannote-core==6.0.1
 pyannote-database==6.1.1
 pyannote-metrics==4.1


### PR DESCRIPTION
# Pull Request

## Description

Combines five separate Dependabot pull requests (#57–#61) into one so CI runs once instead of per-PR with the usual rebase churn. All five constituent PRs were green on CI individually; this branch is the exact union of their commits (cherry-picked, no conflicts).

Updates included:

**Docker base images (#57)** — digest refresh only, tags unchanged:
- `python:3.14-slim` (api builder + runtime)
- `node:26-alpine` (frontend)

**GitHub Actions (#59)**:
- `actions/setup-python` v6.2.0 → v6.3.0
- `anthropics/claude-code-action` v1 (digest bump)

**npm — development (#58)**:
- `baseline-browser-mapping` ^2.9.2 → ^2.10.40
- `@types/node` 26.0.0 → 26.0.1

**npm — production (#60)**:
- `driver.js` ^1.5.0 → ^1.6.0

**Python (#61)** — 11 updates across `requirements/*.txt`:
- `fastapi` 0.138.0 → 0.138.1
- `openai` 2.43.0 → 2.44.0 (backend + worker, kept in lockstep)
- `anthropic` 0.111.0 → 0.112.0 (backend + worker)
- `google-genai` 2.9.0 → 2.10.0 (backend + worker)
- `sqlmodel` 0.0.38 → 0.0.39
- `alembic` 1.18.4 → 1.18.5
- `ruff` 0.15.18 → 0.15.20
- `huggingface_hub` 1.20.1 → 1.21.0
- `opentelemetry-api`/`-sdk`/`-exporter-otlp` 1.42.1 → 1.43.0

No application code changes; all updates are minor/patch/digest version bumps.

## Type of change

- [x] Other: dependency maintenance (no functional change)

## Checks run

CI ran green on each constituent Dependabot PR (#57–#61) before combining. The merged branch re-runs the full suite here.

- [x] Backend tests (passed on #57, #59, #61)
- [x] Python quality (passed on #57, #59, #61)
- [x] Frontend lint (passed on all)
- [x] Frontend unit tests (passed on all)
- [x] Frontend build (passed on all)
- [x] Docs validation (passed on all)
- [x] Alembic validation (passed on all)

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required.

## Security impact

- [x] No security-sensitive change. Digest/SHA pins for Docker base images and GitHub Actions are rotated by Dependabot; pinning discipline preserved.

## Manual verification

None required — dependency version bumps only, no capture, recording, or UI behaviour changes. Relies on the automated suite.
