### PR TITLE
perf(worker): gpu/cpu/io Celery lanes with warm live models, plus Ollama num_ctx notes-truncation fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ If the issue depends on specific input (an audio file, a recording length, a cal
 **Logs**
 Attach relevant logs. **Redact secrets and personal data first** — remove `FIRST_RUN_PASSWORD`, `DATA_ENCRYPTION_KEY`, API keys, tokens, `Authorization` headers, cookies, and meeting content you do not want public.
 - Browser: open DevTools and copy any relevant console or network errors.
-- Server: collect `docker compose logs api worker frontend`.
+- Server: collect `docker compose logs api worker-gpu worker-cpu worker-io frontend`.
 
 **Screenshots**
 If applicable, add screenshots to help explain the problem (with sensitive content redacted).

--- a/.github/ISSUE_TEMPLATE/platform_report.md
+++ b/.github/ISSUE_TEMPLATE/platform_report.md
@@ -45,7 +45,7 @@ A clear and concise description of what you expected to happen.
 **Logs**
 Please attach any relevant logs, with personal data redacted.
 - Browser: open DevTools and copy any relevant console or network errors.
-- Server: collect `docker compose logs api worker frontend`.
+- Server: collect `docker compose logs api worker-gpu worker-cpu worker-io frontend`.
 
 **Additional context**
 Add any other context about the problem here, including whether the browser share picker exposed an audio toggle and whether a shared-audio track was granted.

--- a/backend/api/v1/endpoints/system.py
+++ b/backend/api/v1/endpoints/system.py
@@ -147,7 +147,10 @@ except DockerException as e:
 ALLOWED_CONTAINERS = {
     # Production container names
     "nojoin-api",
-    "nojoin-worker",
+    "nojoin-worker-gpu",
+    "nojoin-worker-cpu",
+    "nojoin-worker-io",
+    "nojoin-worker",  # legacy single-worker deployments
     "nojoin-frontend",
     "nojoin-nginx",
     "nojoin-redis",
@@ -155,7 +158,10 @@ ALLOWED_CONTAINERS = {
     "nojoin-socket-proxy",
     # Development container names
     "nojoin-dev-api",
-    "nojoin-dev-worker",
+    "nojoin-dev-worker-gpu",
+    "nojoin-dev-worker-cpu",
+    "nojoin-dev-worker-io",
+    "nojoin-dev-worker",  # legacy single-worker deployments
     "nojoin-dev-frontend",
     "nojoin-dev-nginx",
     "nojoin-dev-redis",
@@ -263,7 +269,9 @@ async def websocket_logs(
             # Filter by name prefix or label if possible. For now, strict list.
             containers_list = [
                 "nojoin-api",
-                "nojoin-worker",
+                "nojoin-worker-gpu",
+                "nojoin-worker-cpu",
+                "nojoin-worker-io",
                 "nojoin-frontend",
                 "nojoin-nginx",
                 "nojoin-redis",

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -170,9 +170,7 @@ TASK_ROUTES = {
     "backend.worker.tasks.download_models_task": {"queue": GPU_QUEUE},
     "backend.worker.tasks.get_worker_device_status": {"queue": GPU_QUEUE},
     # CPU lane: ffmpeg transcode/proxy and local disk work.
-    "backend.processing.segment_transcode.transcode_segment_task": {
-        "queue": CPU_QUEUE
-    },
+    "backend.processing.segment_transcode.transcode_segment_task": {"queue": CPU_QUEUE},
     "backend.worker.tasks.generate_proxy_task": {"queue": CPU_QUEUE},
     "backend.worker.tasks.create_backup_task": {"queue": CPU_QUEUE},
     # IO/LLM lane: network-bound (LLM APIs, calendar) and light bookkeeping.

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -23,17 +23,72 @@ def log_placeholder_secret_warnings_on_worker_start(**kwargs):
     log_deployment_warnings(startup_path="worker startup", logger_instance=logger)
 
 
+_LIVE_CAPTURE_CHECK_TTL_SECONDS = 2.0
+_live_capture_check_cache: tuple[float, bool] | None = None
+
+
+def _has_active_live_capture() -> bool:
+    """Return True while any recording is actively uploading live segments.
+
+    Reloading the live ASR model on every segment costs ~9s (observed in worker
+    logs), so while a capture is in flight the per-task cache release is skipped
+    to keep Whisper resident. The result is cached briefly so this does not issue
+    a DB query after every task on busy workers.
+    """
+    global _live_capture_check_cache
+
+    now = time.time()
+    cached = _live_capture_check_cache
+    if cached is not None and now - cached[0] < _LIVE_CAPTURE_CHECK_TTL_SECONDS:
+        return cached[1]
+
+    active = False
+    try:
+        from sqlmodel import select
+
+        from backend.core.db import get_sync_session
+        from backend.models.recording import Recording, RecordingStatus
+
+        with get_sync_session() as session:
+            row = session.exec(
+                select(Recording.id)
+                .where(Recording.status == RecordingStatus.UPLOADING)
+                .where(Recording.is_deleted == False)  # noqa: E712
+                .limit(1)
+            ).first()
+        active = row is not None
+    except Exception as exc:  # noqa: BLE001 -- boundary: a check failure must not block cleanup
+        logger.debug("Active-capture check failed; assuming idle: %s", exc)
+        active = False
+
+    _live_capture_check_cache = (now, active)
+    return active
+
+
+def _should_release_model_caches() -> bool:
+    """Whether the per-task model-cache release should run.
+
+    Skipped when the operator pinned models (``keep_models_loaded``) or while a
+    live capture is in flight (keep the live ASR model warm across segments).
+    """
+    from backend.utils.config_manager import config_manager
+
+    if config_manager.get("keep_models_loaded", False):
+        return False
+    if _has_active_live_capture():
+        return False
+    return True
+
+
 def release_worker_model_caches() -> None:
     try:
         import ctypes
         import sys
 
-        from backend.utils.config_manager import config_manager
-
-        if config_manager.get("keep_models_loaded", False):
+        if not _should_release_model_caches():
             return
 
-        logger.info("Releasing worker model caches (keep_models_loaded=False)...")
+        logger.info("Releasing worker model caches...")
 
         loaded_release_hooks = (
             ("backend.processing.transcribe", "release_model_cache"),
@@ -93,12 +148,58 @@ celery_app = Celery(
     ],
 )
 
+# --- Task routing: resource lanes -------------------------------------------
+# Split work so a long GPU job never blocks lightweight CPU/network tasks. Each
+# worker process consumes one lane (`-Q gpu|cpu|io`); see docker-compose.
+GPU_QUEUE = "gpu"
+CPU_QUEUE = "cpu"
+IO_QUEUE = "io"
+
+# Explicit per-task routing. Anything unrouted falls back to the GPU lane
+# (`task_default_queue`), the safe default: a mis-routed GPU task still finds
+# the card, whereas routing it to a GPU-less worker would fail. New tasks must
+# be added here when introduced.
+TASK_ROUTES = {
+    # GPU lane: heavy ML inference. Serialised — the host has one 8 GB card.
+    "backend.worker.tasks.process_recording_task": {"queue": GPU_QUEUE},
+    "backend.processing.live_transcribe.transcribe_segment_live_task": {
+        "queue": GPU_QUEUE
+    },
+    "backend.worker.tasks.extract_embedding_task": {"queue": GPU_QUEUE},
+    "backend.worker.tasks.update_speaker_embedding_task": {"queue": GPU_QUEUE},
+    "backend.worker.tasks.download_models_task": {"queue": GPU_QUEUE},
+    "backend.worker.tasks.get_worker_device_status": {"queue": GPU_QUEUE},
+    # CPU lane: ffmpeg transcode/proxy and local disk work.
+    "backend.processing.segment_transcode.transcode_segment_task": {
+        "queue": CPU_QUEUE
+    },
+    "backend.worker.tasks.generate_proxy_task": {"queue": CPU_QUEUE},
+    "backend.worker.tasks.create_backup_task": {"queue": CPU_QUEUE},
+    # IO/LLM lane: network-bound (LLM APIs, calendar) and light bookkeeping.
+    "backend.worker.tasks.refresh_meeting_edge_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.generate_notes_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.infer_speakers_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.process_document_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.index_transcript_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.get_text_embedding_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.sync_calendar_connection_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.sync_calendar_connections_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.ensure_calendar_push_channels_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.renew_calendar_push_channels_task": {"queue": IO_QUEUE},
+    "backend.worker.tasks.cleanup_temp_recordings": {"queue": IO_QUEUE},
+}
+
 celery_app.conf.update(
     task_serializer="json",
     accept_content=["json"],
     result_serializer="json",
     timezone="UTC",
     enable_utc=True,
+    task_routes=TASK_ROUTES,
+    task_default_queue=GPU_QUEUE,
+    # One reserved message per worker process so a slow task cannot hoard a batch
+    # queued behind it; keeps the CPU/IO lanes fair under load.
+    worker_prefetch_multiplier=1,
     beat_schedule={
         "cleanup-temp-recordings-every-24h": {
             "task": "backend.worker.tasks.cleanup_temp_recordings",

--- a/backend/processing/llm_services.py
+++ b/backend/processing/llm_services.py
@@ -1927,6 +1927,13 @@ class AnthropicLLMBackend(LLMBackend):
             raise ValueError(f"Anthropic API validation failed: {e}")
 
 
+# Ollama's server default context window is only 2048 tokens, which silently
+# truncates meeting-length prompts mid-output. When no ollama_context_window is
+# configured, Nojoin pins num_ctx to this floor instead. Operators with long
+# meetings should raise ollama_context_window in Settings.
+OLLAMA_DEFAULT_NUM_CTX = 8192
+
+
 class OllamaLLMBackend(LLMBackend):
     def __init__(
         self,
@@ -1957,8 +1964,13 @@ class OllamaLLMBackend(LLMBackend):
     def _chat_options(self, *, temperature: float) -> dict[str, object]:
         options: dict[str, object] = {"temperature": temperature}
         context_window = getattr(self, "context_window", None)
-        if context_window:
-            options["num_ctx"] = int(context_window)
+        # Always pin num_ctx. Without it Ollama uses its 2048 default, which
+        # silently truncates meeting-length prompts mid-output (the model reports
+        # done_reason="stop", so _raise_if_truncated cannot catch it). A
+        # configured ollama_context_window wins; otherwise use a safe floor.
+        options["num_ctx"] = (
+            int(context_window) if context_window else OLLAMA_DEFAULT_NUM_CTX
+        )
         return options
 
     @staticmethod

--- a/backend/processing/llm_services.py
+++ b/backend/processing/llm_services.py
@@ -1927,10 +1927,7 @@ class AnthropicLLMBackend(LLMBackend):
             raise ValueError(f"Anthropic API validation failed: {e}")
 
 
-# Ollama's server default context window is only 2048 tokens, which silently
-# truncates meeting-length prompts mid-output. When no ollama_context_window is
-# configured, Nojoin pins num_ctx to this floor instead. Operators with long
-# meetings should raise ollama_context_window in Settings.
+# Ollama's num_ctx defaults to 2048, which silently truncates meeting-length prompts.
 OLLAMA_DEFAULT_NUM_CTX = 8192
 
 
@@ -1962,16 +1959,10 @@ class OllamaLLMBackend(LLMBackend):
         )
 
     def _chat_options(self, *, temperature: float) -> dict[str, object]:
-        options: dict[str, object] = {"temperature": temperature}
-        context_window = getattr(self, "context_window", None)
-        # Always pin num_ctx. Without it Ollama uses its 2048 default, which
-        # silently truncates meeting-length prompts mid-output (the model reports
-        # done_reason="stop", so _raise_if_truncated cannot catch it). A
-        # configured ollama_context_window wins; otherwise use a safe floor.
-        options["num_ctx"] = (
-            int(context_window) if context_window else OLLAMA_DEFAULT_NUM_CTX
-        )
-        return options
+        # num_ctx must always be sent; an unset one lets Ollama fall back to its
+        # 2048 default, which silently truncates meeting-length prompts.
+        ctx = getattr(self, "context_window", None) or OLLAMA_DEFAULT_NUM_CTX
+        return {"temperature": temperature, "num_ctx": int(ctx)}
 
     @staticmethod
     def _raise_if_truncated(response_metadata: dict | None) -> None:

--- a/backend/tests/test_llm_services_unified.py
+++ b/backend/tests/test_llm_services_unified.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from backend.processing.llm_services import (
+    OLLAMA_DEFAULT_NUM_CTX,
     AnthropicLLMBackend,
     GeminiLLMBackend,
     OllamaLLMBackend,
@@ -242,6 +243,20 @@ def test_ollama_generate_meeting_intelligence_repairs_contract_failure() -> None
     assert "Validation error:" in repair_prompt
     assert "Previous Invalid Response" in repair_prompt
     assert "Return a corrected response" in repair_prompt
+
+
+def test_ollama_chat_options_pins_num_ctx_floor_when_unconfigured() -> None:
+    # Without num_ctx Ollama defaults to 2048 and silently truncates meeting-
+    # length prompts, so an unconfigured backend must still send the safe floor.
+    backend = object.__new__(OllamaLLMBackend)
+    backend.context_window = None
+    assert backend._chat_options(temperature=0.3)["num_ctx"] == OLLAMA_DEFAULT_NUM_CTX
+
+
+def test_ollama_chat_options_honours_configured_context_window() -> None:
+    backend = object.__new__(OllamaLLMBackend)
+    backend.context_window = 131072
+    assert backend._chat_options(temperature=0.3)["num_ctx"] == 131072
 
 
 def test_ollama_streaming_chat_raises_when_context_exhausted() -> None:

--- a/backend/tests/test_task_routing.py
+++ b/backend/tests/test_task_routing.py
@@ -1,0 +1,73 @@
+"""Guards for Celery task routing into resource lanes.
+
+Work is split across ``gpu`` / ``cpu`` / ``io`` queues (see
+``backend/celery_app.py``) so a long GPU job never blocks lightweight CPU or
+network tasks. A regression here would silently re-serialise the worker or route
+a GPU task to a GPU-less lane where it would fail.
+"""
+
+# Importing the task packages registers every task on the app so the
+# completeness check below sees the full surface.
+import backend.processing.live_transcribe  # noqa: F401
+import backend.processing.segment_transcode  # noqa: F401
+import backend.worker.tasks  # noqa: F401
+from backend.celery_app import (
+    CPU_QUEUE,
+    GPU_QUEUE,
+    IO_QUEUE,
+    TASK_ROUTES,
+    celery_app,
+)
+
+
+def _queue(task_name: str) -> str:
+    return TASK_ROUTES[task_name]["queue"]
+
+
+def test_heavy_gpu_tasks_route_to_gpu_lane() -> None:
+    for task in (
+        "backend.worker.tasks.process_recording_task",
+        "backend.processing.live_transcribe.transcribe_segment_live_task",
+        "backend.worker.tasks.extract_embedding_task",
+        "backend.worker.tasks.update_speaker_embedding_task",
+    ):
+        assert _queue(task) == GPU_QUEUE
+
+
+def test_ffmpeg_tasks_route_to_cpu_lane() -> None:
+    for task in (
+        "backend.processing.segment_transcode.transcode_segment_task",
+        "backend.worker.tasks.generate_proxy_task",
+    ):
+        assert _queue(task) == CPU_QUEUE
+
+
+def test_network_tasks_route_to_io_lane() -> None:
+    for task in (
+        "backend.worker.tasks.refresh_meeting_edge_task",
+        "backend.worker.tasks.generate_notes_task",
+        "backend.worker.tasks.infer_speakers_task",
+        "backend.worker.tasks.sync_calendar_connections_task",
+    ):
+        assert _queue(task) == IO_QUEUE
+
+
+def test_unrouted_tasks_fall_back_to_gpu_lane() -> None:
+    # Safe default: a mis-routed GPU task still finds the card, whereas a
+    # GPU-less lane would fail it outright.
+    assert celery_app.conf.task_default_queue == GPU_QUEUE
+
+
+def test_prefetch_multiplier_is_one_for_fair_dispatch() -> None:
+    assert celery_app.conf.worker_prefetch_multiplier == 1
+
+
+def test_every_nojoin_task_has_an_explicit_route() -> None:
+    """A task without a route silently lands on the GPU lane; catch that here."""
+    unrouted = [
+        name
+        for name in celery_app.tasks
+        if name.startswith(("backend.worker.tasks.", "backend.processing."))
+        and name not in TASK_ROUTES
+    ]
+    assert not unrouted, f"tasks missing an explicit lane route: {sorted(unrouted)}"

--- a/backend/tests/test_worker_model_cache_gate.py
+++ b/backend/tests/test_worker_model_cache_gate.py
@@ -1,0 +1,35 @@
+"""Guards for the warm-during-live model-cache gate.
+
+Reloading the live ASR model on every segment costs ~9s (observed in worker
+logs), so the per-task cache release is skipped while a capture is uploading.
+It must still release when idle, and must always honour the ``keep_models_loaded``
+operator pin.
+"""
+
+import backend.celery_app as celery_app_module
+from backend.celery_app import _should_release_model_caches
+
+
+def _patch_keep_models_loaded(monkeypatch, value: bool) -> None:
+    monkeypatch.setattr(
+        "backend.utils.config_manager.config_manager.get",
+        lambda key, default=None: value if key == "keep_models_loaded" else default,
+    )
+
+
+def test_releases_when_idle_and_not_pinned(monkeypatch) -> None:
+    monkeypatch.setattr(celery_app_module, "_has_active_live_capture", lambda: False)
+    _patch_keep_models_loaded(monkeypatch, False)
+    assert _should_release_model_caches() is True
+
+
+def test_skips_release_during_active_capture(monkeypatch) -> None:
+    monkeypatch.setattr(celery_app_module, "_has_active_live_capture", lambda: True)
+    _patch_keep_models_loaded(monkeypatch, False)
+    assert _should_release_model_caches() is False
+
+
+def test_keep_models_loaded_pin_wins_even_when_idle(monkeypatch) -> None:
+    monkeypatch.setattr(celery_app_module, "_has_active_live_capture", lambda: False)
+    _patch_keep_models_loaded(monkeypatch, True)
+    assert _should_release_model_caches() is False

--- a/backend/worker/tasks/pipeline.py
+++ b/backend/worker/tasks/pipeline.py
@@ -1235,34 +1235,28 @@ def _release_pipeline_vram() -> None:
     try:
         logger.info("Releasing VRAM (keep_models_loaded=False)...")
 
-        # 1. Whisper
         from backend.processing.transcribe import release_model_cache
 
         release_model_cache()
 
-        # 2. Pyannote
         from backend.processing.diarize import release_pipeline_cache
 
         release_pipeline_cache()
 
-        # 3. Speaker Embeddings
         from backend.processing.embedding_core import release_embedding_model_cache
 
         release_embedding_model_cache()
 
-        # 4. Segmentation Refinement
         from backend.processing.segmentation_refinement import (
             release_segmentation_model_cache,
         )
 
         release_segmentation_model_cache()
 
-        # 5. Text Embeddings
         from backend.processing.text_embedding import release_embedding_model
 
         release_embedding_model()
 
-        # 6. Garbage Collection
         import gc
 
         gc.collect()
@@ -1320,11 +1314,8 @@ def process_recording_task(
         logger.info("Recording %s was cancelled. Aborting task.", recording_id)
         return
 
-    # A live capture on another recording may have left the live ASR model
-    # resident (see the keep-warm gate in backend.celery_app). Clear cached
-    # models before this finalize loads its diarisation/segmentation stack so the
-    # two never stack past the 8 GB VRAM budget. Models this task needs are
-    # reloaded on demand below; on a multi-minute finalize the reload is noise.
+    # Clear any live ASR model left warm by another capture before this finalise
+    # loads its diarisation stack, so the two never exceed the 8 GB GPU budget.
     if not config_manager.get("keep_models_loaded", False):
         _release_pipeline_vram()
 

--- a/backend/worker/tasks/pipeline.py
+++ b/backend/worker/tasks/pipeline.py
@@ -1320,6 +1320,14 @@ def process_recording_task(
         logger.info("Recording %s was cancelled. Aborting task.", recording_id)
         return
 
+    # A live capture on another recording may have left the live ASR model
+    # resident (see the keep-warm gate in backend.celery_app). Clear cached
+    # models before this finalize loads its diarisation/segmentation stack so the
+    # two never stack past the 8 GB VRAM budget. Models this task needs are
+    # reloaded on demand below; on a multi-minute finalize the reload is noise.
+    if not config_manager.get("keep_models_loaded", False):
+        _release_pipeline_vram()
+
     user_settings = {}
     if recording.user_id:
         user = session.get(User, recording.user_id)

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -30,6 +30,39 @@ x-shared-app-environment: &shared-app-environment
   MICROSOFT_OAUTH_CLIENT_SECRET: ${MICROSOFT_OAUTH_CLIENT_SECRET:-}
   MICROSOFT_OAUTH_TENANT_ID: ${MICROSOFT_OAUTH_TENANT_ID:-common}
 
+# Shared config for the three worker lanes (worker-gpu / worker-cpu / worker-io).
+# They run the same image and differ only in Celery queue, pool, and GPU access.
+x-worker-base: &worker-base
+  image: ghcr.io/valtora/nojoin-worker:latest
+  volumes:
+    - ./data:/app/data
+    - model_cache:/home/appuser/.cache
+    - /sys/class/drm:/sys/class/drm:ro
+    - backup_temp:/tmp
+  depends_on:
+    init-perms:
+      condition: service_completed_successfully
+    db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  extra_hosts:
+    - host.docker.internal:host-gateway
+  restart: unless-stopped
+  networks:
+    - nojoin_net
+  logging: *default-logging
+
+x-worker-environment: &worker-environment
+  <<: *shared-app-environment
+  XDG_CACHE_HOME: /home/appuser/.cache
+  HF_HOME: /home/appuser/.cache/huggingface
+  OMP_NUM_THREADS: 2
+  MKL_NUM_THREADS: 2
+  OPENBLAS_NUM_THREADS: 2
+  VECLIB_MAXIMUM_THREADS: 2
+  NUMEXPR_NUM_THREADS: 2
+
 services:
   db:
     container_name: nojoin-db
@@ -146,27 +179,23 @@ services:
       - nojoin_net
     logging: *default-logging
 
-  worker:
-    container_name: nojoin-worker
-    image: ghcr.io/valtora/nojoin-worker:latest
-    volumes:
-      - ./data:/app/data
-      - model_cache:/home/appuser/.cache
-      - /sys/class/drm:/sys/class/drm:ro
-      - backup_temp:/tmp
+  # Worker lanes: work is split by resource profile so a long GPU job never
+  # blocks lightweight CPU or network tasks. Each service drains one Celery
+  # queue (see backend/celery_app.py TASK_ROUTES). All three run the same image;
+  # only the queue, pool, and GPU access differ.
+  #
+  # GPU lane: finalize, live ASR, embeddings. Single-slot (--pool=solo
+  # --concurrency=1) so the one 8 GB card only ever runs one model pipeline at a
+  # time. This is the ONLY worker with GPU access.
+  worker-gpu:
+    <<: *worker-base
+    container_name: nojoin-worker-gpu
     environment:
-      <<: *shared-app-environment
+      <<: *worker-environment
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
       NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
       WHISPER_ENABLE_WORD_TIMESTAMPS: ${WHISPER_ENABLE_WORD_TIMESTAMPS:-true}
-      XDG_CACHE_HOME: /home/appuser/.cache
-      HF_HOME: /home/appuser/.cache/huggingface
-      OMP_NUM_THREADS: 2
-      MKL_NUM_THREADS: 2
-      OPENBLAS_NUM_THREADS: 2
-      VECLIB_MAXIMUM_THREADS: 2
-      NUMEXPR_NUM_THREADS: 2
-    # Remove this block for CPU-only deployments.
+    # Remove this deploy block for CPU-only deployments.
     deploy:
       resources:
         reservations:
@@ -174,19 +203,36 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
-    depends_on:
-      init-perms:
-        condition: service_completed_successfully
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    extra_hosts:
-      - host.docker.internal:host-gateway
-    restart: unless-stopped
-    networks:
-      - nojoin_net
-    logging: *default-logging
+    command:
+      [
+        "celery", "-A", "backend.celery_app.celery_app", "worker",
+        "-Q", "gpu", "--pool=solo", "--concurrency=1", "--loglevel=info",
+      ]
+
+  # CPU lane: ffmpeg segment transcode, proxy generation, backups. No GPU.
+  worker-cpu:
+    <<: *worker-base
+    container_name: nojoin-worker-cpu
+    environment: *worker-environment
+    command:
+      [
+        "celery", "-A", "backend.celery_app.celery_app", "worker",
+        "-Q", "cpu", "--pool=prefork", "--concurrency=3", "--loglevel=info",
+      ]
+
+  # IO/LLM lane: Meeting Edge, notes, chat embeddings, calendar sync, cleanup.
+  # Network-bound, so it runs a wider prefork pool. Owns Celery Beat (-B) so the
+  # periodic jobs fire exactly once across the stack (no double-scheduling).
+  worker-io:
+    <<: *worker-base
+    container_name: nojoin-worker-io
+    environment: *worker-environment
+    command:
+      [
+        "celery", "-A", "backend.celery_app.celery_app", "worker",
+        "-Q", "io", "-B", "-s", "/app/data/celerybeat-schedule",
+        "--pool=prefork", "--concurrency=4", "--loglevel=info",
+      ]
 
   frontend:
     container_name: nojoin-frontend

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -106,9 +106,13 @@ USER appuser
 # Entrypoint preloads ML models, then hands off to the CMD
 ENTRYPOINT ["backend/worker_entrypoint.sh"]
 
-# Run the worker with embedded Celery Beat (-B) so periodic jobs (15-minute
-# calendar sync, 24-hour temp cleanup, calendar push-channel renewal) actually
-# fire. Nojoin runs a single worker, so embedded beat cannot double-schedule.
-# The beat schedule DB lives on the persistent ./data volume so the cadence
-# survives restarts instead of resetting.
-CMD ["celery", "-A", "backend.celery_app.celery_app", "worker", "-B", "-s", "/app/data/celerybeat-schedule", "--loglevel=info", "--pool=solo", "--concurrency=1"]
+# Default command: a single worker draining all resource lanes (gpu, cpu, io)
+# with embedded Celery Beat (-B), so a standalone `docker run` of this image
+# still processes everything and fires periodic jobs (15-minute calendar sync,
+# 24-hour temp cleanup, calendar push-channel renewal). The beat schedule DB
+# lives on the persistent ./data volume so the cadence survives restarts.
+#
+# In the Compose deployment this CMD is overridden: work is split across the
+# worker-gpu / worker-cpu / worker-io services, and beat (-B) runs on the io
+# worker ONLY, so periodic jobs cannot double-schedule.
+CMD ["celery", "-A", "backend.celery_app.celery_app", "worker", "-B", "-s", "/app/data/celerybeat-schedule", "-Q", "gpu,cpu,io", "--pool=solo", "--concurrency=1", "--loglevel=info"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,14 @@ The backend is responsible for:
 
 The processing-heavy work runs in Celery workers rather than inside API endpoints.
 
+Celery work is split across three resource lanes so a long recording finalise
+never blocks lightweight tasks: a single-slot GPU lane (finalise, live ASR,
+embeddings), a CPU lane (ffmpeg transcode, proxies, backups), and an IO/LLM lane
+(Meeting Edge, notes, chat, calendar sync) that also runs Celery Beat. Routing
+lives in `backend/celery_app.py` (`TASK_ROUTES`); see [DEPLOYMENT.md](DEPLOYMENT.md)
+for pool sizing. To avoid reloading the live ASR model between segments, the GPU
+lane keeps it resident while a capture is uploading and releases it when idle.
+
 ### Web Client
 
 The web client is responsible for:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -109,21 +109,53 @@ the configured Whisper model, Pyannote diarisation, and voice embeddings. The
 worker validates those assets on CPU where possible, caches them on disk, and
 releases model objects and CUDA memory before returning to idle.
 
-The worker also runs an embedded Celery Beat scheduler (`celery worker -B`) that
-drives Nojoin's periodic jobs: calendar sync every 15 minutes, calendar
-push-channel renewal every 30 minutes, and temporary-recording cleanup daily.
-Because Nojoin runs a single worker, embedded beat cannot double-schedule, and
-the beat schedule state lives on the persistent data volume so the cadence
-survives restarts. Optional calendar live sync (push notifications) additionally
-requires the instance to be reachable from the public internet over HTTPS at
+One worker lane (`worker-io`) runs the embedded Celery Beat scheduler (`celery
+worker -B`) that drives Nojoin's periodic jobs: calendar sync every 15 minutes,
+calendar push-channel renewal every 30 minutes, and temporary-recording cleanup
+daily. Beat runs on that single lane only, so it cannot double-schedule, and the
+beat schedule state lives on the persistent data volume so the cadence survives
+restarts. Optional calendar live sync (push notifications) additionally requires
+the instance to be reachable from the public internet over HTTPS at
 `WEB_APP_URL`; see [CALENDAR.md](CALENDAR.md).
 
 If an administrator switches transcription to Parakeet or Canary, Nojoin queues
 preparation for the selected ONNX ASR model after the setting is saved. Live and
 final processing still load inference models only for active work. After each
 worker task, Nojoin releases model caches and clears CUDA memory when
-`keep_models_loaded` is unset or false. Set `keep_models_loaded=true` only if you
-deliberately prefer warmer repeated processing over idle VRAM.
+`keep_models_loaded` is unset or false — except while a recording is actively
+uploading (live capture), where the live ASR model is kept resident so
+consecutive segments are not forced to reload it (a reload costs several seconds
+per segment). When capture goes idle the caches are released as normal, and a
+recording finalise clears cached models before loading its heavier diarisation
+stack so the two never exceed VRAM. Set `keep_models_loaded=true` only if you
+deliberately prefer warmer repeated processing over idle VRAM across the board.
+
+### Worker Concurrency Lanes
+
+To stop a long recording finalise from blocking every other user's live
+transcription, notes, chat, and calendar sync, worker tasks are split across
+three Celery queues, each drained by its own container:
+
+- `worker-gpu` — GPU-bound inference (recording finalise, live ASR, speaker
+  embeddings). Single-slot (`--pool=solo --concurrency=1`): with one GPU, heavy
+  work is deliberately serialised to protect VRAM. This is the only worker
+  granted GPU access.
+- `worker-cpu` — ffmpeg segment transcode, proxy generation, and backups
+  (`--pool=prefork --concurrency=3`). No GPU.
+- `worker-io` — network-bound work: Meeting Edge, notes, chat embeddings,
+  calendar sync, and cleanup (`--pool=prefork --concurrency=4`). No GPU. Also
+  runs Celery Beat.
+
+Task-to-queue routing is defined in `backend/celery_app.py` (`TASK_ROUTES`);
+anything unrouted falls back to the GPU lane. Tune the `--concurrency` values in
+`docker-compose.yml` to your host: the CPU and IO lanes are cheap (no model
+memory), while the GPU lane should stay at `--concurrency=1` unless you have
+multiple GPUs, or a single card large enough to hold two concurrent pipelines.
+
+With three worker containers plus the API, several worker processes each keep a
+small database connection pool. The default PostgreSQL `max_connections` (100)
+comfortably covers the reference `3` / `4` lane sizing; if you scale the lanes
+much wider, raise `max_connections` to match.
 
 ### GPU Acceleration
 
@@ -138,10 +170,11 @@ The Parakeet and Canary ASR engines also use ONNX Runtime CUDA. Some ONNX graph 
 If you do not have a compatible NVIDIA GPU:
 
 1. Open `docker-compose.yml`.
-2. Remove the `deploy` section under the `worker` service.
+2. Remove the `deploy` section under the `worker-gpu` service.
 3. Start the stack normally with `docker compose up -d`.
 
-Processing will be slower, but the application remains usable.
+Processing will be slower, but the application remains usable. All three worker
+lanes then run on CPU.
 
 ## Configure .env
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -189,14 +189,14 @@ Use the normal container rebuild loop when you are staying in the containerised 
 
 ```bash
 docker compose up -d --build api
-docker compose up -d --build worker
+docker compose up -d --build worker-gpu worker-cpu worker-io
 docker compose up -d --build frontend
 ```
 
 Practical use:
 
 - Run `docker compose up -d --build api` after API changes or shared backend changes.
-- Run `docker compose up -d --build worker` after worker code, dependency, or worker-image changes.
+- Run `docker compose up -d --build worker-gpu worker-cpu worker-io` after worker code, dependency, or worker-image changes. The three worker lanes share one image, so this rebuilds it once and recreates all three containers.
 - Run `docker compose up -d --build frontend` after frontend changes that you want to verify through Nginx.
 
 The compose files now gate `frontend` on a healthy `api`, and gate `nginx` (or `nginx-dev` in development) on healthy `api` plus `frontend`, so the proxy waits for both application tiers before becoming ready.
@@ -219,7 +219,7 @@ If you need to discard cached layers or the application services drift out of sy
 
 ```bash
 docker compose down
-docker compose build --no-cache api worker frontend
+docker compose build --no-cache api worker-gpu worker-cpu worker-io frontend
 docker compose up -d --force-recreate
 ```
 
@@ -239,7 +239,7 @@ services:
       - backup_temp:/tmp
 
   worker:
-    command: watchmedo auto-restart --directory=./backend --pattern=*.py --recursive -- celery -A backend.celery_app.celery_app worker --loglevel=info --pool=solo
+    command: watchmedo auto-restart --directory=./backend --pattern=*.py --recursive -- celery -A backend.celery_app.celery_app worker -Q gpu,cpu,io -B -s /app/data/celerybeat-schedule --loglevel=info --pool=solo
     volumes:
       - .:/app
       - ./data:/app/data
@@ -247,6 +247,8 @@ services:
       - /sys/class/drm:/sys/class/drm:ro
       - backup_temp:/tmp
 ```
+
+The development compose runs a single worker that drains all three resource lanes (`-Q gpu,cpu,io`) with embedded beat, which keeps the local loop simple. Production instead splits that work across dedicated `worker-gpu`, `worker-cpu`, and `worker-io` services; see [Worker Concurrency Lanes](DEPLOYMENT.md#worker-concurrency-lanes). The `-Q gpu,cpu,io` flag above is required — without it the worker would only consume the default (gpu) queue and CPU/IO tasks would never run.
 
 That patch is optional. It changes the backend feedback loop only. It does not change the frontend contract. If Nginx still proxies the `frontend` container, rebuilding `frontend` remains the way to update `https://localhost:14443`.
 

--- a/frontend/src/components/settings/SystemTab.tsx
+++ b/frontend/src/components/settings/SystemTab.tsx
@@ -190,7 +190,9 @@ export default function SystemTab() {
   const containers = [
     "all",
     "nojoin-api",
-    "nojoin-worker",
+    "nojoin-worker-gpu",
+    "nojoin-worker-cpu",
+    "nojoin-worker-io",
     "nojoin-frontend",
     "nojoin-nginx",
     "nojoin-redis",


### PR DESCRIPTION
## Description

Two related workstreams to make the deployment handle several concurrent users and to stop Ollama meeting notes truncating.

**1. Worker concurrency lanes + warm live models.** Previously the worker ran a single `--pool=solo --concurrency=1` process with no queue routing, so every task type shared one lane: a multi-minute recording finalise blocked every other user's live transcription, Meeting Edge, chat, and calendar sync. Work is now split by resource profile across three Celery queues, each drained by its own container:

- `worker-gpu` — finalise, live ASR, embeddings. Single-slot (`--pool=solo --concurrency=1`); the only worker with GPU access, so the single GPU stays VRAM-safe.
- `worker-cpu` — ffmpeg transcode, proxy generation, backups (`--pool=prefork --concurrency=3`).
- `worker-io` — Meeting Edge, notes, chat embeddings, calendar sync, cleanup (`--pool=prefork --concurrency=4`). Runs Celery Beat.

Routing lives in `backend/celery_app.py` (`TASK_ROUTES`), with a GPU default queue for anything unrouted and `worker_prefetch_multiplier=1` for fair dispatch. To stop the live ASR model reloading (~9s observed) on every segment, the per-task model-cache release is skipped while a recording is `UPLOADING`, and the finalise clears VRAM at its start so the live model and the diarisation stack never exceed the GPU budget. The Dockerfile default command drains all lanes for a standalone run; beat is pinned to the io lane so periodic jobs cannot double-schedule. The container-name allowlist, log viewer, and issue templates are updated for the new names.

**2. Ollama notes truncation fix.** `OllamaLLMBackend._chat_options` only sent `num_ctx` when a context window was configured; otherwise Ollama fell back to its 2048 default, which silently truncated meeting-length prompts mid-sentence (reported as a normal `stop`, so the existing truncation guard could not catch it). It now always sends `num_ctx`, using the configured `ollama_context_window` or a safe 8192 floor.

Fixes # (n/a)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [ ] Python quality: `python scripts/check.py` (ran `ruff check` on changed files — clean; did not run full mypy pass)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (37 files, 181 tests)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

New tests: `backend/tests/test_task_routing.py` (lane routing + completeness), `backend/tests/test_worker_model_cache_gate.py` (warm-during-live release gate), and two `num_ctx` cases in `backend/tests/test_llm_services_unified.py`.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR: `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT.md` (new "Worker Concurrency Lanes" section + CPU-only note), and `docs/DEVELOPMENT.md` (rebuild commands, source-mount patch).

## Security impact

- [x] No security-sensitive change. The `system.py` edit only extends the superuser-gated container log allowlist with the new worker names; no auth, token, encryption, capture-ownership, or exposure behaviour changes.

## Manual verification

- Split deployed to the live host: `worker-gpu` / `worker-cpu` / `worker-io` all came up and processed jobs; API and frontend healthy. Old single `nojoin-worker` retired via `--remove-orphans`.
- Ollama fix validated against the live Ollama (gemma4, `num_ctx: 131072`): a notes-style generation completed naturally (`done_reason: "stop"`, full output) with no truncation, confirming the root cause was the missing `num_ctx` in the pre-fix image.
- Still recommended before relying on it under load: observe `nvidia-smi` peak during a finalise that overlaps a live meeting to confirm the warm-model + finalise VRAM stays within the 8 GB budget on the reference RTX 2080 SUPER.

No capture, recording context-menu, auth/session, or migration paths were touched.
