### PR TITLE
feat(setup): unlock-gated first-run setup with state-hiding denials, rate limiting, and wizard model/demo options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Nojoin is built for people who want the usefulness of meeting assistants without
    docker compose up -d
    ```
 
-5. Open the web app.
+5. Open the setup wizard.
 
    ```text
-   https://localhost:14443
+   https://localhost:14443/setup
    ```
 
-6. Complete the first-run wizard.
+6. Unlock the wizard with your `FIRST_RUN_PASSWORD` and complete the first-run setup. The sign-in page does not link to setup; the wizard is only reachable at `/setup`.
 
 7. Open Nojoin in Chrome on Windows, Linux, or macOS for shared-audio recording, in another Chromium-family browser on Windows or Linux, or in Chrome on Android/iOS for microphone-only recording, then start a short test meeting. Other Chromium-family browsers on macOS are best-effort. See [docs/CAPTURE.md](docs/CAPTURE.md) for browser capture guidance.
 

--- a/backend/api/v1/endpoints/setup.py
+++ b/backend/api/v1/endpoints/setup.py
@@ -25,17 +25,19 @@ from backend.utils.ollama_url_policy import (
     OllamaURLValidationError,
     validate_ollama_api_url,
 )
+from backend.utils.rate_limit import enforce_rate_limit
 
 logger = logging.getLogger(__name__)
 
 FIRST_RUN_PASSWORD_AUTH_SCHEME = "Bootstrap"
 FIRST_RUN_PASSWORD_ENV_KEY = "FIRST_RUN_PASSWORD"
-FIRST_RUN_PASSWORD_REQUIRED_DETAIL = "Bootstrap password required for first-run setup."
-FIRST_RUN_PASSWORD_NOT_CONFIGURED_DETAIL = (
-    "First-run setup is disabled until FIRST_RUN_PASSWORD is set. "
-    "Set the env var and restart or redeploy Nojoin before initialising the system."
-)
+# Every setup denial uses this one detail so anonymous responses are identical
+# whether the system is initialised, the bootstrap password is wrong, or
+# FIRST_RUN_PASSWORD is not configured. The specific reason is server-log only.
 FIRST_RUN_SETUP_ACCESS_DENIED_DETAIL = "First-run setup access denied."
+SETUP_RATE_LIMIT = 60
+SETUP_RATE_LIMIT_WINDOW_SECONDS = 10 * 60
+SETUP_RATE_LIMIT_DETAIL = "Too many setup requests. Please try again later."
 PUBLIC_LLM_VALIDATION_ERROR_DETAIL = "Unable to validate the AI provider configuration."
 PUBLIC_HF_VALIDATION_ERROR_DETAIL = "Unable to validate the Hugging Face token."
 PUBLIC_MODEL_LIST_ERROR_DETAIL = "Unable to list AI provider models."
@@ -111,9 +113,13 @@ def get_first_run_password(request: Request) -> Optional[str]:
 def require_first_run_password(request: Request) -> None:
     configured_password = os.getenv(FIRST_RUN_PASSWORD_ENV_KEY)
     if not configured_password:
+        logger.warning(
+            "First-run setup request denied: FIRST_RUN_PASSWORD is not set. "
+            "Set the env var and restart or redeploy Nojoin before initialising."
+        )
         raise HTTPException(
-            status_code=503,
-            detail=FIRST_RUN_PASSWORD_NOT_CONFIGURED_DETAIL,
+            status_code=403,
+            detail=FIRST_RUN_SETUP_ACCESS_DENIED_DETAIL,
         )
 
     provided_password = get_first_run_password(request)
@@ -121,10 +127,28 @@ def require_first_run_password(request: Request) -> None:
         provided_password,
         configured_password,
     ):
+        logger.warning(
+            "First-run setup request denied: missing or incorrect bootstrap password."
+        )
         raise HTTPException(
             status_code=403,
-            detail=FIRST_RUN_PASSWORD_REQUIRED_DETAIL,
+            detail=FIRST_RUN_SETUP_ACCESS_DENIED_DETAIL,
         )
+
+
+async def enforce_setup_rate_limit(request: Request) -> None:
+    """
+    Shared per-client limit for the setup surface. Applied uniformly before any
+    state-dependent work so throttling behaviour cannot disclose whether the
+    system is initialised.
+    """
+    await enforce_rate_limit(
+        request,
+        namespace="setup",
+        limit=SETUP_RATE_LIMIT,
+        window_seconds=SETUP_RATE_LIMIT_WINDOW_SECONDS,
+        detail=SETUP_RATE_LIMIT_DETAIL,
+    )
 
 
 async def check_setup_permission(db: AsyncSession, request: Request):
@@ -134,6 +158,8 @@ async def check_setup_permission(db: AsyncSession, request: Request):
     1. System is NOT initialized (no users exist).
     2. OR User is authenticated as Admin/Owner (JWT token in header).
     """
+    await enforce_setup_rate_limit(request)
+
     is_initialized = await is_system_initialized(db)
 
     if not is_initialized:

--- a/backend/api/v1/endpoints/system.py
+++ b/backend/api/v1/endpoints/system.py
@@ -31,6 +31,7 @@ from backend.api.services.health_service import (
 )
 from backend.api.v1.endpoints.setup import (
     FIRST_RUN_SETUP_ACCESS_DENIED_DETAIL,
+    enforce_setup_rate_limit,
     is_system_initialized,
     require_first_run_password,
 )
@@ -48,6 +49,7 @@ from backend.utils.download_progress import (
     get_download_progress,
     is_download_in_progress,
 )
+from backend.utils.model_utils import WHISPER_MODEL_SIZES_MB
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -310,11 +312,24 @@ class SetupRequest(BaseModel):
     password: str = Field(min_length=MIN_PASSWORD_LENGTH)
     whisper_model_size: Optional[str] = "turbo"
     selected_model: Optional[str] = None
+    include_demo_recording: bool = True
 
     @field_validator("password")
     @classmethod
     def validate_password(cls, value: str) -> str:
         return validate_password_policy(value)
+
+    @field_validator("whisper_model_size")
+    @classmethod
+    def validate_whisper_model_size(cls, value: Optional[str]) -> str:
+        if value is None:
+            return "turbo"
+        if value not in WHISPER_MODEL_SIZES_MB:
+            raise ValueError(
+                "whisper_model_size must be one of: "
+                + ", ".join(sorted(WHISPER_MODEL_SIZES_MB))
+            )
+        return value
 
 
 @router.get("/health")
@@ -383,6 +398,8 @@ async def setup_system(
     Initialize the system with the first admin user and initial configuration.
     Only works if no users exist.
     """
+    await enforce_setup_rate_limit(request)
+
     if await is_system_initialized(db):
         raise HTTPException(
             status_code=403,
@@ -408,13 +425,18 @@ async def setup_system(
         force_password_change=False,  # First user sets their own password, so no need to force change
         role="owner",
         settings=settings,
+        # Opting out marks the demo as already seen so startup seeding also
+        # skips it; Settings > Help can still force-recreate it later.
+        has_seen_demo_recording=not setup_in.include_demo_recording,
     )
     db.add(user)
     await db.commit()
     await db.refresh(user)
 
     # Seed demo data for the new admin user
-    if user.id is None:
+    if not setup_in.include_demo_recording:
+        logger.info("Skipping demo recording seed: opted out during first-run setup.")
+    elif user.id is None:
         logger.error(
             "Failed to seed demo data during setup: created user has no persisted ID."
         )

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from contextlib import asynccontextmanager
 from ipaddress import ip_address
 from urllib.parse import urlparse
@@ -121,6 +122,7 @@ from backend.services.recording_identity_service import (
     ensure_recording_public_ids,
 )
 from backend.utils.config_manager import (
+    get_configured_web_origin,
     get_cors_origin_list,
     get_trusted_host_list,
     get_trusted_web_origin,
@@ -159,6 +161,31 @@ async def ensure_owner_exists():
                 logger.warning("No users found to promote.")
 
 
+async def log_first_run_setup_pointer() -> None:
+    """
+    Point operators at the setup wizard while no users exist. The login page
+    deliberately never advertises /setup, so the server log is the discovery
+    channel for fresh deployments.
+    """
+    async with async_session_maker() as session:
+        query = select(User).limit(1)
+        result = await session.execute(query)
+        if result.scalar_one_or_none() is not None:
+            return
+
+    setup_url = f"{get_configured_web_origin()}/setup"
+    logger.info(
+        "Nojoin is not initialised yet. Open %s and unlock it with your "
+        "FIRST_RUN_PASSWORD to create the owner account.",
+        setup_url,
+    )
+    if not os.getenv("FIRST_RUN_PASSWORD"):
+        logger.warning(
+            "FIRST_RUN_PASSWORD is not set. First-run setup will refuse to "
+            "unlock until it is set and the stack is restarted or redeployed."
+        )
+
+
 async def ensure_recording_meeting_uids_on_startup() -> None:
     async with async_session_maker() as session:
         repaired_count = await ensure_recording_meeting_uids(session)
@@ -195,6 +222,7 @@ def run_migrations():
 async def lifespan(app: FastAPI):
     run_migrations()
     await ensure_owner_exists()
+    await log_first_run_setup_pointer()
     await ensure_recording_public_ids_on_startup()
     await ensure_recording_meeting_uids_on_startup()
     log_deployment_warnings(startup_path="API startup", logger_instance=logger)

--- a/backend/tests/test_first_run_pointer.py
+++ b/backend/tests/test_first_run_pointer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+import pytest
+
+from backend import main as backend_main
+
+
+class _FakeResult:
+    def __init__(self, user):
+        self._user = user
+
+    def scalar_one_or_none(self):
+        return self._user
+
+
+class _FakeSession:
+    def __init__(self, user):
+        self._user = user
+
+    async def execute(self, statement):
+        return _FakeResult(self._user)
+
+
+def _fake_session_maker(user):
+    @asynccontextmanager
+    async def _maker():
+        yield _FakeSession(user)
+
+    return _maker
+
+
+@pytest.mark.anyio
+async def test_startup_pointer_logged_while_uninitialised(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(backend_main, "async_session_maker", _fake_session_maker(None))
+    monkeypatch.setattr(
+        backend_main,
+        "get_configured_web_origin",
+        lambda: "https://nojoin.example.com",
+    )
+    monkeypatch.setenv("FIRST_RUN_PASSWORD", "bootstrap-secret")
+
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        await backend_main.log_first_run_setup_pointer()
+
+    assert "https://nojoin.example.com/setup" in caplog.text
+    assert "FIRST_RUN_PASSWORD is not set" not in caplog.text
+
+
+@pytest.mark.anyio
+async def test_startup_pointer_warns_when_password_unset(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(backend_main, "async_session_maker", _fake_session_maker(None))
+    monkeypatch.setattr(
+        backend_main,
+        "get_configured_web_origin",
+        lambda: "https://nojoin.example.com",
+    )
+    monkeypatch.delenv("FIRST_RUN_PASSWORD", raising=False)
+
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        await backend_main.log_first_run_setup_pointer()
+
+    assert "https://nojoin.example.com/setup" in caplog.text
+    assert "FIRST_RUN_PASSWORD is not set" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_startup_pointer_silent_once_initialised(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(
+        backend_main, "async_session_maker", _fake_session_maker(object())
+    )
+
+    with caplog.at_level(logging.INFO, logger="backend.main"):
+        await backend_main.log_first_run_setup_pointer()
+
+    assert "/setup" not in caplog.text

--- a/backend/tests/test_security_surface.py
+++ b/backend/tests/test_security_surface.py
@@ -17,6 +17,19 @@ BOOTSTRAP_PASSWORD = "bootstrap-secret"
 LEGACY_FIRST_RUN_PASSWORD_HEADER = "X-First-Run-Password"
 SECURE_TEST_BASE_URL = "https://test"
 
+# Captured before the autouse bypass fixture patches the module attribute so
+# the dedicated rate-limit test can restore the real implementation.
+_REAL_ENFORCE_SETUP_RATE_LIMIT = setup.enforce_setup_rate_limit
+
+
+@pytest.fixture(autouse=True)
+def _bypass_setup_rate_limit(monkeypatch):
+    async def _allow(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(setup, "enforce_setup_rate_limit", _allow)
+    monkeypatch.setattr(system, "enforce_setup_rate_limit", _allow)
+
 
 class _FakeResult:
     def __init__(self, initialized: bool):
@@ -374,7 +387,7 @@ async def test_first_run_setup_rejects_missing_bootstrap_password(monkeypatch) -
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "Bootstrap password required for first-run setup.",
+        "detail": "First-run setup access denied.",
     }
 
 
@@ -395,7 +408,7 @@ async def test_first_run_setup_rejects_legacy_bootstrap_header(monkeypatch) -> N
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "Bootstrap password required for first-run setup.",
+        "detail": "First-run setup access denied.",
     }
 
 
@@ -416,12 +429,11 @@ async def test_first_run_setup_rejects_when_server_password_is_unset(
             json={"username": "owner", "password": "password123"},
         )
 
-    assert response.status_code == 503
+    # Fails closed with the same generic denial used everywhere else so the
+    # unset-password state is not disclosed to anonymous clients.
+    assert response.status_code == 403
     assert response.json() == {
-        "detail": (
-            "First-run setup is disabled until FIRST_RUN_PASSWORD is set. "
-            "Set the env var and restart or redeploy Nojoin before initialising the system."
-        ),
+        "detail": "First-run setup access denied.",
     }
 
 
@@ -499,6 +511,100 @@ async def test_initialised_setup_post_does_not_disclose_state(monkeypatch) -> No
     assert response.json() == {
         "detail": "First-run setup access denied.",
     }
+
+
+@pytest.mark.anyio
+async def test_setup_denials_do_not_disclose_initialisation_state(
+    monkeypatch,
+) -> None:
+    """
+    Anonymous setup denials must be byte-identical across every state an
+    outside prober could try to distinguish: uninitialised with a wrong
+    bootstrap password, uninitialised with FIRST_RUN_PASSWORD unset, and
+    initialised without credentials.
+    """
+    responses: list[tuple[int, dict]] = []
+
+    scenarios = [
+        {"initialized": False, "env_password": BOOTSTRAP_PASSWORD},
+        {"initialized": False, "env_password": None},
+        {"initialized": True, "env_password": BOOTSTRAP_PASSWORD},
+    ]
+
+    for scenario in scenarios:
+        app, _ = _build_app(initialized=scenario["initialized"])
+        if scenario["env_password"] is None:
+            monkeypatch.delenv(setup.FIRST_RUN_PASSWORD_ENV_KEY, raising=False)
+        else:
+            monkeypatch.setenv(
+                setup.FIRST_RUN_PASSWORD_ENV_KEY, scenario["env_password"]
+            )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url=SECURE_TEST_BASE_URL
+        ) as client:
+            get_response = await client.get(
+                "/api/v1/setup/initial-config",
+                headers=_bootstrap_auth_headers("wrong-guess"),
+            )
+            post_response = await client.post(
+                "/api/v1/system/setup",
+                headers=_bootstrap_auth_headers("wrong-guess"),
+                json={"username": "owner", "password": "password123"},
+            )
+
+        responses.append((get_response.status_code, get_response.json()))
+        responses.append((post_response.status_code, post_response.json()))
+
+    assert all(item == responses[0] for item in responses)
+    assert responses[0] == (403, {"detail": "First-run setup access denied."})
+
+
+@pytest.mark.anyio
+async def test_setup_requests_are_rate_limited(monkeypatch) -> None:
+    from backend.utils import rate_limit as rate_limit_utils
+
+    monkeypatch.setattr(
+        setup, "enforce_setup_rate_limit", _REAL_ENFORCE_SETUP_RATE_LIMIT
+    )
+    monkeypatch.setattr(
+        system, "enforce_setup_rate_limit", _REAL_ENFORCE_SETUP_RATE_LIMIT
+    )
+    monkeypatch.setattr(setup, "SETUP_RATE_LIMIT", 2)
+
+    async def _no_redis():
+        return None
+
+    monkeypatch.setattr(rate_limit_utils, "_get_redis", _no_redis)
+    rate_limit_utils._fallback_windows.clear()
+
+    app, _ = _build_app(initialized=False)
+    monkeypatch.setenv(setup.FIRST_RUN_PASSWORD_ENV_KEY, BOOTSTRAP_PASSWORD)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url=SECURE_TEST_BASE_URL
+    ) as client:
+        first = await client.get(
+            "/api/v1/setup/initial-config",
+            headers=_bootstrap_auth_headers("wrong-guess"),
+        )
+        second = await client.post(
+            "/api/v1/system/setup",
+            headers=_bootstrap_auth_headers("wrong-guess"),
+            json={"username": "owner", "password": "password123"},
+        )
+        third = await client.get(
+            "/api/v1/setup/initial-config",
+            headers=_bootstrap_auth_headers("wrong-guess"),
+        )
+
+    rate_limit_utils._fallback_windows.clear()
+
+    assert first.status_code == 403
+    assert second.status_code == 403
+    assert third.status_code == 429
+    assert third.json() == {"detail": setup.SETUP_RATE_LIMIT_DETAIL}
+    assert "retry-after" in {key.lower() for key in third.headers}
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_setup_auth_redirects.py
+++ b/backend/tests/test_setup_auth_redirects.py
@@ -14,6 +14,15 @@ BOOTSTRAP_PASSWORD = "bootstrap-secret"
 SECURE_TEST_BASE_URL = "https://test"
 
 
+@pytest.fixture(autouse=True)
+def _bypass_setup_rate_limit(monkeypatch):
+    async def _allow(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(setup, "enforce_setup_rate_limit", _allow)
+    monkeypatch.setattr(system, "enforce_setup_rate_limit", _allow)
+
+
 class _FakeResult:
     def __init__(self, initialized: bool):
         self._initialized = initialized

--- a/backend/utils/model_utils.py
+++ b/backend/utils/model_utils.py
@@ -45,18 +45,20 @@ def is_whisper_model_downloaded(model_size: str) -> bool:
         return False
 
 
+# Approximate parameter size in millions based on Whisper documentation
+WHISPER_MODEL_SIZES_MB = {
+    "tiny": 39,
+    "base": 74,
+    "small": 244,
+    "medium": 769,
+    "large": 1550,
+    "turbo": 809,  # Whisper Turbo model size
+}
+
+
 def get_whisper_model_size_mb(model_size: str) -> Optional[float]:
     """Get the approximate size of a Whisper model in MB."""
-    # Approximate parameter size in millions based on Whisper documentation
-    model_sizes = {
-        "tiny": 39,
-        "base": 74,
-        "small": 244,
-        "medium": 769,
-        "large": 1550,
-        "turbo": 809,  # Whisper Turbo model size
-    }
-    return model_sizes.get(model_size)
+    return WHISPER_MODEL_SIZES_MB.get(model_size)
 
 
 def check_default_model_availability() -> tuple[bool, str]:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -44,11 +44,18 @@ The repository does not ship a separate Docker Compose development override.
    docker compose up -d
    ```
 
-8. Open `https://localhost:14443`.
+8. Open `https://localhost:14443/setup` and unlock the first-run wizard with your `FIRST_RUN_PASSWORD`.
 9. Use Chrome on Windows, Linux, or macOS for shared-audio live recording, another Chromium-family browser on Windows or Linux, or Chrome on Android/iOS for microphone-only live recording. Other Chromium-family browsers on macOS are best-effort. Other browsers can still review and administer Nojoin.
 
 Nojoin refuses first initialisation if `FIRST_RUN_PASSWORD` is missing.
 If you add or change it, redeploy the stack before using the setup wizard.
+The sign-in page does not link to the setup wizard, and every anonymous setup
+denial returns the same generic response regardless of cause, so the service
+never discloses whether it has been initialised. The specific denial reason
+(wrong password, unset `FIRST_RUN_PASSWORD`, or already-initialised system)
+appears in the API logs, and the API startup log prints the `/setup` address
+while the system is uninitialised. Setup requests are rate limited per client
+address.
 If `FIRST_RUN_PASSWORD`, `DATA_ENCRYPTION_KEY`, `REDIS_PASSWORD`, or the
 tracked PostgreSQL password placeholder are left at their example values,
 Nojoin now emits startup log warnings and an authenticated frontend warning
@@ -146,7 +153,7 @@ Nojoin can also auto-generate `data/.data_encryption_key`, but operators should 
 
 ### Always Set
 
-- `FIRST_RUN_PASSWORD`: Required bootstrap password for the first successful Nojoin initialisation.
+- `FIRST_RUN_PASSWORD`: Required bootstrap password for the first successful Nojoin initialisation. It unlocks the setup wizard at `/setup` on an uninitialised system and is not used after initialisation.
 - `DATA_ENCRYPTION_KEY`: Stable installation-wide encryption seed used for calendar OAuth client secrets and user calendar tokens. Set this once and keep it unchanged for the lifetime of the deployment.
 - `POSTGRES_PASSWORD`: Replace the tracked example value before any deployment that persists data or is reachable by other users or hosts.
 - `REDIS_PASSWORD`: Replace the tracked example value before any deployment that persists data or is reachable by other users or hosts.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,17 +43,21 @@ If you do not have an NVIDIA GPU, see [DEPLOYMENT.md](DEPLOYMENT.md) for CPU-onl
 
 `DATA_ENCRYPTION_KEY` prevents future decryptability issues if the app data directory and database do not move together during restores, host migrations, or partial replacements.
 
-## 2. Open the Web App
+## 2. Open the Setup Wizard
 
 Open:
 
 ```text
-https://localhost:14443
+https://localhost:14443/setup
 ```
 
 Nojoin uses a self-signed certificate by default, so your browser will show a certificate warning on first access.
 
+The sign-in page deliberately does not link to the setup wizard, and the server never reveals to visitors whether it has been initialised. On a fresh deployment, browse to `/setup` directly; the API startup log also prints this address until the system is initialised.
+
 ## 3. Complete the First-Run Wizard
+
+Unlock the wizard with the `FIRST_RUN_PASSWORD` value from your `.env`. Every unlock failure shows the same generic denial — if you are certain the password is correct, confirm `FIRST_RUN_PASSWORD` is set and the stack was restarted after setting it, and check the API logs for the specific reason.
 
 The first user becomes the Owner account.
 
@@ -62,6 +66,8 @@ During setup, the system automatically detects configured API keys and Hugging F
 - Detect active AI provider credentials and Hugging Face tokens.
 - Detect whether the bundled local Pyannote speaker models are already present.
 - Let you select the default model for your configured AI provider.
+- Let you choose the Whisper transcription model. Turbo (default) suits GPU servers; Small or Base is much faster on CPU-only deployments. You can change it later in Settings > AI.
+- Let you choose whether to include the "Welcome to Nojoin" sample meeting. You can remove or recreate it later in Settings > Help.
 - Warn you if no AI provider credentials are configured, explaining the loss of core intelligence features (Meeting Edge, Notes, and Speaker Inference), and allow you to proceed or reload the configuration.
 
 If you skip AI configuration, Nojoin still records, transcribes, and diarises meetings. The automatic AI enhancement step is simply skipped until you configure a provider later by setting environment variables in `.env` and restarting the server.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -13,6 +13,8 @@ Nojoin requires an operator-defined `FIRST_RUN_PASSWORD` before the first succes
 - The bootstrap password is only used while the system is uninitialised.
 - The web client sends the bootstrap secret via the standard `Authorization` header using the `Bootstrap` scheme rather than a bespoke setup header.
 - If `FIRST_RUN_PASSWORD` is missing, first-run setup fails closed until the operator sets it and restarts or redeploys.
+- The setup surface does not disclose initialisation state. The sign-in page never references setup, the `/setup` page renders the same unlock gate in every state, and every anonymous setup denial returns the same `403` with the detail `First-run setup access denied.` whether the bootstrap password is wrong, `FIRST_RUN_PASSWORD` is unset, or the system is already initialised. The specific reason is written to the server log only, and the API startup log points operators at `/setup` while the system is uninitialised.
+- Setup endpoints are rate limited per client address before any state-dependent processing, so throttling behaviour is also identical across states and the bootstrap password cannot be brute-forced quickly.
 - After initialisation, normal authenticated admin operations do not use the bootstrap password path.
 - The bootstrap password is never returned by the API or persisted into Nojoin configuration.
 - Application log output redacts `Authorization`, cookies, bootstrap credentials, passwords, tokens, and API-key fields if they are accidentally included in a log record.

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -4,7 +4,6 @@ import axios from "axios";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import Link from "next/link";
 import { login, getCurrentUser } from "@/lib/api";
 import { Lock, User } from "lucide-react";
 
@@ -169,10 +168,6 @@ export default function LoginPage() {
               {loading ? "Signing in..." : "Sign in"}
             </button>
           </div>
-
-          <p className="text-center text-sm text-gray-600 dark:text-gray-300">
-            Need first-run initialisation? <Link href="/setup" className="font-medium text-orange-600 hover:text-orange-500">Open setup</Link>
-          </p>
         </form>
       </div>
     </div>

--- a/frontend/src/app/setup/_components/AccountStep.tsx
+++ b/frontend/src/app/setup/_components/AccountStep.tsx
@@ -7,19 +7,21 @@ interface AccountStepProps {
     confirmPassword: string;
   };
   error: string;
+  includeDemoRecording: boolean;
   onSubmit: (e: React.FormEvent) => void;
   onInputChange: (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => void;
-  onBootstrapPasswordChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onIncludeDemoRecordingChange: (include: boolean) => void;
 }
 
 export default function AccountStep({
   formData,
   error,
+  includeDemoRecording,
   onSubmit,
   onInputChange,
-  onBootstrapPasswordChange,
+  onIncludeDemoRecordingChange,
 }: AccountStepProps) {
   return (
     <form
@@ -36,30 +38,6 @@ export default function AccountStep({
         </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           Set up your administrator credentials
-        </p>
-      </div>
-
-      <div>
-        <label htmlFor="setup-bootstrap-password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-          Bootstrap Password
-        </label>
-        <input
-          id="setup-bootstrap-password"
-          type="password"
-          name="setup-bootstrap-password"
-          autoComplete="off"
-          autoCapitalize="none"
-          autoCorrect="off"
-          spellCheck={false}
-          aria-describedby={error ? "setup-error" : undefined}
-          aria-invalid={Boolean(error)}
-          required
-          onChange={onBootstrapPasswordChange}
-          className="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none"
-          placeholder="Enter first-run bootstrap password"
-        />
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          Set FIRST_RUN_PASSWORD before the first deployment. This password is only used for initialisation.
         </p>
       </div>
 
@@ -127,6 +105,28 @@ export default function AccountStep({
           placeholder="••••••••"
         />
       </div>
+
+      <label
+        htmlFor="setup-include-demo-recording"
+        className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 cursor-pointer"
+      >
+        <input
+          id="setup-include-demo-recording"
+          type="checkbox"
+          name="setup-include-demo-recording"
+          checked={includeDemoRecording}
+          onChange={(e) => onIncludeDemoRecordingChange(e.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-orange-600 focus:ring-orange-500"
+        />
+        <span className="text-sm text-gray-700 dark:text-gray-300">
+          Include a sample meeting
+          <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            Adds a short &quot;Welcome to Nojoin&quot; recording so you can
+            explore transcripts, notes, and speakers. You can remove or
+            recreate it later in Settings &gt; Help.
+          </span>
+        </span>
+      </label>
 
       <button
         type="submit"

--- a/frontend/src/app/setup/_components/CompleteStep.tsx
+++ b/frontend/src/app/setup/_components/CompleteStep.tsx
@@ -63,6 +63,12 @@ export default function CompleteStep({
             </div>
           </div>
 
+          <p className="text-xs text-center text-gray-500 dark:text-gray-400">
+            Your owner account is already created. Model preparation continues
+            on the server even if you close this page — you can sign in at any
+            time while it finishes.
+          </p>
+
           {error && (
             <button
               onClick={onComplete}

--- a/frontend/src/app/setup/_components/HuggingFaceStep.tsx
+++ b/frontend/src/app/setup/_components/HuggingFaceStep.tsx
@@ -1,12 +1,18 @@
 import { AlertTriangle, ArrowRight, CheckCircle, Loader2, RefreshCw } from "lucide-react";
 
+import { WHISPER_MODELS } from "@/lib/whisperModels";
+
 interface HuggingFaceStepProps {
   formData: {
     hf_token: string;
+    whisper_model_size: string;
   };
   loading: boolean;
   pyannoteModelsReady: boolean;
   bundledPyannoteModelsReady: boolean;
+  onInputChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => void;
   onReloadConfig: () => void;
   onSubmit: () => void;
 }
@@ -16,158 +22,158 @@ export default function HuggingFaceStep({
   loading,
   pyannoteModelsReady,
   bundledPyannoteModelsReady,
+  onInputChange,
   onReloadConfig,
   onSubmit,
 }: HuggingFaceStepProps) {
-  if (!formData.hf_token && !pyannoteModelsReady) {
-    return (
-      <div className="space-y-4">
-        <div className="space-y-6">
-          <div className="text-center mb-6">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-              Hugging Face Integration
-            </h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-              Speaker identification token missing
-            </p>
-          </div>
-
-          <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
-            <div>
-              <p className="text-sm font-semibold text-yellow-800 dark:text-yellow-300">
-                Speaker Diarization Disabled
-              </p>
-              <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-1 leading-relaxed">
-                Without a Hugging Face token configured in your server environment (.env), Nojoin will record and transcribe meetings, but it will not be able to identify who is speaking (diarization).
-              </p>
-            </div>
-          </div>
-
-          <div className="p-4 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-xl text-xs space-y-2 text-gray-600 dark:text-gray-300">
-            <p className="font-semibold text-gray-900 dark:text-white">To enable speaker identification:</p>
-            <ol className="list-decimal list-inside space-y-1">
-              <li>Create a read token on <a href="https://huggingface.co/settings/tokens" target="_blank" rel="noopener noreferrer" className="underline font-semibold text-blue-600 dark:text-blue-400">Hugging Face</a>.</li>
-              <li>Accept the terms of service for <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">pyannote/speaker-diarization-community-1</code>.</li>
-              <li>Add <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">HF_TOKEN=your_token</code> to your <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">.env</code>.</li>
-              <li>Restart your docker containers.</li>
-            </ol>
-          </div>
-
-          <div className="flex flex-col gap-3 mt-6">
-            <button
-              type="button"
-              onClick={onReloadConfig}
-              disabled={loading}
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
-            >
-              {loading ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <RefreshCw className="w-4 h-4" />
-              )}
-              Check Config Again
-            </button>
-            <button
-              type="button"
-              onClick={onSubmit}
-              className="w-full border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 py-2.5 rounded-lg font-medium transition-colors"
-            >
-              Finish Setup (Disable Speaker Diarization)
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (!formData.hf_token) {
-    return (
-      <div className="space-y-4">
-        <div className="space-y-6">
-          <div className="text-center mb-6">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-              Hugging Face Integration
-            </h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-              Local speaker models detected
-            </p>
-          </div>
-
-          <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl flex items-start gap-3">
-            <CheckCircle className="w-5 h-5 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
-            <div>
-              <p className="text-sm font-semibold text-green-800 dark:text-green-300">
-                Speaker Diarization Ready
-              </p>
-              <p className="text-xs text-green-700 dark:text-green-400 mt-1 leading-relaxed">
-                Nojoin found local Pyannote model assets on the server, so speaker diarization can run without a Hugging Face token.
-              </p>
-            </div>
-          </div>
-
-          <div className="p-4 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-xl text-xs space-y-2 text-gray-600 dark:text-gray-300">
-            <p className="font-semibold text-gray-900 dark:text-white">
-              {bundledPyannoteModelsReady
-                ? "Bundled repo models are available."
-                : "Local cached models are available."}
-            </p>
-            <p>
-              A Hugging Face token is optional here. You only need one later if you want to refresh these Pyannote assets from upstream.
-            </p>
-          </div>
-
-          <div className="flex gap-3 mt-6">
-            <button
-              type="button"
-              onClick={onSubmit}
-              className="w-full bg-orange-600 hover:bg-orange-700 text-white font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
-            >
-              Finish Setup <ArrowRight className="w-4 h-4" />
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const diarizationMissing = !formData.hf_token && !pyannoteModelsReady;
 
   return (
     <div className="space-y-4">
       <div className="space-y-6">
         <div className="text-center mb-6">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            Hugging Face Integration
+            Transcription &amp; Speaker Models
           </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-            Speaker identification and diarization model preparation
+            Choose the transcription model and review speaker identification
           </p>
         </div>
 
-        <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl flex items-center gap-3">
-          <CheckCircle className="w-6 h-6 text-green-500 shrink-0" />
-          <div>
-            <p className="text-sm font-semibold text-green-800 dark:text-green-300">
-              Hugging Face Token Configured
-            </p>
-            <p className="text-xs text-green-700 dark:text-green-400 mt-0.5">
-              Your Hugging Face token was found in the server environment (.env).
-            </p>
-          </div>
-        </div>
-
-        <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-xl text-xs text-blue-800 dark:text-blue-200">
-          Nojoin will use this token to prepare Pyannote speaker diarization and voice embedding models before your first recording.
-        </div>
-
-        <div className="flex gap-3 mt-6">
-          <button
-            type="button"
-            onClick={onSubmit}
-            className="w-full bg-orange-600 hover:bg-orange-700 text-white font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
+        <div>
+          <label
+            htmlFor="setup-whisper-model"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
           >
-            Finish Setup <ArrowRight className="w-4 h-4" />
-          </button>
+            Transcription model
+          </label>
+          <select
+            id="setup-whisper-model"
+            name="setup-whisper-model"
+            data-field-key="whisper_model_size"
+            value={formData.whisper_model_size}
+            onChange={onInputChange}
+            className="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none"
+          >
+            {WHISPER_MODELS.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.label} — {model.params} params, {model.vram} VRAM,{" "}
+                {model.speed} speed
+              </option>
+            ))}
+          </select>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            Turbo (default) is recommended for GPU servers. On CPU-only
+            deployments, Small or Base processes much faster. You can change
+            this later in Settings &gt; AI.
+          </p>
         </div>
+
+        {diarizationMissing ? (
+          <>
+            <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl flex items-start gap-3">
+              <AlertTriangle className="w-5 h-5 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
+              <div>
+                <p className="text-sm font-semibold text-yellow-800 dark:text-yellow-300">
+                  Speaker Diarization Disabled
+                </p>
+                <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-1 leading-relaxed">
+                  Without a Hugging Face token configured in your server environment (.env), Nojoin will record and transcribe meetings, but it will not be able to identify who is speaking (diarization).
+                </p>
+              </div>
+            </div>
+
+            <div className="p-4 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-xl text-xs space-y-2 text-gray-600 dark:text-gray-300">
+              <p className="font-semibold text-gray-900 dark:text-white">To enable speaker identification:</p>
+              <ol className="list-decimal list-inside space-y-1">
+                <li>Create a read token on <a href="https://huggingface.co/settings/tokens" target="_blank" rel="noopener noreferrer" className="underline font-semibold text-blue-600 dark:text-blue-400">Hugging Face</a>.</li>
+                <li>Accept the terms of service for <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">pyannote/speaker-diarization-community-1</code>.</li>
+                <li>Add <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">HF_TOKEN=your_token</code> to your <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">.env</code>.</li>
+                <li>Restart your docker containers.</li>
+              </ol>
+            </div>
+
+            <div className="flex flex-col gap-3 mt-6">
+              <button
+                type="button"
+                onClick={onReloadConfig}
+                disabled={loading}
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
+              >
+                {loading ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="w-4 h-4" />
+                )}
+                Check Config Again
+              </button>
+              <button
+                type="button"
+                onClick={onSubmit}
+                className="w-full border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 py-2.5 rounded-lg font-medium transition-colors"
+              >
+                Finish Setup (Disable Speaker Diarization)
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            {!formData.hf_token ? (
+              <>
+                <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl flex items-start gap-3">
+                  <CheckCircle className="w-5 h-5 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-sm font-semibold text-green-800 dark:text-green-300">
+                      Speaker Diarization Ready
+                    </p>
+                    <p className="text-xs text-green-700 dark:text-green-400 mt-1 leading-relaxed">
+                      Nojoin found local Pyannote model assets on the server, so speaker diarization can run without a Hugging Face token.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="p-4 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-xl text-xs space-y-2 text-gray-600 dark:text-gray-300">
+                  <p className="font-semibold text-gray-900 dark:text-white">
+                    {bundledPyannoteModelsReady
+                      ? "Bundled repo models are available."
+                      : "Local cached models are available."}
+                  </p>
+                  <p>
+                    A Hugging Face token is optional here. You only need one later if you want to refresh these Pyannote assets from upstream.
+                  </p>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl flex items-center gap-3">
+                  <CheckCircle className="w-6 h-6 text-green-500 shrink-0" />
+                  <div>
+                    <p className="text-sm font-semibold text-green-800 dark:text-green-300">
+                      Hugging Face Token Configured
+                    </p>
+                    <p className="text-xs text-green-700 dark:text-green-400 mt-0.5">
+                      Your Hugging Face token was found in the server environment (.env).
+                    </p>
+                  </div>
+                </div>
+
+                <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-xl text-xs text-blue-800 dark:text-blue-200">
+                  Nojoin will use this token to prepare Pyannote speaker diarization and voice embedding models before your first recording.
+                </div>
+              </>
+            )}
+
+            <div className="flex gap-3 mt-6">
+              <button
+                type="button"
+                onClick={onSubmit}
+                className="w-full bg-orange-600 hover:bg-orange-700 text-white font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
+              >
+                Finish Setup <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/setup/_components/UnlockStep.tsx
+++ b/frontend/src/app/setup/_components/UnlockStep.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import { Loader2, Lock } from "lucide-react";
+
+interface UnlockStepProps {
+  error: string;
+  unlocking: boolean;
+  onBootstrapPasswordChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}
+
+// The unlock gate is rendered identically whether or not the system is
+// initialised; only a correct FIRST_RUN_PASSWORD on an uninitialised system
+// advances past it, so the page never discloses initialisation state.
+export default function UnlockStep({
+  error,
+  unlocking,
+  onBootstrapPasswordChange,
+  onSubmit,
+}: UnlockStepProps) {
+  return (
+    <form
+      id="setup-unlock-form"
+      name="setup-unlock-form"
+      method="post"
+      onSubmit={onSubmit}
+      className="space-y-4"
+      autoComplete="off"
+    >
+      <div className="text-center mb-6">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          First-Run Setup
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+          Unlock the setup wizard to initialise this Nojoin deployment
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="setup-unlock-password"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          First-run setup password
+        </label>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <Lock className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+          </div>
+          <input
+            id="setup-unlock-password"
+            type="password"
+            name="setup-unlock-password"
+            autoComplete="off"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            aria-describedby={error ? "setup-error" : undefined}
+            aria-invalid={Boolean(error)}
+            required
+            onChange={onBootstrapPasswordChange}
+            className="w-full pl-10 pr-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none"
+            placeholder="Enter first-run setup password"
+          />
+        </div>
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          This is the FIRST_RUN_PASSWORD value from your deployment environment
+          (.env). It is only used to initialise a new Nojoin system.
+        </p>
+      </div>
+
+      <button
+        type="submit"
+        disabled={unlocking}
+        className="w-full mt-4 bg-orange-600 hover:bg-orange-700 text-white font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed"
+      >
+        {unlocking ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" /> Unlocking...
+          </>
+        ) : (
+          "Unlock Setup"
+        )}
+      </button>
+
+      <p className="text-center text-sm text-gray-600 dark:text-gray-300 mt-2">
+        Already set up?{" "}
+        <Link
+          href="/login"
+          className="font-medium text-orange-600 hover:text-orange-500"
+        >
+          Back to sign in
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/app/setup/_hooks/useSetupWizard.ts
+++ b/frontend/src/app/setup/_hooks/useSetupWizard.ts
@@ -13,11 +13,19 @@ import {
 } from "@/lib/api";
 import { getErrorMessage, getErrorStatus } from "@/lib/errors";
 
+// Shown for every unlock failure. The backend deliberately returns one
+// generic denial whether the password is wrong, FIRST_RUN_PASSWORD is unset,
+// or the system is already initialised, so the client cannot say more.
+const SETUP_ACCESS_DENIED_MESSAGE =
+  "Setup access denied. Check the first-run password, or sign in normally if this system is already set up.";
+
 export function useSetupWizard() {
   const router = useRouter();
   const bootstrapPasswordRef = useRef("");
   const [loading, setLoading] = useState(true);
-  const [step, setStep] = useState(0); // 0: Legal, 1: Account, 2: LLM, 3: HuggingFace, 4: Complete
+  // 0: Unlock, 1: Legal, 2: Account, 3: LLM, 4: Models, 5: Complete
+  const [step, setStep] = useState(0);
+  const [unlocking, setUnlocking] = useState(false);
   const [initialConfigLoaded, setInitialConfigLoaded] = useState(false);
   const [pyannoteModelsReady, setPyannoteModelsReady] = useState(false);
   const [bundledPyannoteModelsReady, setBundledPyannoteModelsReady] = useState(false);
@@ -34,7 +42,9 @@ export function useSetupWizard() {
     ollama_api_url: "http://host.docker.internal:11434",
     hf_token: "",
     selected_model: "",
+    whisper_model_size: "turbo",
   });
+  const [includeDemoRecording, setIncludeDemoRecording] = useState(true);
 
   // Validation State
   const [validatingLLM, setValidatingLLM] = useState(false);
@@ -75,23 +85,6 @@ export function useSetupWizard() {
           if (getErrorStatus(err) !== 401) {
             throw err;
           }
-        }
-
-                const ffmpegStatus = await checkFFmpeg().catch((err: unknown) => {
-          if (getErrorStatus(err) === 401 || getErrorStatus(err) === 403) {
-            return {
-              ffmpeg: true,
-              ffprobe: true,
-              ffmpeg_path: null,
-              ffprobe_path: null,
-            };
-          }
-
-          throw err;
-        });
-
-        if (!ffmpegStatus.ffmpeg || !ffmpegStatus.ffprobe) {
-          setFfmpegMissing(true);
         }
 
         setLoading(false);
@@ -135,11 +128,6 @@ export function useSetupWizard() {
     (formData.llm_provider === "anthropic" && !formData.anthropic_api_key) ||
     (formData.llm_provider === "ollama" && !formData.ollama_api_url);
 
-  // --- Step 0: Legal Disclaimer ---
-  const handleLegalSubmit = () => {
-    setStep(1);
-  };
-
   const getBootstrapPassword = () => bootstrapPasswordRef.current;
 
   const handleBootstrapPasswordChange = (
@@ -156,7 +144,7 @@ export function useSetupWizard() {
 
     const bootstrapPassword = getBootstrapPassword();
     if (!bootstrapPassword) {
-      setError("Bootstrap password required.");
+      setError("Enter the first-run setup password.");
       return false;
     }
 
@@ -188,19 +176,34 @@ export function useSetupWizard() {
 
         } catch (err: unknown) {
       if (getErrorStatus(err) === 403) {
-        setError(
-          "First-run setup access denied. Check FIRST_RUN_PASSWORD or use the login page.",
-        );
+        setError(SETUP_ACCESS_DENIED_MESSAGE);
         return false;
       }
       setError(
-        getErrorMessage(err, "Failed to unlock first-run setup. Check FIRST_RUN_PASSWORD."),
+        getErrorMessage(err, "Unable to unlock setup. Check the server logs and try again."),
       );
       return false;
     }
   };
 
-  // --- Step 1: Account ---
+  // --- Step 0: Unlock ---
+  const handleUnlockSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setUnlocking(true);
+    const unlocked = await loadInitialConfig();
+    setUnlocking(false);
+    if (unlocked) {
+      setStep(1);
+    }
+  };
+
+  // --- Step 1: Legal Disclaimer ---
+  const handleLegalSubmit = () => {
+    setStep(2);
+  };
+
+  // --- Step 2: Account ---
   const handleAccountSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (formData.password !== formData.confirmPassword) {
@@ -212,16 +215,11 @@ export function useSetupWizard() {
       return;
     }
 
-    const initialConfigReady = await loadInitialConfig();
-    if (!initialConfigReady) {
-      return;
-    }
-
     setError("");
-    setStep(2);
+    setStep(3);
   };
 
-  // --- Step 2: LLM ---
+  // --- Step 3: LLM ---
   const validateAndFetchModels = useCallback(async () => {
     setValidatingLLM(true);
     setError("");
@@ -282,7 +280,7 @@ export function useSetupWizard() {
 
   const handleLLMSubmit = () => {
     if (llmSkipped) {
-      setStep(3);
+      setStep(4);
       return;
     }
 
@@ -297,7 +295,7 @@ export function useSetupWizard() {
     }
 
     setError("");
-    setStep(3);
+    setStep(4);
   };
 
   const handleSkipLLM = () => {
@@ -315,7 +313,7 @@ export function useSetupWizard() {
       anthropic_api_key: "",
       selected_model: "",
     }));
-    setStep(3);
+    setStep(4);
   };
 
   const handleReloadConfig = async () => {
@@ -332,7 +330,7 @@ export function useSetupWizard() {
   };
 
   useEffect(() => {
-    if (step === 2 && initialConfigLoaded) {
+    if (step === 3 && initialConfigLoaded) {
       if (!llmConfigMissing && !modelsFetched && !validatingLLM) {
         void validateAndFetchModels();
       }
@@ -351,7 +349,7 @@ export function useSetupWizard() {
     validatingLLM,
   ]);
 
-  // --- Step 3: HuggingFace ---
+  // --- Step 4: Transcription & Speaker Models ---
   const handleHFSubmit = async () => {
     await createAccountAndStartDownload();
   };
@@ -379,11 +377,13 @@ export function useSetupWizard() {
       await new Promise((resolve) => setTimeout(resolve, 2000));
     }
 
-    throw new Error("Model preparation timed out. Check the worker logs and model cache status.");
+    throw new Error(
+      "Model preparation is taking longer than expected. It continues in the background on the server — you can open the dashboard now and check progress later in Settings.",
+    );
   };
 
   const createAccountAndStartDownload = async () => {
-    setStep(4);
+    setStep(5);
     setModelPreparationComplete(false);
     setModelPreparationProgress(0);
     setModelPreparationMessage("Preparing transcription and speaker models...");
@@ -396,26 +396,37 @@ export function useSetupWizard() {
         username: formData.username,
         password: formData.password,
         selected_model: formData.selected_model || undefined,
+        whisper_model_size: formData.whisper_model_size,
+        include_demo_recording: includeDemoRecording,
       }, getBootstrapPassword());
 
       // 2. Login
       await login(formData.username, formData.password);
       loggedIn = true;
 
+      // FFmpeg availability is admin-gated, so it can only be checked once
+      // the owner session exists.
+      try {
+        const ffmpegStatus = await checkFFmpeg();
+        if (!ffmpegStatus.ffmpeg || !ffmpegStatus.ffprobe) {
+          setFfmpegMissing(true);
+        }
+      } catch {
+        // Non-fatal: admin health surfaces FFmpeg problems after setup.
+      }
+
       await waitForModelPreparation();
 
         } catch (err: unknown) {
       console.error("Setup failed:", err);
       if (getErrorStatus(err) === 403) {
-        setError(
-          "First-run setup access denied. Check FIRST_RUN_PASSWORD or use the login page.",
-        );
+        setError(SETUP_ACCESS_DENIED_MESSAGE);
       } else {
         setError(getErrorMessage(err, "Setup failed. Please try again."));
       }
 
       if (!loggedIn) {
-        setStep(3); // Go back only if the account/login did not finish.
+        setStep(4); // Go back only if the account/login did not finish.
       }
     }
   };
@@ -429,6 +440,9 @@ export function useSetupWizard() {
     step,
     formData,
     error,
+    unlocking,
+    includeDemoRecording,
+    setIncludeDemoRecording,
     ffmpegMissing,
     showSkipLLMModal,
     setShowSkipLLMModal,
@@ -444,6 +458,7 @@ export function useSetupWizard() {
     modelPreparationComplete,
     handleInputChange,
     handleBootstrapPasswordChange,
+    handleUnlockSubmit,
     handleLegalSubmit,
     handleAccountSubmit,
     handleLLMSubmit,

--- a/frontend/src/app/setup/page.test.tsx
+++ b/frontend/src/app/setup/page.test.tsx
@@ -41,12 +41,38 @@ function makeUnauthorised() {
   });
 }
 
-async function advanceToStep2(provider: Record<string, unknown> = {}) {
-  // Step 0 -> Step 1
-  fireEvent.click(screen.getByText("I Accept & Continue"));
+function makeForbidden() {
+  return Object.assign(new Error("forbidden"), {
+    response: {
+      status: 403,
+      data: { detail: "First-run setup access denied." },
+    },
+  });
+}
 
-  const bootstrap = await screen.findByLabelText("Bootstrap Password");
-  fireEvent.change(bootstrap, { target: { value: "first-run-pw" } });
+async function unlockWizard() {
+  const unlockInput = await screen.findByLabelText("First-run setup password");
+  fireEvent.change(unlockInput, { target: { value: "first-run-pw" } });
+  fireEvent.click(screen.getByText("Unlock Setup"));
+
+  await waitFor(() => {
+    expect(screen.getByText("Legal Disclaimer")).toBeInTheDocument();
+  });
+}
+
+async function advanceToAccountStep(provider: Record<string, unknown> = {}) {
+  getInitialConfig.mockResolvedValue({ llm_provider: "gemini", ...provider });
+
+  await unlockWizard();
+
+  // Legal -> Account
+  fireEvent.click(screen.getByText("I Accept & Continue"));
+  await screen.findByLabelText("Username");
+}
+
+async function advanceToLlmStep(provider: Record<string, unknown> = {}) {
+  await advanceToAccountStep(provider);
+
   fireEvent.change(screen.getByLabelText("Username"), {
     target: { value: "admin" },
   });
@@ -56,8 +82,6 @@ async function advanceToStep2(provider: Record<string, unknown> = {}) {
   fireEvent.change(screen.getByLabelText("Confirm Password"), {
     target: { value: "supersecret" },
   });
-
-  getInitialConfig.mockResolvedValue({ llm_provider: "gemini", ...provider });
 
   fireEvent.click(screen.getByText(/Next Step/));
 }
@@ -88,39 +112,56 @@ describe("SetupPage", () => {
     });
   });
 
-  it("shows the legal disclaimer first for an unauthenticated user", async () => {
+  it("shows the unlock gate first for an unauthenticated user", async () => {
     renderWithProviders(<SetupPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Legal Disclaimer")).toBeInTheDocument();
+      expect(screen.getByText("First-Run Setup")).toBeInTheDocument();
     });
+    expect(
+      screen.getByLabelText("First-run setup password"),
+    ).toBeInTheDocument();
+    // Nothing beyond the gate renders before a successful unlock.
+    expect(screen.queryByText("Legal Disclaimer")).not.toBeInTheDocument();
+    expect(getInitialConfig).not.toHaveBeenCalled();
   });
 
-  it("warns when FFmpeg is missing", async () => {
-    checkFFmpeg.mockResolvedValue({
-      ffmpeg: false,
-      ffprobe: false,
-      ffmpeg_path: null,
-      ffprobe_path: null,
-    });
+  it("shows a generic denial when the unlock password is rejected", async () => {
+    getInitialConfig.mockRejectedValue(makeForbidden());
 
     renderWithProviders(<SetupPage />);
 
+    const unlockInput = await screen.findByLabelText(
+      "First-run setup password",
+    );
+    fireEvent.change(unlockInput, { target: { value: "wrong-guess" } });
+    fireEvent.click(screen.getByText("Unlock Setup"));
+
     await waitFor(() => {
-      expect(screen.getByText("FFmpeg not detected")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Setup access denied. Check the first-run password, or sign in normally if this system is already set up.",
+        ),
+      ).toBeInTheDocument();
     });
+    expect(screen.queryByText("Legal Disclaimer")).not.toBeInTheDocument();
+  });
+
+  it("advances to the legal step after a successful unlock", async () => {
+    getInitialConfig.mockResolvedValue({ llm_provider: "gemini" });
+
+    renderWithProviders(<SetupPage />);
+
+    await unlockWizard();
+
+    expect(getInitialConfig).toHaveBeenCalledWith("first-run-pw");
   });
 
   it("blocks account submission when passwords do not match", async () => {
     renderWithProviders(<SetupPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Legal Disclaimer")).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText("I Accept & Continue"));
+    await advanceToAccountStep();
 
-    const bootstrap = await screen.findByLabelText("Bootstrap Password");
-    fireEvent.change(bootstrap, { target: { value: "pw" } });
     fireEvent.change(screen.getByLabelText("Username"), {
       target: { value: "admin" },
     });
@@ -135,7 +176,7 @@ describe("SetupPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
     });
-    expect(getInitialConfig).not.toHaveBeenCalled();
+    expect(setupSystem).not.toHaveBeenCalled();
   });
 
   it("validates the provider and lists models on reaching the LLM step", async () => {
@@ -144,10 +185,7 @@ describe("SetupPage", () => {
 
     renderWithProviders(<SetupPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Legal Disclaimer")).toBeInTheDocument();
-    });
-    await advanceToStep2({ gemini_api_key: "key-123" });
+    await advanceToLlmStep({ gemini_api_key: "key-123" });
 
     await waitFor(() => {
       expect(validateLLM).toHaveBeenCalled();
@@ -163,10 +201,7 @@ describe("SetupPage", () => {
   it("shows the missing-provider state when no key is configured", async () => {
     renderWithProviders(<SetupPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Legal Disclaimer")).toBeInTheDocument();
-    });
-    await advanceToStep2();
+    await advanceToLlmStep();
 
     await waitFor(() => {
       expect(
@@ -174,5 +209,68 @@ describe("SetupPage", () => {
       ).toBeInTheDocument();
     });
     expect(validateLLM).not.toHaveBeenCalled();
+  });
+
+  it("completes setup with the chosen transcription model and demo opt-out", async () => {
+    validateLLM.mockResolvedValue({ message: "Validation successful" });
+    listModels.mockResolvedValue({ models: ["gemini-pro-latest"] });
+    setupSystem.mockResolvedValue({ initialized: true });
+    login.mockResolvedValue({});
+    checkFFmpeg.mockResolvedValue({
+      ffmpeg: false,
+      ffprobe: false,
+      ffmpeg_path: null,
+      ffprobe_path: null,
+    });
+    getDownloadProgress.mockResolvedValue({
+      status: "complete",
+      progress: 100,
+      message: "Models ready",
+      stage: "complete",
+    });
+
+    renderWithProviders(<SetupPage />);
+
+    await advanceToAccountStep({ gemini_api_key: "key-123" });
+
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "admin" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "supersecret" },
+    });
+    fireEvent.change(screen.getByLabelText("Confirm Password"), {
+      target: { value: "supersecret" },
+    });
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    fireEvent.click(screen.getByText(/Next Step/));
+
+    await waitFor(() => {
+      expect(screen.getByText("Select Model")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText(/Next Step/));
+
+    const whisperSelect = await screen.findByLabelText("Transcription model");
+    fireEvent.change(whisperSelect, { target: { value: "small" } });
+    fireEvent.click(screen.getByText(/Finish Setup/));
+
+    await waitFor(() => {
+      expect(setupSystem).toHaveBeenCalledWith(
+        {
+          username: "admin",
+          password: "supersecret",
+          selected_model: "gemini-pro-latest",
+          whisper_model_size: "small",
+          include_demo_recording: false,
+        },
+        "first-run-pw",
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Setup Complete")).toBeInTheDocument();
+    });
+    expect(screen.getByText("FFmpeg not detected")).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/setup/page.tsx
+++ b/frontend/src/app/setup/page.tsx
@@ -9,6 +9,7 @@ import CompleteStep from "./_components/CompleteStep";
 import HuggingFaceStep from "./_components/HuggingFaceStep";
 import LegalStep from "./_components/LegalStep";
 import LlmStep from "./_components/LlmStep";
+import UnlockStep from "./_components/UnlockStep";
 import { useSetupWizard } from "./_hooks/useSetupWizard";
 
 export default function SetupPage() {
@@ -17,6 +18,9 @@ export default function SetupPage() {
     step,
     formData,
     error,
+    unlocking,
+    includeDemoRecording,
+    setIncludeDemoRecording,
     ffmpegMissing,
     showSkipLLMModal,
     setShowSkipLLMModal,
@@ -32,6 +36,7 @@ export default function SetupPage() {
     modelPreparationComplete,
     handleInputChange,
     handleBootstrapPasswordChange,
+    handleUnlockSubmit,
     handleLegalSubmit,
     handleAccountSubmit,
     handleLLMSubmit,
@@ -80,15 +85,17 @@ export default function SetupPage() {
           <p className="text-orange-100 mt-2">Initial System Setup</p>
         </div>
 
-        {/* Progress Steps */}
-        <div className="flex border-b border-gray-200 dark:border-gray-700">
-          {[0, 1, 2, 3, 4].map((s) => (
-            <div
-              key={s}
-              className={`flex-1 h-1 ${s <= step ? "bg-blue-600" : "bg-gray-200 dark:bg-gray-700"}`}
-            />
-          ))}
-        </div>
+        {/* Progress Steps (hidden on the unlock gate) */}
+        {step > 0 && (
+          <div className="flex border-b border-gray-200 dark:border-gray-700">
+            {[1, 2, 3, 4, 5].map((s) => (
+              <div
+                key={s}
+                className={`flex-1 h-1 ${s <= step ? "bg-orange-600" : "bg-gray-200 dark:bg-gray-700"}`}
+              />
+            ))}
+          </div>
+        )}
 
         <div className="p-8">
           {error && (
@@ -119,22 +126,33 @@ export default function SetupPage() {
             </div>
           )}
 
-          {/* Step 0: Legal Disclaimer */}
-          {step === 0 && <LegalStep onAccept={handleLegalSubmit} />}
-
-          {/* Step 1: Account */}
-          {step === 1 && (
-            <AccountStep
-              formData={formData}
+          {/* Step 0: Unlock Gate */}
+          {step === 0 && (
+            <UnlockStep
               error={error}
-              onSubmit={handleAccountSubmit}
-              onInputChange={handleInputChange}
+              unlocking={unlocking}
               onBootstrapPasswordChange={handleBootstrapPasswordChange}
+              onSubmit={handleUnlockSubmit}
             />
           )}
 
-          {/* Step 2: LLM Setup */}
+          {/* Step 1: Legal Disclaimer */}
+          {step === 1 && <LegalStep onAccept={handleLegalSubmit} />}
+
+          {/* Step 2: Account */}
           {step === 2 && (
+            <AccountStep
+              formData={formData}
+              error={error}
+              includeDemoRecording={includeDemoRecording}
+              onSubmit={handleAccountSubmit}
+              onInputChange={handleInputChange}
+              onIncludeDemoRecordingChange={setIncludeDemoRecording}
+            />
+          )}
+
+          {/* Step 3: LLM Setup */}
+          {step === 3 && (
             <LlmStep
               formData={formData}
               loading={loading}
@@ -150,20 +168,21 @@ export default function SetupPage() {
             />
           )}
 
-          {/* Step 3: HuggingFace */}
-          {step === 3 && (
+          {/* Step 4: Transcription & Speaker Models */}
+          {step === 4 && (
             <HuggingFaceStep
               formData={formData}
               loading={loading}
               pyannoteModelsReady={pyannoteModelsReady}
               bundledPyannoteModelsReady={bundledPyannoteModelsReady}
+              onInputChange={handleInputChange}
               onReloadConfig={handleReloadConfig}
               onSubmit={handleHFSubmit}
             />
           )}
 
-          {/* Step 4: Complete */}
-          {step === 4 && (
+          {/* Step 5: Complete */}
+          {step === 5 && (
             <CompleteStep
               modelPreparationComplete={modelPreparationComplete}
               modelPreparationMessage={modelPreparationMessage}

--- a/frontend/src/components/settings/WhisperModelModal.tsx
+++ b/frontend/src/components/settings/WhisperModelModal.tsx
@@ -13,6 +13,7 @@ import {
   deleteModel,
 } from "@/lib/api";
 import { useNotificationStore } from "@/lib/notificationStore";
+import { WHISPER_MODELS } from "@/lib/whisperModels";
 
 interface WhisperModelModalProps {
   isOpen: boolean;
@@ -21,27 +22,6 @@ interface WhisperModelModalProps {
   isAdmin: boolean;
   onUpdate: (newSize: string) => void;
 }
-
-const WHISPER_MODELS = [
-  { id: "tiny", label: "Tiny", params: "39 M", vram: "~1 GB", speed: "~10x" },
-  { id: "base", label: "Base", params: "74 M", vram: "~1 GB", speed: "~7x" },
-  { id: "small", label: "Small", params: "244 M", vram: "~2 GB", speed: "~4x" },
-  {
-    id: "medium",
-    label: "Medium",
-    params: "769 M",
-    vram: "~5 GB",
-    speed: "~2x",
-  },
-  {
-    id: "large",
-    label: "Large",
-    params: "1550 M",
-    vram: "~10 GB",
-    speed: "1x",
-  },
-  { id: "turbo", label: "Turbo", params: "809 M", vram: "~6 GB", speed: "~8x" },
-];
 
 export default function WhisperModelModal({
   isOpen,

--- a/frontend/src/lib/api/setup.ts
+++ b/frontend/src/lib/api/setup.ts
@@ -10,6 +10,8 @@ export const setupSystem = async (
     username: string;
     password: string;
     selected_model?: string;
+    whisper_model_size?: string;
+    include_demo_recording?: boolean;
   },
   bootstrapPassword?: string,
 ): Promise<{ initialized: boolean; model_preparation_task_id?: string | null }> => {

--- a/frontend/src/lib/whisperModels.ts
+++ b/frontend/src/lib/whisperModels.ts
@@ -1,0 +1,30 @@
+export interface WhisperModelOption {
+  id: string;
+  label: string;
+  params: string;
+  vram: string;
+  speed: string;
+}
+
+// Shared Whisper catalogue used by the first-run wizard and the settings
+// model picker. Keep in sync with WHISPER_MODEL_SIZES_MB on the backend.
+export const WHISPER_MODELS: WhisperModelOption[] = [
+  { id: "tiny", label: "Tiny", params: "39 M", vram: "~1 GB", speed: "~10x" },
+  { id: "base", label: "Base", params: "74 M", vram: "~1 GB", speed: "~7x" },
+  { id: "small", label: "Small", params: "244 M", vram: "~2 GB", speed: "~4x" },
+  {
+    id: "medium",
+    label: "Medium",
+    params: "769 M",
+    vram: "~5 GB",
+    speed: "~2x",
+  },
+  {
+    id: "large",
+    label: "Large",
+    params: "1550 M",
+    vram: "~10 GB",
+    speed: "1x",
+  },
+  { id: "turbo", label: "Turbo", params: "809 M", vram: "~6 GB", speed: "~8x" },
+];


### PR DESCRIPTION
## Description

Removes the permanent "Need first-run initialisation? Open setup" link from the sign-in page and closes the initialisation-state oracle in the setup API.

Previously, anonymous probes to the setup endpoints returned distinguishable responses (403 "Bootstrap password required..." pre-initialisation, 503 when `FIRST_RUN_PASSWORD` was unset, 403 "First-run setup access denied." post-initialisation), so anyone could detect whether an instance had been claimed. Now:

- `/setup` opens with an unlock gate: a single first-run-password field rendered identically in every state. The wizard only appears after `GET /setup/initial-config` accepts the bootstrap password.
- Every anonymous setup denial returns the same `403 {"detail": "First-run setup access denied."}` regardless of cause (wrong password, unset `FIRST_RUN_PASSWORD`, already initialised). The specific reason is logged server-side only. A new test asserts the three states produce byte-identical responses.
- The whole setup surface is rate limited (60 requests / 10 min per client address) via the existing `enforce_rate_limit` infrastructure, applied before any state-dependent work so throttling cannot act as an oracle either. Previously the bootstrap password could be brute-forced without limit.
- Discovery moves to the docs plus a startup log line: while uninitialised, the API logs the `/setup` URL and warns separately if `FIRST_RUN_PASSWORD` is unset (recovering the operator guidance the old 503 provided).

Bundled first-run wizard improvements:

- The final step gains a Whisper transcription-model selector (validated server-side against a shared catalogue; previously `SetupRequest.whisper_model_size` existed but the frontend never sent it, so every install silently got `turbo`).
- The Account step gains an "Include a sample meeting" opt-out. Opting out creates the owner with `has_seen_demo_recording=true`, which also stops the startup seeding path from re-adding the demo on restart; Settings > Help force-recreate still works.
- The FFmpeg check now runs after the wizard logs in as the new owner. It previously ran on page load where the anonymous 401 was swallowed, so the warning banner was unreachable during real first-run setup.
- The model-preparation screen clarifies the account is already created and downloads continue server-side; the timeout message no longer implies setup failed.
- The bootstrap password moves to its own screen (password managers no longer try to save it as the admin credentials); wizard progress bar uses brand orange.

Behaviour changes to note: setup failure responses changed (503 -> 403, unified detail string), and the sign-in page no longer links to `/setup` — README, Getting Started, and Deployment docs now direct operators there. No new dependencies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test`
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration. Single checked-in head preserved; no committed revisions deleted or renamed. Upgrade and downgrade behaviour described above.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR (README quick start, docs/GETTING_STARTED.md, docs/DEPLOYMENT.md, docs/SECURITY.md).

## Security impact

- [ ] No security-sensitive change.
- [x] Touches auth, tokens, encryption, capture ownership, or exposure. `docs/SECURITY.md` boundaries preserved and updated where behaviour changed (first-run bootstrap section now documents uniform denials, rate limiting, and the no-disclosure property).

## Manual verification

Automated coverage: new backend tests assert byte-identical anonymous denials across all three initialisation states, 429 behaviour on the setup namespace, and the startup log pointer; rewritten wizard tests cover the unlock gate (denial and success), the full happy path including the new `setupSystem` payload (`whisper_model_size`, `include_demo_recording`), and the post-login FFmpeg warning.

1. Fresh stack, no users: API log shows the `/setup` pointer; `/login` shows no setup text; `/setup` shows the unlock gate; wrong password gives the generic denial; correct password opens the wizard; complete it with a non-default Whisper model and the sample meeting unticked; confirm no demo recording after login and none re-seeded after an API restart.
2. Initialised stack: `/setup` while signed out shows the same gate and any password gets the same generic denial; signed-in users are redirected away; `curl -H "Authorization: Bootstrap x" .../api/v1/setup/initial-config` returns the same 403 body as pre-initialisation.

## Screenshots (if relevant)

None — UI changes are covered by the manual steps above (no running fresh instance available in this environment).
