### PR TITLE
ci: tune Claude PR reviewer for materiality and swap per-push re-review for an opt-in label

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -49,7 +49,7 @@ The canonical label set is defined in [labels.yml](labels.yml), grouped as:
 - **Scope:** `scope:backend`, `scope:worker`, `scope:frontend`, `scope:capture`, `scope:migration`, `scope:deployment`, `scope:docs`, `scope:security` (mirrors [CODEOWNERS](CODEOWNERS)).
 - **Platform:** `platform:windows`, `platform:linux`, `platform:macos`, `platform:android`, `platform:ios`, plus the `platform-issue` triage label.
 - **Release impact:** `release:breaking`, `release:migration-required`, `release:safe`.
-- **Workflow:** `needs-triage`, `flaky`, `slow-test`, `dependencies`, `audit`.
+- **Workflow:** `needs-triage`, `flaky`, `slow-test`, `dependencies`, `audit`, `claude-review` (adding `claude-review` to a pull request triggers an on-demand Claude re-review).
 
 ### Applying the Labels (maintainer-action-pending)
 
@@ -82,6 +82,7 @@ gh label create "flaky"             --color e99695 --description "Intermittently
 gh label create "slow-test"         --color fef2c0 --description "Test flagged as slow by pytest --durations." --force
 gh label create "dependencies"      --color 0366d6 --description "Dependency update (used by Dependabot pull requests)." --force
 gh label create "audit"             --color 0052cc --description "Periodic repository-quality re-audit (GOV-008)." --force
+gh label create "claude-review"     --color 6f42c1 --description "Request an on-demand Claude PR re-review (triggers claude-review.yml)." --force
 ```
 
 This step is a one-time (then on-change) maintainer action and is not enforced from the repository tree. `.github/labels.yml` remains the canonical definition; keep these commands in step with it when the taxonomy changes.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -95,3 +95,6 @@
 - name: "audit"
   color: "0052cc"
   description: "Periodic repository-quality re-audit (GOV-008)."
+- name: "claude-review"
+  color: "6f42c1"
+  description: "Request an on-demand Claude PR re-review (triggers claude-review.yml)."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,15 +1,36 @@
 name: Claude Review
 
-# Automatic pull-request review by Claude, replacing the former Codex connector.
-# Runs when a PR is opened or pushed to, posts inline comments plus a summary,
-# and authenticates against a Claude subscription via CLAUDE_CODE_OAUTH_TOKEN
-# (generate with `claude setup-token`, store as a repo secret of that name).
+# Automated pull-request review by Claude. It authenticates against a Claude
+# subscription via CLAUDE_CODE_OAUTH_TOKEN (generate with `claude setup-token`,
+# store as a repo secret of that name) and runs the read-only claude-code-action.
+#
+# Review policy at a glance (the enforceable version lives in the prompt below):
+#   - Materiality over confidence. Every candidate finding is scored 0-100 for
+#     confidence AND materiality, and anything below 80 is suppressed. "True but
+#     trivial" (style, naming, DRY-for-its-own-sake, convention-following
+#     duplication) is dropped, not posted. The reviewer prefers zero comments to
+#     noise: a clean diff gets a one-line summary and no inline comments.
+#   - Verify before flagging. The reviewer confirms a finding is reachable and
+#     checks the repository's existing conventions (it may Read/Grep/Glob the
+#     checked-out tree) before commenting, and never overstates severity.
+#
+# Trigger model (deliberately NOT a review on every push):
+#   - opened / reopened / ready_for_review: one automatic review when the PR
+#     first becomes reviewable. Draft PRs are skipped until marked ready.
+#   - labeled with `claude-review`: an explicit, opt-in re-review after the
+#     author pushes fixes. This replaces the previous review-on-every-push
+#     behaviour, which re-reviewed the whole PR on each `synchronize` event and
+#     was the source of the "relentless" reviewer noise. Remove and re-add the
+#     label to request each subsequent re-review.
+#
+# The `claude-review` trigger label is defined in .github/labels.yml and applied
+# with the `gh` commands in .github/SUPPORT.md, like every other Nojoin label.
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, ready_for_review, labeled]
 
-# One review per PR: a new push cancels the review still running for the
-# previous commit so reviews never stack up on rapid pushes.
+# One review per PR: a new trigger cancels a review still running for the
+# previous commit so reviews never stack up on rapid pushes or re-labels.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -24,15 +45,26 @@ jobs:
   review:
     name: Claude review
     runs-on: ubuntu-latest
-    # Skip drafts and Dependabot (noisy/auth-limited), and skip PRs opened from
-    # forks: GitHub withholds repo secrets from pull_request runs whose head is a
-    # fork, so CLAUDE_CODE_OAUTH_TOKEN would be empty and the action would fail
-    # red. CONTRIBUTING.md routes external contributors through forks, and those
-    # PRs are instead covered by the Codex reviewer (a GitHub App, not secret-gated).
+    # Gate the review to same-repo, non-draft, human PRs, and — for `labeled`
+    # events only — to the dedicated `claude-review` label:
+    #   - draft == false: drafts are skipped until marked ready for review.
+    #   - actor != dependabot[bot]: Dependabot PRs are noisy and auth-limited.
+    #   - head.repo.full_name == github.repository: skip PRs opened from forks.
+    #     GitHub withholds repo secrets from pull_request runs whose head is a
+    #     fork, so CLAUDE_CODE_OAUTH_TOKEN would be empty and the action would
+    #     fail red. CONTRIBUTING.md routes external contributors through forks,
+    #     and those PRs are covered by the Codex reviewer (a GitHub App, not
+    #     secret-gated) instead. Staying on `pull_request` (never
+    #     `pull_request_target`) means fork code is never run with our secrets.
+    #   - action != 'labeled' || label.name == 'claude-review': non-label
+    #     triggers always run; a label trigger runs only for our review label,
+    #     so unrelated label changes evaluate this `if` to false and are skipped
+    #     before a runner starts.
     if: >-
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'labeled' || github.event.label.name == 'claude-review')
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -43,20 +75,67 @@ jobs:
         uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Deliver the summary as one sticky comment that updates in place on a
+          # re-review, rather than stacking a fresh summary on every run.
+          use_sticky_comment: "true"
           prompt: |
-            Review the pull request #${{ github.event.pull_request.number }} in
-            ${{ github.repository }}. Focus, in priority order, on:
-              1. Correctness bugs, logic errors, and unhandled edge cases.
-              2. Security issues — injection, secret handling, auth, unsafe
-                 deserialisation, path traversal.
-              3. Concurrency, data-loss, and error-handling problems.
-              4. Reuse and simplification: duplicated logic, needless complexity.
+            You are reviewing pull request #${{ github.event.pull_request.number }}
+            in ${{ github.repository }}. Review only the changes in this PR's diff.
 
-            Leave specific, actionable inline comments on the exact lines using the
-            inline comment tool. Then post one concise summary comment with an
-            overall assessment. Be direct and do not pad the review with praise.
-            Only raise issues you are confident about; if the diff looks clean,
-            say so briefly rather than inventing nitpicks.
-          # Read-only inspection tools only — the reviewer must not mutate the repo.
+            Aim for a HIGH-SIGNAL review. Prefer posting nothing over posting
+            noise. Materiality matters more than confidence: being certain a
+            finding is true does not make it worth raising.
+
+            Look, in priority order, for:
+              1. Correctness bugs, logic errors, and unhandled edge cases.
+              2. Security issues: injection, secret handling, auth/authz,
+                 unsafe deserialisation, path traversal, SSRF.
+              3. Concurrency, data-loss, and error-handling defects.
+
+            Before flagging anything, VERIFY it:
+              - Confirm the problem is actually reachable and is not already
+                prevented by surrounding code, a caller, or a validated input.
+              - Check the repository's existing conventions before calling
+                something wrong. You may Read/Grep/Glob the checked-out tree. A
+                pattern used consistently across the codebase (for example a
+                per-module local constant read) is a convention, not a defect.
+              - Do not overstate severity. Only use a severity term when the
+                mechanism actually holds end to end.
+
+            Score every candidate finding 0-100 and POST ONLY findings scoring 80+:
+              - 0-40: false positive, pre-existing, or not reachable. Drop it.
+              - around 50: verified real but a nitpick or rarely hit. Drop it.
+              - 75+: verified, and it will realistically affect correctness,
+                security, or data integrity in practice. Post it.
+
+            Do NOT comment on (these are out of scope for this review):
+              - Style, naming, formatting, import order, or docstring wording.
+              - Duplicated constants/logic or "this could be DRY/simpler" unless
+                the duplication will realistically cause a correctness or security
+                bug if the copies drift. Following an existing convention is fine.
+              - Missing tests, unless there is a concrete coverage gap on newly
+                added risky logic.
+              - Anything CI already enforces: Ruff lint/format, mypy, ESLint, and
+                the test suites. Do not restate lint, type, or test failures.
+              - Pre-existing issues on lines this PR does not modify.
+
+            Ignore (do not review) generated files, Alembic migrations under
+            backend/alembic/versions/, lock files (package-lock.json,
+            requirements/*.txt), and vendored or minified assets.
+
+            Output:
+              - If nothing scores 80+, post a single one-line summary saying no
+                material issues were found and leave NO inline comments.
+              - Otherwise leave a specific, actionable inline comment on each
+                exact line with the inline comment tool — at most the 6 most
+                material findings — then one concise summary. Be direct; do not
+                pad with praise.
+          # Read-only inspection tools only: the reviewer reads the diff and the
+          # checked-out tree and posts inline comments, but must never mutate the
+          # repository. Read/Grep/Glob enable verify-before-flag; Bash is limited
+          # to the two read-only gh subcommands. --max-turns is a generous
+          # ceiling: high enough not to truncate a multi-comment review now that
+          # file reads are allowed, low enough to bound a runaway loop.
           claude_args: |
-            --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*)"
+            --max-turns 25
+            --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Read,Grep,Glob"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,15 @@ Sensitive scopes carry an additional review obligation that the maintainer (or, 
 - **Capture (`frontend/src/lib/capture/**`):** complete the manual browser smoke coverage listed under [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) and keep `RecordingCard.tsx` and `Sidebar.tsx` context menus in sync.
 - **Deployment / release (`docker/**`, `docker-compose*.yml`, `.github/workflows/**`):** keep the pinned action SHAs, pinned base-image digests, and the gated/signed release ordering intact, and run the full backend, frontend, docs, and Alembic validation set together.
 
+### Automated Review
+
+Pull requests receive an automated first-pass review alongside the required `CI gate` and the maintainer review. These automated reviews are advisory: they post inline comments and a short summary, but they are not required status checks and never gate a merge.
+
+- **Claude reviewer** (`.github/workflows/claude-review.yml`): reviews same-repository pull requests. It is tuned for materiality rather than volume — it scores each candidate finding for confidence and impact and posts only high-signal correctness, security, and data-integrity issues, deliberately skipping style, naming, convention-following duplication, and anything the CI quality jobs already enforce. If the diff is clean it posts a one-line summary and no inline comments. It reviews once when a pull request is opened, reopened, or marked ready for review — not on every push. To request a re-review after pushing fixes, add the `claude-review` label (remove and re-add it to trigger each subsequent pass).
+- **Codex reviewer** (a GitHub App): covers pull requests opened from forks, which the Claude workflow skips because GitHub withholds repository secrets — and therefore the reviewer's credentials — from fork `pull_request` runs.
+
+Treat both as a first pass that surfaces issues early, not as a substitute for the maintainer review and the required checks above.
+
 ### Branch Protection (maintainer-action-pending)
 
 Branch protection and required-reviewer enforcement cannot be applied from the repository tree; they are GitHub repository settings. The settings to apply on `main` are designed so the sole maintainer can always merge their own green pull request and are never an irreversible lockout:


### PR DESCRIPTION
## Description

Reworks the automated Claude PR reviewer (`.github/workflows/claude-review.yml`) to fix two maintainer complaints: it was too picky (surfacing true-but-trivial findings) and it re-reviewed the whole PR on **every push**, which felt relentless. This goes beyond a prompt tweak and adjusts the trigger model, tool scope, output shape, and the documented review contract. No application code changes; the change is confined to CI config and docs.

### Before → after

| Aspect | Before | After |
| --- | --- | --- |
| Triggers | `opened, synchronize, reopened` (re-reviews on every push) | `opened, reopened, ready_for_review, labeled` (one review when the PR becomes reviewable; **no** per-push re-review) |
| Re-review | Automatic on each push | Opt-in: add the `claude-review` label (remove + re-add for each pass) |
| Pickiness bar | "Only raise issues you are confident about" (a **confidence** bar) | Explicit **materiality** bar: score each candidate 0–100 for confidence *and* impact, post only 80+, drop verified-but-trivial (~50) |
| Nit sources | Priority item 4 invited DRY/style nits | Removed; explicit "do NOT comment on" list (style, naming, convention-following duplication, missing-tests-unless-real-gap, CI-enforced lint/type/test, pre-existing/unmodified-line issues) |
| Verify-before-flag | None | Reviewer may `Read`/`Grep`/`Glob` the tree to confirm reachability and existing conventions before flagging; must not overstate severity |
| Scope | Whole diff | Skips generated files, `backend/alembic/versions/`, lock files, vendored/minified assets |
| Summary comments | New summary every run | `use_sticky_comment` — one summary updated in place |

### Key decisions (rationale)

- **Prompt-tuning over the `code-review` plugin.** The official plugin exposes a hard confidence gate (default 80) and is the closest thing to a real "pickiness dial", but `plugin_marketplaces` clones upstream `main` at runtime and is **not SHA-pinnable** — which conflicts with this repo's sensitive-scope rule ("keep the pinned action SHAs intact", CONTRIBUTING.md) and its pin-everything culture. Instead I ported the plugin's proven model — its 0–100 confidence/materiality rubric, its ≥80 filter, and its exclusion list — into the inline prompt, keeping the workflow fully self-contained and pinned. The plugin remains a drop-in future option (`plugin_marketplaces: "https://github.com/anthropics/claude-code.git"`, `plugins: "code-review@claude-code-plugins"`) if multi-agent depth is later wanted and an unpinned marketplace is acceptable.
- **Label gate over `@claude` / `issue_comment` for on-demand re-review.** A label stays entirely within the `pull_request` event family, so the existing fork/draft/dependabot `if:` and GitHub's fork-secret withholding keep working unchanged. An `issue_comment` `@claude` path would run in base-repo context with secrets and needs extra care around checking out fork head; the label avoids that surface. Labelling is already restricted to users with triage/write access.
- **`REVIEW.md` rejected as unverified.** No evidence the bare action honours a dedicated `REVIEW.md`. `CLAUDE.md` *is* honoured, but introducing a repo-wide `CLAUDE.md` solely for review policy would also affect contributors' local Claude sessions; an inline, version-controlled prompt is more contained for a single review entry point. Noted as the home if the plugin is later adopted.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update (primarily a CI/review-workflow change that also updates `CONTRIBUTING.md` and `.github/SUPPORT.md`; no application code touched)

## Checks run

Only the checks applicable to the changed paths (`.github/**`, `CONTRIBUTING.md`) were run. The backend/frontend/script suites are not applicable — no code under `backend/**`, `frontend/**`, or `scripts/**` changed — which is exactly why CI's `detect-changes` path filters skip them for this PR.

- [ ] Backend tests: `pytest` (N/A — no backend code changed)
- [ ] Python quality: `python scripts/check.py` (N/A — no Python code changed)
- [ ] Frontend lint / unit tests / build (N/A — no frontend changed)
- [x] Docs validation: `python3 scripts/validate_docs.py` — passed (22 files)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — passed (unchanged graph)

Additionally run (not in the template, relevant here): `actionlint` on all workflows (clean), `git diff --check` (clean), and a manual confirmation that both actions remain pinned to full commit SHAs.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR. `CONTRIBUTING.md` gains an "Automated Review" subsection documenting the review contract, the trigger model, the re-review label, and the Codex division of labour on fork PRs; `.github/SUPPORT.md` and `.github/labels.yml` register the new `claude-review` label.

## Security impact

- [x] No security-sensitive change (no auth, token, encryption, capture-ownership, or exposure boundary in `docs/SECURITY.md` is touched).

Although no application security boundary changes, the workflow's own security posture was deliberately reviewed and **preserved**: still `pull_request` (never `pull_request_target`, so fork code is never run with our secrets); fork/draft/dependabot gating intact; least-privilege permissions unchanged (`contents: read`); `--allowed-tools` remains strictly read-only (the added `Read`/`Grep`/`Glob` cannot mutate the repo and `Bash` stays limited to `gh pr view`/`gh pr diff`); both actions remain pinned to full commit SHAs.

## Manual verification

- Linted with `actionlint` (v1.7.12): `claude-review.yml` and all workflows clean.
- Reasoned through the trigger/permission/gating/concurrency logic by hand for: normal same-repo push (reviews once on open, **not** on later pushes), draft (skipped), draft→ready (reviews), dependabot (skipped), fork PR (skipped; Codex covers), `claude-review` label add (re-reviews), any other label add (skipped before a runner starts), reopened (reviews). Concurrency group resolves for every case.
- Ran `validate_docs.py`, `validate_alembic.py`, and `git diff --check` — all clean.

### Live run on this PR (observed)

Opening this PR triggered both workflows on the `opened` event, which confirmed the new triggers fire, `CLAUDE_CODE_OAUTH_TOKEN` is available on a same-repo PR, and the rewritten YAML/`claude_args` parse and load. The reviewer then **correctly skipped posting**: the action enforces an anti-tamper guard that only runs when the workflow file is byte-identical to the version on the default branch. Because this PR edits `claude-review.yml`, the guard trips by design — the run log reads "your workflow will begin working once you merge your PR." Net effect: the new review behaviour cannot be demonstrated on this self-modifying PR and will first run on the next normal PR after merge, so please evaluate this change from the static diff, the `actionlint` pass, and the by-hand trigger reasoning rather than a live demo. Because Claude was never invoked, no review tokens were consumed. (This anti-tamper guard is itself a useful protection: a PR cannot rewrite the review workflow and have the tampered version run with our secrets.)

### Pending before the re-review label works

- One-time maintainer action: apply the new label with the `gh label create "claude-review" ...` command now listed in `.github/SUPPORT.md` (the same one-time label-sync step used for every other label).

## Screenshots (if relevant)

N/A — CI/config and docs only.
