### PR TITLE
feat(frontend): improve calendar agenda and day timeline UX

### DIFF
--- a/docs/CALENDAR.md
+++ b/docs/CALENDAR.md
@@ -64,11 +64,14 @@ When calendar sync is configured:
 - The dashboard month view shows dots on days with synced events and on days that contain unlinked Nojoin recordings.
 - Unlinked Nojoin recordings use the Nojoin orange accent so they remain visually distinct from Google or Microsoft calendar sources.
 - The agenda view is month-scoped and shows both calendar events and unlinked historical recordings for the viewed month.
+- In the current month, the agenda lists upcoming items first and collapses past items behind a `Show past events` control; past months render fully expanded.
 - Selecting a day in month view opens a day agenda, and selecting today shows a live now marker against timed events.
+- Clicking a timed event on the day timeline opens a details popover with the full event metadata, join link, and linked recordings; live events additionally show a `Join` button on the bubble.
+- Timeline bubbles size their metadata to the event duration: shorter events show fewer detail rows, and events spanning midnight are marked with dashed edges and chevrons.
 - The `Today` action jumps back to the current month and date context.
 - Per-calendar colours can be used so different sources remain visually distinct.
 - Event times render in the user's configured Nojoin timezone.
-- Meeting links and supported online meeting URLs can be surfaced directly from agenda items.
+- Meeting links and supported online meeting URLs surface from agenda items as compact `Join meeting` labels showing the provider host instead of the raw URL.
 
 When no calendar is connected and there are no unlinked recordings in view, the dashboard deliberately shows an honest empty state rather than mock data.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -44,6 +44,11 @@ On desktop viewports around `1920x1080` and smaller, Nojoin automatically shifts
 - Unlinked Nojoin recordings appear on the dashboard calendar as orange meeting items, while Google or Microsoft calendar sources keep their own colours.
 - Recorded meeting cards surface tags, speakers, and timestamps directly inside the selected-day agenda.
 - The agenda view is month-scoped and includes both synced calendar events and unlinked Nojoin meeting history for the viewed month.
+- In the current month, the agenda starts at the next upcoming item; use **Show past events** to expand earlier items. Past months always show their full history.
+- Clicking a timed event bubble in the day timeline opens a details popover with the full title, time, calendar, location, join link, and linked recordings.
+- Live events with a trusted meeting link show a **Join** button directly on the timeline bubble.
+- Meeting links render as compact **Join meeting** labels with the provider host rather than raw URLs; the full URL appears on hover.
+- Events continuing past midnight show dashed edges and chevrons on the day timeline.
 - Event times render in your configured Nojoin timezone.
 
 Read [CALENDAR.md](CALENDAR.md) for connection and setup details.

--- a/frontend/src/components/DashboardUpcomingMeetingsCard.test.tsx
+++ b/frontend/src/components/DashboardUpcomingMeetingsCard.test.tsx
@@ -149,7 +149,9 @@ describe("DashboardUpcomingMeetingsCard", () => {
     });
   });
 
-  it("shows recordings and events in the agenda view", async () => {
+  it("shows upcoming items in the agenda view and reveals past items on demand", async () => {
+    // now is 10:00; the event ended at 09:30 (past), the recording ends at
+    // 11:45 (still upcoming).
     getCalendarDashboardSummary.mockResolvedValue(
       makeSummary({
         agenda_items: [makeEvent({ id: 1, title: "Planning meeting" })],
@@ -166,9 +168,19 @@ describe("DashboardUpcomingMeetingsCard", () => {
     fireEvent.click(screen.getByRole("button", { name: /Agenda/ }));
 
     await vi.waitFor(() => {
-      expect(screen.getByText("Planning meeting")).toBeInTheDocument();
+      expect(screen.getByText("Recorded sync")).toBeInTheDocument();
     });
+    expect(screen.queryByText("Planning meeting")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show 1 past event" }),
+    );
+
+    expect(screen.getByText("Planning meeting")).toBeInTheDocument();
     expect(screen.getByText("Recorded sync")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide past events" }),
+    ).toBeInTheDocument();
   });
 
   it("links a recording card to its recording detail page", async () => {

--- a/frontend/src/components/DashboardUpcomingMeetingsCard.test.tsx
+++ b/frontend/src/components/DashboardUpcomingMeetingsCard.test.tsx
@@ -193,6 +193,51 @@ describe("DashboardUpcomingMeetingsCard", () => {
     expect(within(card!).getByText("Alice, Bob")).toBeInTheDocument();
   });
 
+  it("opens an event details popover when a timeline bubble is clicked", async () => {
+    const location =
+      "Huckletree Oxford Circus - West London Coworking & Office Space, 213 Oxford St, London W1D 2LG, UK";
+    getCalendarDashboardSummary.mockResolvedValue(
+      makeSummary({
+        agenda_items: [
+          makeEvent({
+            title: "Workshop",
+            starts_at: "2026-06-15T11:00:00.000Z",
+            ends_at: "2026-06-15T12:00:00.000Z",
+            location,
+            meeting_url: "https://meet.google.com/abc-defg-hij",
+            meeting_url_trusted: true,
+            meeting_url_host: "meet.google.com",
+          }),
+        ],
+      }),
+    );
+
+    renderWithProviders(<DashboardUpcomingMeetingsCard />);
+
+    const bubbles = await vi.waitFor(() => {
+      const found = screen.getAllByRole("button", {
+        name: "View details for Workshop",
+      });
+      expect(found.length).toBeGreaterThan(0);
+      return found;
+    });
+
+    expect(screen.queryByText(/Join meeting/)).not.toBeInTheDocument();
+
+    const [bubble] = bubbles;
+    fireEvent.click(bubble);
+
+    const joinLink = screen.getByRole("link", {
+      name: /Join meeting \(meet\.google\.com\)/,
+    });
+    expect(joinLink).toHaveAttribute(
+      "href",
+      "https://meet.google.com/abc-defg-hij",
+    );
+    // The popover shows the full, unclipped location.
+    expect(screen.getAllByText(location).length).toBeGreaterThan(0);
+  });
+
   it("disables the Today button while viewing today", async () => {
     renderWithProviders(<DashboardUpcomingMeetingsCard />);
 

--- a/frontend/src/components/DashboardUpcomingMeetingsCard.test.tsx
+++ b/frontend/src/components/DashboardUpcomingMeetingsCard.test.tsx
@@ -205,6 +205,45 @@ describe("DashboardUpcomingMeetingsCard", () => {
     expect(within(card!).getByText("Alice, Bob")).toBeInTheDocument();
   });
 
+  it("renders a compact join label instead of the raw meeting URL in the agenda", async () => {
+    getCalendarDashboardSummary.mockResolvedValue(
+      makeSummary({
+        agenda_items: [
+          makeEvent({
+            title: "Investors call",
+            starts_at: "2026-06-16T16:00:00.000Z",
+            ends_at: "2026-06-16T17:00:00.000Z",
+            meeting_url:
+              "https://us02web.zoom.us/w/89206805925?tk=G2SKabvvz99wb7RA7XM2kJvfx0",
+            meeting_url_trusted: true,
+            meeting_url_host: "us02web.zoom.us",
+          }),
+        ],
+      }),
+    );
+
+    renderWithProviders(<DashboardUpcomingMeetingsCard />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("June 2026")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Agenda/ }));
+
+    const joinLink = await vi.waitFor(() =>
+      screen.getByRole("link", {
+        name: "Join meeting (us02web.zoom.us)",
+      }),
+    );
+    expect(joinLink).toHaveAttribute(
+      "href",
+      "https://us02web.zoom.us/w/89206805925?tk=G2SKabvvz99wb7RA7XM2kJvfx0",
+    );
+    expect(
+      screen.queryByText(/us02web\.zoom\.us\/w\/89206805925/),
+    ).not.toBeInTheDocument();
+  });
+
   it("opens an event details popover when a timeline bubble is clicked", async () => {
     const location =
       "Huckletree Oxford Circus - West London Coworking & Office Space, 213 Oxford St, London W1D 2LG, UK";

--- a/frontend/src/components/DashboardUpcomingMeetingsCard.tsx
+++ b/frontend/src/components/DashboardUpcomingMeetingsCard.tsx
@@ -419,6 +419,8 @@ export default function DashboardUpcomingMeetingsCard() {
                                   status={event.status}
                                   layout="timeline"
                                   visualHeight={event.height}
+                                  continuesBefore={event.continuesBefore}
+                                  continuesAfter={event.continuesAfter}
                                 />
                               </div>
                             ))}

--- a/frontend/src/components/DashboardUpcomingMeetingsCard.tsx
+++ b/frontend/src/components/DashboardUpcomingMeetingsCard.tsx
@@ -5,6 +5,7 @@ import {
   CalendarRange,
   ChevronLeft,
   ChevronRight,
+  History,
   LayoutGrid,
   Loader2,
   List,
@@ -47,6 +48,11 @@ export default function DashboardUpcomingMeetingsCard() {
     footerText,
     monthAgendaItems,
     monthHasContent,
+    agendaPastItems,
+    agendaUpcomingItems,
+    agendaShowsPastItems,
+    canTogglePastAgendaItems,
+    handleTogglePastAgendaItems,
     selectedDayEvents,
     selectedDayRecordings,
     selectedDayHasContent,
@@ -277,7 +283,22 @@ export default function DashboardUpcomingMeetingsCard() {
               </div>
             ) : monthAgendaItems.length ? (
               <div className="mt-4 space-y-3">
-                {monthAgendaItems.map((item) => (
+                {canTogglePastAgendaItems && (
+                  <button
+                    type="button"
+                    onClick={handleTogglePastAgendaItems}
+                    className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white/85 px-3 py-1.5 text-xs font-medium text-gray-600 shadow-sm transition-colors hover:border-orange-200 hover:bg-orange-50 hover:text-orange-700 dark:border-white/10 dark:bg-white/5 dark:text-gray-300 dark:hover:border-orange-500/20 dark:hover:bg-orange-500/10 dark:hover:text-orange-300"
+                  >
+                    <History className="h-3.5 w-3.5" />
+                    {agendaShowsPastItems
+                      ? "Hide past events"
+                      : `Show ${agendaPastItems.length} past ${agendaPastItems.length === 1 ? "event" : "events"}`}
+                  </button>
+                )}
+                {(agendaShowsPastItems
+                  ? [...agendaPastItems, ...agendaUpcomingItems]
+                  : agendaUpcomingItems
+                ).map((item) => (
                   item.kind === "event" ? (
                     <AgendaEventCard key={`event-${item.event.id}`} event={item.event} timeZone={activeTimeZone} />
                   ) : (
@@ -289,6 +310,13 @@ export default function DashboardUpcomingMeetingsCard() {
                     />
                   )
                 ))}
+                {!agendaShowsPastItems && agendaUpcomingItems.length === 0 && (
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    <span suppressHydrationWarning>
+                      No upcoming events in {viewedMonthLabel}.
+                    </span>
+                  </p>
+                )}
               </div>
             ) : (
               <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">

--- a/frontend/src/components/upcomingMeetings/CalendarCards.tsx
+++ b/frontend/src/components/upcomingMeetings/CalendarCards.tsx
@@ -3,6 +3,8 @@ import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
   ArrowRight,
   Calendar,
+  ChevronsDown,
+  ChevronsUp,
   Clock,
   ExternalLink,
   MapPin,
@@ -181,12 +183,16 @@ export function DayTimelineEventCard({
   status,
   layout,
   visualHeight,
+  continuesBefore,
+  continuesAfter,
 }: {
   event: CalendarDashboardEvent;
   timeZone: string;
   status: DayTimelineStatus;
   layout: "timeline" | "stacked";
   visualHeight?: number;
+  continuesBefore?: boolean;
+  continuesAfter?: boolean;
 }) {
   const calendarColour = getCalendarColourPresentation(event.calendar_colour);
   const {
@@ -238,6 +244,10 @@ export function DayTimelineEventCard({
       : "border-gray-200 dark:border-gray-700/70"
   } ${
     isPast ? "opacity-70" : ""
+  } ${
+    layout === "timeline" && continuesBefore ? "[border-top-style:dashed]" : ""
+  } ${
+    layout === "timeline" && continuesAfter ? "[border-bottom-style:dashed]" : ""
   }`;
   const cardContent = (
     <>
@@ -245,6 +255,12 @@ export function DayTimelineEventCard({
         className={`absolute inset-y-0 left-0 w-1.5 ${calendarColour.className}`}
         style={calendarColour.style}
       />
+      {layout === "timeline" && continuesBefore && (
+        <ChevronsUp className="pointer-events-none absolute left-1/2 top-0 h-3 w-3 -translate-x-1/2 text-gray-400 dark:text-gray-500" />
+      )}
+      {layout === "timeline" && continuesAfter && (
+        <ChevronsDown className="pointer-events-none absolute bottom-0 left-1/2 h-3 w-3 -translate-x-1/2 text-gray-400 dark:text-gray-500" />
+      )}
       <div className={`h-full pl-4 pr-3 ${paddingClass}`}>
         <div className={`flex items-start justify-between gap-3 ${showJoinPill ? "pr-12" : ""}`}>
           <div className="min-w-0">

--- a/frontend/src/components/upcomingMeetings/CalendarCards.tsx
+++ b/frontend/src/components/upcomingMeetings/CalendarCards.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
   ArrowRight,
   Calendar,
@@ -6,6 +7,7 @@ import {
   ExternalLink,
   MapPin,
   Users,
+  Video,
 } from "lucide-react";
 
 import { getColorByKey } from "@/lib/constants";
@@ -31,6 +33,7 @@ import {
   getTimelinePaddingClass,
   getTimelineTitleClass,
 } from "./calendarUtils";
+import { EventDetailsPopoverContent } from "./EventDetailsPopover";
 
 export function LinkedRecordingsMeta({
   recordings,
@@ -194,11 +197,10 @@ export function DayTimelineEventCard({
   } = getAgendaEventPresentation(event);
   const isLive = status === "live";
   const isPast = status === "past";
-  const primaryUrl = showMeetingUrl && meetingUrl
-    ? meetingUrl
-    : showLocation && locationText && locationIsUrl
-      ? locationText
-      : null;
+  const hasLink = Boolean(
+    (showMeetingUrl && meetingUrl) ||
+      (showLocation && locationText && locationIsUrl),
+  );
   const timelineDensity = layout === "timeline"
     ? visualHeight !== undefined && visualHeight < 28
       ? "dense"
@@ -223,16 +225,18 @@ export function DayTimelineEventCard({
   const dotSizeClass = layout === "timeline"
     ? getTimelineDotSizeClass(visualHeight)
     : "h-2.5 w-2.5";
-  const cardClasses = `relative h-full overflow-hidden rounded-[5px] border bg-white shadow-sm dark:bg-gray-900/95 ${
+  const showJoinPill = Boolean(
+    isLive &&
+      showMeetingUrl &&
+      meetingUrl &&
+      (layout === "stacked" || timelineDensity === "comfortable"),
+  );
+  const cardClasses = `relative block h-full w-full cursor-pointer overflow-hidden rounded-[5px] border bg-white text-left shadow-sm transition-colors hover:border-orange-200 hover:bg-orange-50/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 dark:bg-gray-900/95 dark:hover:border-orange-400/30 dark:hover:bg-orange-500/10 ${
     isLive
       ? "border-orange-300 shadow-orange-600/15 dark:border-orange-400/40"
       : "border-gray-200 dark:border-gray-700/70"
   } ${
     isPast ? "opacity-70" : ""
-  } ${
-    primaryUrl
-      ? "block cursor-pointer transition-colors hover:border-orange-200 hover:bg-orange-50/60 dark:hover:border-orange-400/30 dark:hover:bg-orange-500/10"
-      : ""
   }`;
   const cardContent = (
     <>
@@ -241,7 +245,7 @@ export function DayTimelineEventCard({
         style={calendarColour.style}
       />
       <div className={`h-full pl-4 pr-3 ${paddingClass}`}>
-        <div className="flex items-start justify-between gap-3">
+        <div className={`flex items-start justify-between gap-3 ${showJoinPill ? "pr-12" : ""}`}>
           <div className="min-w-0">
             {showTimeRow && (
               <div className="flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">
@@ -257,15 +261,17 @@ export function DayTimelineEventCard({
               {event.title}
             </div>
           </div>
-          <div className="mt-1 flex shrink-0 items-center gap-1.5">
-            {primaryUrl && (
-              <ExternalLink className={`${linkIndicatorClass} text-gray-400 dark:text-gray-500`} />
-            )}
-            <span
-              className={`${dotSizeClass} rounded-full ${calendarColour.className}`}
-              style={calendarColour.style}
-            />
-          </div>
+          {!showJoinPill && (
+            <div className="mt-1 flex shrink-0 items-center gap-1.5">
+              {hasLink && (
+                <ExternalLink className={`${linkIndicatorClass} text-gray-400 dark:text-gray-500`} />
+              )}
+              <span
+                className={`${dotSizeClass} rounded-full ${calendarColour.className}`}
+                style={calendarColour.style}
+              />
+            </div>
+          )}
         </div>
 
         {showSecondaryMetadata && (
@@ -284,29 +290,47 @@ export function DayTimelineEventCard({
               </div>
             )}
 
-            {!isSmallTimelineEvent ? (
-              <LinkedRecordingsMeta recordings={event.linked_recordings} />
-            ) : null}
           </>
         )}
       </div>
     </>
   );
 
-  if (primaryUrl) {
-    return (
-      <a
-        href={primaryUrl}
-        target="_blank"
-        rel="noopener noreferrer"
+  return (
+    <Popover className="relative block h-full">
+      <PopoverButton
         className={cardClasses}
+        aria-label={`View details for ${event.title}`}
       >
         {cardContent}
-      </a>
-    );
-  }
-
-  return <div className={cardClasses}>{cardContent}</div>;
+      </PopoverButton>
+      {showJoinPill && meetingUrl && (
+        <a
+          href={meetingUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute right-2 top-2 z-20 inline-flex items-center gap-1 rounded-full bg-orange-600 px-2.5 py-0.5 text-[10px] font-semibold text-white shadow-sm transition-colors hover:bg-orange-700"
+        >
+          <Video className="h-3 w-3" />
+          Join
+        </a>
+      )}
+      <PopoverPanel
+        anchor={{
+          to: layout === "timeline" ? "right start" : "bottom",
+          gap: 8,
+          padding: 12,
+        }}
+        className="z-50 focus:outline-none"
+      >
+        <EventDetailsPopoverContent
+          event={event}
+          timeZone={timeZone}
+          status={status}
+        />
+      </PopoverPanel>
+    </Popover>
+  );
 }
 
 export function AgendaEventCard({

--- a/frontend/src/components/upcomingMeetings/CalendarCards.tsx
+++ b/frontend/src/components/upcomingMeetings/CalendarCards.tsx
@@ -36,6 +36,7 @@ import {
   getTimelineMetadataRowCapacity,
   getTimelinePaddingClass,
   getTimelineTitleClass,
+  getUrlHost,
 } from "./calendarUtils";
 import { EventDetailsPopoverContent } from "./EventDetailsPopover";
 
@@ -386,6 +387,8 @@ export function AgendaEventCard({
     showLocation,
     showMeetingUrl,
   } = getAgendaEventPresentation(event);
+  const meetingHost = event.meeting_url_host || getUrlHost(meetingUrl);
+  const locationHost = getUrlHost(locationText);
 
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700/70 dark:bg-gray-800/80">
@@ -412,10 +415,13 @@ export function AgendaEventCard({
                 href={locationText}
                 target="_blank"
                 rel="noopener noreferrer"
+                title={locationText}
                 className="inline-flex items-start gap-2 text-gray-600 transition-colors hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-white"
               >
                 <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
-                <span className="min-w-0 break-all">{locationText}</span>
+                <span className="min-w-0 break-words">
+                  Open link{locationHost ? ` (${locationHost})` : ""}
+                </span>
               </a>
             ) : (
               <div className="inline-flex items-start gap-2">
@@ -430,10 +436,13 @@ export function AgendaEventCard({
               href={meetingUrl}
               target="_blank"
               rel="noopener noreferrer"
+              title={meetingUrl}
               className="inline-flex items-start gap-2 text-gray-600 transition-colors hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-white"
             >
               <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
-              <span className="min-w-0 break-all">{meetingUrl}</span>
+              <span className="min-w-0 break-words">
+                Join meeting{meetingHost ? ` (${meetingHost})` : ""}
+              </span>
             </a>
           )}
         </div>

--- a/frontend/src/components/upcomingMeetings/CalendarCards.tsx
+++ b/frontend/src/components/upcomingMeetings/CalendarCards.tsx
@@ -6,6 +6,7 @@ import {
   Clock,
   ExternalLink,
   MapPin,
+  Mic,
   Users,
   Video,
 } from "lucide-react";
@@ -263,6 +264,17 @@ export function DayTimelineEventCard({
           </div>
           {!showJoinPill && (
             <div className="mt-1 flex shrink-0 items-center gap-1.5">
+              {event.linked_recordings.length > 0 && (
+                <span
+                  title={
+                    event.linked_recordings.length === 1
+                      ? "1 linked recording"
+                      : `${event.linked_recordings.length} linked recordings`
+                  }
+                >
+                  <Mic className={`${linkIndicatorClass} text-orange-600 dark:text-orange-300`} />
+                </span>
+              )}
               {hasLink && (
                 <ExternalLink className={`${linkIndicatorClass} text-gray-400 dark:text-gray-500`} />
               )}

--- a/frontend/src/components/upcomingMeetings/CalendarCards.tsx
+++ b/frontend/src/components/upcomingMeetings/CalendarCards.tsx
@@ -275,9 +275,12 @@ export function DayTimelineEventCard({
             </div>
 
             {showPlainLocation && locationText && (
-              <div className="mt-2 inline-flex max-w-full items-start gap-2 text-xs text-gray-600 dark:text-gray-300">
-                <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0 text-orange-600 dark:text-orange-300" />
-                <span className="line-clamp-2">{locationText}</span>
+              <div
+                className="mt-2 flex min-w-0 items-center gap-2 text-xs text-gray-600 dark:text-gray-300"
+                title={locationText}
+              >
+                <MapPin className="h-3.5 w-3.5 shrink-0 text-orange-600 dark:text-orange-300" />
+                <span className="truncate">{locationText}</span>
               </div>
             )}
 

--- a/frontend/src/components/upcomingMeetings/CalendarCards.tsx
+++ b/frontend/src/components/upcomingMeetings/CalendarCards.tsx
@@ -33,6 +33,7 @@ import {
   getRecordingStatusClasses,
   getTimelineDotSizeClass,
   getTimelineIndicatorSizeClass,
+  getTimelineMetadataRowCapacity,
   getTimelinePaddingClass,
   getTimelineTitleClass,
 } from "./calendarUtils";
@@ -216,8 +217,15 @@ export function DayTimelineEventCard({
         : "comfortable"
     : "comfortable";
   const isSmallTimelineEvent = layout === "timeline" && timelineDensity !== "comfortable";
-  const showSecondaryMetadata = layout === "stacked" || timelineDensity === "comfortable";
-  const showPlainLocation = Boolean(showLocation && locationText && !locationIsUrl && showSecondaryMetadata);
+  const metadataRowCapacity = layout === "stacked"
+    ? 2
+    : timelineDensity === "comfortable"
+      ? getTimelineMetadataRowCapacity(visualHeight)
+      : 0;
+  const hasPlainLocation = Boolean(showLocation && locationText && !locationIsUrl);
+  const showPlainLocation = hasPlainLocation && metadataRowCapacity >= 1;
+  const showCalendarName =
+    metadataRowCapacity >= 2 || (metadataRowCapacity >= 1 && !hasPlainLocation);
   const showTimeRow = layout === "stacked" || !isSmallTimelineEvent;
   const showLiveBadge = layout === "stacked" && isLive;
   const titleClass = layout === "timeline"
@@ -302,11 +310,13 @@ export function DayTimelineEventCard({
           )}
         </div>
 
-        {showSecondaryMetadata && (
+        {(showCalendarName || showPlainLocation) && (
           <>
-            <div className="mt-2 text-xs text-gray-600 dark:text-gray-300">
-              {event.calendar_name}
-            </div>
+            {showCalendarName && (
+              <div className="mt-2 text-xs text-gray-600 dark:text-gray-300">
+                {event.calendar_name}
+              </div>
+            )}
 
             {showPlainLocation && locationText && (
               <div

--- a/frontend/src/components/upcomingMeetings/EventDetailsPopover.tsx
+++ b/frontend/src/components/upcomingMeetings/EventDetailsPopover.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import { ArrowRight, ExternalLink, MapPin, Video } from "lucide-react";
+
+import { CalendarDashboardEvent } from "@/types";
+
+import {
+  DayTimelineStatus,
+  formatAgendaDate,
+  formatAgendaTime,
+  getAgendaEventPresentation,
+  getCalendarColourPresentation,
+  getUrlHost,
+} from "./calendarUtils";
+
+export function EventDetailsPopoverContent({
+  event,
+  timeZone,
+  status,
+}: {
+  event: CalendarDashboardEvent;
+  timeZone: string;
+  status?: DayTimelineStatus;
+}) {
+  const calendarColour = getCalendarColourPresentation(event.calendar_colour);
+  const {
+    locationText,
+    meetingUrl,
+    locationIsUrl,
+    showLocation,
+    showMeetingUrl,
+  } = getAgendaEventPresentation(event);
+  const meetingHost = event.meeting_url_host || getUrlHost(meetingUrl);
+  const locationHost = getUrlHost(locationText);
+
+  return (
+    <div className="w-72 rounded-2xl border border-gray-200 bg-white p-4 text-left shadow-xl shadow-gray-950/15 dark:border-gray-700/70 dark:bg-gray-900 sm:w-80">
+      <div className="flex items-start justify-between gap-3">
+        <div className="text-sm font-semibold text-gray-950 dark:text-white">
+          {event.title}
+        </div>
+        {status === "live" && (
+          <span className="shrink-0 rounded-full bg-orange-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-orange-700 dark:bg-orange-500/15 dark:text-orange-200">
+            Live now
+          </span>
+        )}
+      </div>
+
+      <div className="mt-2 text-xs font-medium uppercase tracking-[0.12em] text-gray-500 dark:text-gray-400">
+        {formatAgendaDate(event, timeZone)} • {formatAgendaTime(event, timeZone)}
+      </div>
+
+      <div className="mt-2 flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+        <span
+          className={`h-2 w-2 shrink-0 rounded-full ${calendarColour.className}`}
+          style={calendarColour.style}
+        />
+        <span className="min-w-0 truncate">{event.calendar_name}</span>
+      </div>
+
+      {showLocation && locationText && (
+        locationIsUrl ? (
+          <a
+            href={locationText}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={locationText}
+            className="mt-3 flex items-start gap-2 text-xs text-gray-600 transition-colors hover:text-gray-900 hover:underline dark:text-gray-300 dark:hover:text-white"
+          >
+            <ExternalLink className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
+            <span className="min-w-0 break-words">
+              Open link{locationHost ? ` (${locationHost})` : ""}
+            </span>
+          </a>
+        ) : (
+          <div className="mt-3 flex items-start gap-2 text-xs text-gray-600 dark:text-gray-300">
+            <MapPin className="h-3.5 w-3.5 shrink-0 text-orange-600 dark:text-orange-300" />
+            <span className="min-w-0 break-words">{locationText}</span>
+          </div>
+        )
+      )}
+
+      {showMeetingUrl && meetingUrl && (
+        <a
+          href={meetingUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={meetingUrl}
+          className="mt-3 inline-flex items-center gap-2 rounded-full bg-orange-600 px-3.5 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-orange-700"
+        >
+          <Video className="h-3.5 w-3.5" />
+          Join meeting{meetingHost ? ` (${meetingHost})` : ""}
+        </a>
+      )}
+
+      {event.linked_recordings.length > 0 && (
+        <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700/70">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-gray-500 dark:text-gray-400">
+            Linked recordings
+          </div>
+          <div className="mt-2 space-y-1.5">
+            {event.linked_recordings.map((recording) => (
+              <Link
+                key={recording.id}
+                href={`/recordings/${recording.id}`}
+                className="flex items-center gap-1.5 text-xs font-medium text-gray-700 transition-colors hover:text-orange-700 dark:text-gray-200 dark:hover:text-orange-300"
+              >
+                <ArrowRight className="h-3 w-3 shrink-0" />
+                <span className="min-w-0 truncate">{recording.name}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/upcomingMeetings/calendarUtils.test.ts
+++ b/frontend/src/components/upcomingMeetings/calendarUtils.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RecordingStatus,
+  type CalendarDashboardEvent,
+  type CalendarDashboardRecording,
+} from "@/types";
+
+import {
+  buildMonthAgendaItems,
+  getTimelineMetadataRowCapacity,
+  getUrlHost,
+  isAgendaItemPast,
+  splitMonthAgendaItems,
+} from "./calendarUtils";
+
+function makeEvent(
+  overrides: Partial<CalendarDashboardEvent> = {},
+): CalendarDashboardEvent {
+  return {
+    id: 1,
+    title: "Standup",
+    provider: "google",
+    calendar_id: 10,
+    calendar_name: "Work",
+    calendar_colour: "blue",
+    meeting_url_trusted: false,
+    is_all_day: false,
+    starts_at: "2026-06-15T09:00:00.000Z",
+    ends_at: "2026-06-15T09:30:00.000Z",
+    linked_recordings: [],
+    ...overrides,
+  };
+}
+
+function makeRecording(
+  overrides: Partial<CalendarDashboardRecording> = {},
+): CalendarDashboardRecording {
+  return {
+    id: 100,
+    name: "Recorded sync",
+    starts_at: "2026-06-15T08:00:00.000Z",
+    ends_at: "2026-06-15T08:45:00.000Z",
+    duration_seconds: 2700,
+    status: RecordingStatus.PROCESSED,
+    speaker_names: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+const now = new Date("2026-06-15T10:00:00.000Z");
+
+describe("isAgendaItemPast", () => {
+  it("treats an ended timed event as past", () => {
+    const [item] = buildMonthAgendaItems([makeEvent()], []);
+    expect(isAgendaItemPast(item, now)).toBe(true);
+  });
+
+  it("treats a live event as upcoming until it ends", () => {
+    const [item] = buildMonthAgendaItems(
+      [
+        makeEvent({
+          starts_at: "2026-06-15T09:30:00.000Z",
+          ends_at: "2026-06-15T10:30:00.000Z",
+        }),
+      ],
+      [],
+    );
+    expect(isAgendaItemPast(item, now)).toBe(false);
+  });
+
+  it("keeps an all-day event current for its whole final day", () => {
+    const [today] = buildMonthAgendaItems(
+      [
+        makeEvent({
+          is_all_day: true,
+          starts_at: null,
+          ends_at: null,
+          start_date: "2026-06-15",
+          end_date: "2026-06-16",
+        }),
+      ],
+      [],
+    );
+    const [yesterday] = buildMonthAgendaItems(
+      [
+        makeEvent({
+          is_all_day: true,
+          starts_at: null,
+          ends_at: null,
+          start_date: "2026-06-14",
+          end_date: "2026-06-15",
+        }),
+      ],
+      [],
+    );
+
+    expect(isAgendaItemPast(today, new Date("2026-06-15T23:00:00.000Z"))).toBe(
+      false,
+    );
+    expect(isAgendaItemPast(yesterday, new Date("2026-06-16T01:00:00.000Z"))).toBe(
+      true,
+    );
+  });
+
+  it("classifies recordings by their end time", () => {
+    const [pastRecording] = buildMonthAgendaItems([], [makeRecording()]);
+    const [upcomingRecording] = buildMonthAgendaItems(
+      [],
+      [
+        makeRecording({
+          starts_at: "2026-06-15T09:45:00.000Z",
+          ends_at: "2026-06-15T10:30:00.000Z",
+        }),
+      ],
+    );
+
+    expect(isAgendaItemPast(pastRecording, now)).toBe(true);
+    expect(isAgendaItemPast(upcomingRecording, now)).toBe(false);
+  });
+});
+
+describe("splitMonthAgendaItems", () => {
+  it("partitions items while preserving chronological order", () => {
+    const items = buildMonthAgendaItems(
+      [
+        makeEvent({ id: 1, title: "Past meeting" }),
+        makeEvent({
+          id: 2,
+          title: "Future meeting",
+          starts_at: "2026-06-20T09:00:00.000Z",
+          ends_at: "2026-06-20T10:00:00.000Z",
+        }),
+      ],
+      [makeRecording({ id: 100 })],
+    );
+
+    const { pastItems, upcomingItems } = splitMonthAgendaItems(items, now);
+
+    expect(pastItems).toHaveLength(2);
+    expect(upcomingItems).toHaveLength(1);
+    expect(
+      upcomingItems[0].kind === "event" && upcomingItems[0].event.title,
+    ).toBe("Future meeting");
+  });
+});
+
+describe("getUrlHost", () => {
+  it("extracts the hostname without the www prefix", () => {
+    expect(getUrlHost("https://www.zoom.us/j/123?pwd=abc")).toBe("zoom.us");
+    expect(getUrlHost("https://meet.google.com/abc-defg-hij")).toBe(
+      "meet.google.com",
+    );
+  });
+
+  it("accepts bare hosts and rejects non-URLs", () => {
+    expect(getUrlHost("meet.google.com")).toBe("meet.google.com");
+    expect(getUrlHost("Room 4, Main Office")).toBeNull();
+    expect(getUrlHost(null)).toBeNull();
+  });
+});
+
+describe("getTimelineMetadataRowCapacity", () => {
+  it("scales metadata rows with the bubble height", () => {
+    expect(getTimelineMetadataRowCapacity(undefined)).toBe(2);
+    expect(getTimelineMetadataRowCapacity(66)).toBe(0);
+    expect(getTimelineMetadataRowCapacity(88)).toBe(1);
+    expect(getTimelineMetadataRowCapacity(132)).toBe(2);
+  });
+});

--- a/frontend/src/components/upcomingMeetings/calendarUtils.ts
+++ b/frontend/src/components/upcomingMeetings/calendarUtils.ts
@@ -366,6 +366,41 @@ export function buildMonthAgendaItems(
   });
 }
 
+export function isAgendaItemPast(item: MonthAgendaItem, now: Date): boolean {
+  if (item.kind === "recording") {
+    const recordingEnd =
+      getRecordingEnd(item.recording) ?? getRecordingStart(item.recording);
+    return recordingEnd < now;
+  }
+
+  const eventEnd = getEventEnd(item.event);
+  if (!eventEnd) {
+    return false;
+  }
+
+  if (item.event.is_all_day) {
+    // getEventEnd returns the start of the last covered day for all-day
+    // events, so the item stays current until that day has fully elapsed.
+    return addDays(startOfDay(eventEnd), 1) <= now;
+  }
+
+  return eventEnd < now;
+}
+
+export function splitMonthAgendaItems(
+  items: MonthAgendaItem[],
+  now: Date,
+): { pastItems: MonthAgendaItem[]; upcomingItems: MonthAgendaItem[] } {
+  const pastItems: MonthAgendaItem[] = [];
+  const upcomingItems: MonthAgendaItem[] = [];
+
+  items.forEach((item) => {
+    (isAgendaItemPast(item, now) ? pastItems : upcomingItems).push(item);
+  });
+
+  return { pastItems, upcomingItems };
+}
+
 export function formatAgendaDate(
   event: CalendarDashboardEvent,
   timeZone: string,

--- a/frontend/src/components/upcomingMeetings/calendarUtils.ts
+++ b/frontend/src/components/upcomingMeetings/calendarUtils.ts
@@ -417,6 +417,20 @@ export function isHttpUrl(value: string | null | undefined): boolean {
   }
 }
 
+export function getUrlHost(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.hostname.replace(/^www\./, "") || null;
+  } catch {
+    // Bare hosts (e.g. backend-provided meeting_url_host) are not valid URLs.
+    return /^[\w.-]+\.[a-z]{2,}$/i.test(value) ? value.replace(/^www\./, "") : null;
+  }
+}
+
 export function normaliseComparableUrl(
   value: string | null | undefined,
 ): string | null {

--- a/frontend/src/components/upcomingMeetings/calendarUtils.ts
+++ b/frontend/src/components/upcomingMeetings/calendarUtils.ts
@@ -508,6 +508,27 @@ export function getTimelineTitleClass(
   return "truncate text-[13px] leading-4";
 }
 
+/**
+ * Number of secondary metadata rows (calendar name, location) that fit inside
+ * a timeline bubble without being clipped by its duration-derived height.
+ * Budget: vertical padding + time row + single-line title is roughly 62px,
+ * and each metadata row adds roughly 24px.
+ */
+export function getTimelineMetadataRowCapacity(
+  visualHeight: number | undefined,
+): number {
+  if (visualHeight === undefined) {
+    return 2;
+  }
+  if (visualHeight >= 108) {
+    return 2;
+  }
+  if (visualHeight >= 84) {
+    return 1;
+  }
+  return 0;
+}
+
 export function getTimelinePaddingClass(
   visualHeight: number | undefined,
   isSmallTimelineEvent: boolean,

--- a/frontend/src/components/upcomingMeetings/useCalendarDashboard.ts
+++ b/frontend/src/components/upcomingMeetings/useCalendarDashboard.ts
@@ -30,6 +30,7 @@ import {
   eventOccursOnDay,
   getDayMarkerColours,
   recordingOccursOnDay,
+  splitMonthAgendaItems,
 } from "./calendarUtils";
 
 export function useCalendarDashboard() {
@@ -48,6 +49,7 @@ export function useCalendarDashboard() {
   const [calendarRefreshing, setCalendarRefreshing] = useState(false);
   const [calendarError, setCalendarError] = useState<string | null>(null);
   const [initialisedView, setInitialisedView] = useState(false);
+  const [showPastAgendaItems, setShowPastAgendaItems] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -92,6 +94,10 @@ export function useCalendarDashboard() {
   }, [currentDay, initialisedView, timeZoneReady]);
 
   const viewedMonthKey = format(viewedMonth, "yyyy-MM");
+
+  useEffect(() => {
+    setShowPastAgendaItems(false);
+  }, [viewedMonthKey]);
 
   useEffect(() => {
     if (!timeZoneReady) {
@@ -200,6 +206,15 @@ export function useCalendarDashboard() {
     [monthEvents, monthRecordings],
   );
   const monthHasContent = monthEvents.length > 0 || monthRecordings.length > 0;
+  const monthAgendaSplit = useMemo(
+    () => splitMonthAgendaItems(monthAgendaItems, now),
+    [monthAgendaItems, now],
+  );
+  const isViewingPastMonth =
+    viewedMonth.getTime() < startOfMonth(currentDay).getTime();
+  const agendaShowsPastItems = showPastAgendaItems || isViewingPastMonth;
+  const canTogglePastAgendaItems =
+    !isViewingPastMonth && monthAgendaSplit.pastItems.length > 0;
   const selectedDayEvents = useMemo(() => {
     if (!selectedDay) {
       return [];
@@ -260,6 +275,8 @@ export function useCalendarDashboard() {
     setViewedMonth((currentMonth) => addMonths(currentMonth, -1));
   const handleNextMonth = () =>
     setViewedMonth((currentMonth) => addMonths(currentMonth, 1));
+  const handleTogglePastAgendaItems = () =>
+    setShowPastAgendaItems((currentValue) => !currentValue);
 
   return {
     now,
@@ -280,6 +297,11 @@ export function useCalendarDashboard() {
     footerText,
     monthAgendaItems,
     monthHasContent,
+    agendaPastItems: monthAgendaSplit.pastItems,
+    agendaUpcomingItems: monthAgendaSplit.upcomingItems,
+    agendaShowsPastItems,
+    canTogglePastAgendaItems,
+    handleTogglePastAgendaItems,
     selectedDayEvents,
     selectedDayRecordings,
     selectedDayHasContent,

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -3,6 +3,16 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// jsdom does not implement ResizeObserver, which Headless UI anchored
+// popovers require for floating positioning.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver ??= ResizeObserverStub as unknown as typeof ResizeObserver;
+
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
## Description

Improves the dashboard calendar and agenda UX in eight focused commits. The core problem was that day-timeline event bubbles clip their content: bubble height encodes event duration, so long locations, the linked-recording pill, and other metadata were cut off by the bubble's `overflow-hidden` boundary. This PR fixes the clipping and modernises the surrounding interaction model.

- Location text in timeline bubbles renders on one line with an ellipsis and the full text on hover, instead of wrapping into the clipped region.
- Clicking a timeline bubble now opens a portal-rendered event details popover (Headless UI v2 `anchor` positioning) with the full title, date/time, calendar, complete location, a Join meeting action, and linked recording links. Bubbles are no longer wholesale hyperlinks; live events with a trusted meeting link show a dedicated Join pill on the bubble.
- The clipped "Recording linked" pill inside bubbles is replaced by a mic icon indicator in the bubble header; full links live in the popover.
- Events continuing past midnight show dashed top/bottom edges with chevrons, rendering the `continuesBefore`/`continuesAfter` flags the timeline already computed.
- Bubble metadata is sized to the rows that genuinely fit the duration-derived height (location prioritised over calendar name) instead of rendering everything and clipping.
- The month-scoped agenda view now starts at the next upcoming item with a "Show N past events" control; past months render fully expanded, and live items count as upcoming until they end.
- Agenda cards show compact "Join meeting (host)" / "Open link (host)" labels instead of raw URLs (fixes multi-line Zoom URLs dominating cards); the full URL remains the link target and hover tooltip.

No new dependencies; the popover uses the already-installed `@headlessui/react` v2. A `ResizeObserver` stub was added to the vitest setup because jsdom lacks it and anchored popovers require it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (731 passed)
- [ ] Python quality: `python scripts/check.py` (no Python changes in this PR)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (179 passed, 10 new)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR: `docs/USAGE.md` (Calendar Surface) and `docs/CALENDAR.md` (Dashboard Behaviour).

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

External links keep the existing `target="_blank" rel="noopener noreferrer"` pattern; the trusted-meeting-URL gating from `getAgendaEventPresentation` is unchanged.

## Manual verification

Automated coverage: new unit tests for the details popover (open on click, join link, unclipped location), the agenda past/upcoming split and toggle flow, compact join labels, `isAgendaItemPast`/`splitMonthAgendaItems`, `getUrlHost`, and `getTimelineMetadataRowCapacity`.

Recommended browser smoke before merge (not yet performed):

- Day timeline: click an event bubble; popover shows full location and join link; Escape/outside click closes it.
- Live event with trusted meeting link: Join pill on the bubble opens the meeting directly.
- Agenda view in the current month: starts at next upcoming item; "Show N past events" expands and collapses history; past months render fully.
- Long Zoom-style URLs render as one-line "Join meeting (host)" labels.
- Short (30 min) events show time and title only, with no clipped fragments; an event spanning midnight shows dashed edges and chevrons.

No capture, recording context-menu, or auth paths are touched.

## Screenshots (if relevant)

Before/after screenshots of the clipped location bubble and agenda URL wrapping are available in the linked issue context; happy to attach on request.
