### PR TITLE
ci: bump claude-code-action to v1.0.164

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 1
 
       - name: Review with Claude
-        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1
+        uses: anthropics/claude-code-action@01872ccc02bf66740207fb338a783ce028216758 # v1.0.164
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Deliver the summary as one sticky comment that updates in place on a


### PR DESCRIPTION
## Description

Fixes the Claude PR reviewer, which errored on PR #78 (run 28681710247) with `SDK execution error: ReferenceError: Claude Code native binary not found at /home/runner/.local/bin/claude` — the review never ran.

Root cause: the workflow pinned `anthropics/claude-code-action` at `769e3bd` (v1.0.163), which bundles Claude Code 2.1.199. In the failed run the action's installer reported "Claude Code installed successfully" after ~100ms but never placed the binary — the known silent-install-failure mode (anthropics/claude-code-action#1242, #1290). Upstream published v1.0.164 hours before our failure, whose only change is bumping Claude Code to 2.1.200.

This PR advances the pin to `01872cc` (v1.0.164) and tightens the pin comment from `# v1` to the exact `# v1.0.164`, matching how other actions in this repo are annotated.

Note: per the reviewer's anti-tamper guard, the Claude review skips PRs that edit its own workflow, so this fix only takes effect on PRs opened after this merges to main.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checks run

Workflow-file-only change; the test suites do not exercise it.

- [x] Docs validation: `python3 scripts/validate_docs.py` (run for v1.4.0 release on the same tree)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (run for v1.4.0 release on the same tree)
- [x] YAML parse check on the edited workflow and `git diff --check`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required.

## Security impact

- [x] No security-sensitive change. The action remains pinned by full commit SHA; permissions and allowed tools are unchanged.

## Manual verification

Confirmed from the failed run log that install "succeeded" in ~100ms with no binary placed, and from the upstream repo that v1.0.164 (Claude Code 2.1.200) is the only release after the pinned v1.0.163 (2.1.199). Real verification happens on the first PR opened after merge, since the reviewer skips PRs editing its own workflow.