### PR TITLE
AI settings redesign + per-user CLI usage & quota admin panel

### DIFF
--- a/backend/alembic/versions/c9f21a7de4b3_add_cli_usage_tracking.py
+++ b/backend/alembic/versions/c9f21a7de4b3_add_cli_usage_tracking.py
@@ -1,0 +1,104 @@
+"""add cli usage tracking
+
+Revision ID: c9f21a7de4b3
+Revises: b30103edc480
+Create Date: 2026-07-07 15:40:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9f21a7de4b3"
+down_revision: Union[str, Sequence[str], None] = "b30103edc480"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Latest-known rate-limit reading on the per-user credential (advisory).
+    op.add_column(
+        "cli_oauth_credentials",
+        sa.Column("last_utilization", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "cli_oauth_credentials",
+        sa.Column("last_rate_limit_status", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "cli_oauth_credentials",
+        sa.Column("last_rate_limit_type", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "cli_oauth_credentials",
+        sa.Column("last_rate_limit_at", sa.DateTime(), nullable=True),
+    )
+
+    # Per-user, per-day token-usage rollup for the admin usage panel.
+    op.create_table(
+        "cli_usage_daily",
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("usage_date", sa.Date(), nullable=False),
+        sa.Column("input_tokens", sa.BigInteger(), server_default="0", nullable=False),
+        sa.Column("output_tokens", sa.BigInteger(), server_default="0", nullable=False),
+        sa.Column(
+            "cache_read_input_tokens",
+            sa.BigInteger(),
+            server_default="0",
+            nullable=False,
+        ),
+        sa.Column(
+            "cache_creation_input_tokens",
+            sa.BigInteger(),
+            server_default="0",
+            nullable=False,
+        ),
+        sa.Column("request_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("total_cost_usd", sa.Float(), server_default="0", nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "provider",
+            "usage_date",
+            name="uq_cli_usage_daily_user_provider_date",
+        ),
+    )
+    op.create_index(
+        op.f("ix_cli_usage_daily_user_id"),
+        "cli_usage_daily",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_cli_usage_daily_provider"),
+        "cli_usage_daily",
+        ["provider"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_cli_usage_daily_usage_date"),
+        "cli_usage_daily",
+        ["usage_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_cli_usage_daily_usage_date"), table_name="cli_usage_daily")
+    op.drop_index(op.f("ix_cli_usage_daily_provider"), table_name="cli_usage_daily")
+    op.drop_index(op.f("ix_cli_usage_daily_user_id"), table_name="cli_usage_daily")
+    op.drop_table("cli_usage_daily")
+    op.drop_column("cli_oauth_credentials", "last_rate_limit_at")
+    op.drop_column("cli_oauth_credentials", "last_rate_limit_type")
+    op.drop_column("cli_oauth_credentials", "last_rate_limit_status")
+    op.drop_column("cli_oauth_credentials", "last_utilization")

--- a/backend/api/v1/endpoints/cli_oauth.py
+++ b/backend/api/v1/endpoints/cli_oauth.py
@@ -14,18 +14,20 @@ refresh token; on first use the manager refreshes on demand.
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.api.deps import get_current_user, get_db
+from backend.api.deps import get_current_admin_user, get_current_user, get_db
 from backend.models.cli_oauth import (
     CliOAuthCredential,
     CliOAuthCredentialStatus,
     CliOAuthProvider,
+    CliUsageDaily,
 )
 from backend.models.user import User
 from backend.services.cli_oauth import oauth
@@ -61,6 +63,34 @@ class CliOAuthStatusRead(BaseModel):
     # Set while a subscription usage limit is still in effect (best-effort reset
     # time from the SDK's RateLimitEvent); None once past, so the UI clears itself.
     usage_limited_until: Optional[datetime] = None
+    # This user's own recorded CLI token usage (input + output), for a self-view
+    # in the AI settings panel. None until the first turn is recorded.
+    tokens_7d: Optional[int] = None
+    tokens_total: Optional[int] = None
+
+
+class CliUsageRow(BaseModel):
+    """One user's CLI usage + quota status for the admin overview table."""
+
+    user_id: int
+    username: str
+    connected: bool
+    tokens_total: int
+    tokens_7d: int
+    tokens_30d: int
+    requests_total: int
+    last_used_on: Optional[date] = None
+    # Latest-known rate-limit reading (advisory; a subscription exposes no
+    # absolute remaining quota). utilization is 0.0-1.0 of the current window.
+    rate_limit_status: Optional[str] = None
+    rate_limit_type: Optional[str] = None
+    utilization: Optional[float] = None
+    usage_limited_until: Optional[datetime] = None
+
+
+class CliUsageOverviewRead(BaseModel):
+    items: list[CliUsageRow]
+    total: int
 
 
 def _status_from_credential(
@@ -85,13 +115,127 @@ def _status_from_credential(
     )
 
 
+async def _usage_by_user(
+    db: AsyncSession, user_ids: Optional[list[int]] = None
+) -> dict[int, dict]:
+    """Per-user token-usage aggregates (input + output) over 7-day, 30-day, and
+    all-time windows, summed in the DB. Restrict to ``user_ids`` for the
+    self-view; omit it to cover every user for the admin overview."""
+    today = utc_now().date()
+    seven = today - timedelta(days=6)
+    thirty = today - timedelta(days=29)
+    tokens = CliUsageDaily.input_tokens + CliUsageDaily.output_tokens
+    stmt = select(
+        CliUsageDaily.user_id,
+        func.coalesce(func.sum(tokens), 0),
+        func.coalesce(
+            func.sum(case((CliUsageDaily.usage_date >= seven, tokens), else_=0)), 0
+        ),
+        func.coalesce(
+            func.sum(case((CliUsageDaily.usage_date >= thirty, tokens), else_=0)), 0
+        ),
+        func.coalesce(func.sum(CliUsageDaily.request_count), 0),
+        func.max(CliUsageDaily.usage_date),
+    ).group_by(CliUsageDaily.user_id)
+    if user_ids is not None:
+        if not user_ids:
+            return {}
+        stmt = stmt.where(CliUsageDaily.user_id.in_(user_ids))
+    result = await db.execute(stmt)
+    out: dict[int, dict] = {}
+    for uid, total, t7, t30, requests, last_used in result.all():
+        out[uid] = {
+            "tokens_total": int(total or 0),
+            "tokens_7d": int(t7 or 0),
+            "tokens_30d": int(t30 or 0),
+            "requests_total": int(requests or 0),
+            "last_used_on": last_used,
+        }
+    return out
+
+
+def _usage_row(
+    user: User,
+    agg: Optional[dict],
+    credential: Optional[CliOAuthCredential],
+) -> CliUsageRow:
+    agg = agg or {}
+    limited_until = credential.usage_limited_until if credential else None
+    return CliUsageRow(
+        user_id=user.id,
+        username=user.username,
+        connected=bool(
+            credential and credential.status == CliOAuthCredentialStatus.ACTIVE.value
+        ),
+        tokens_total=agg.get("tokens_total", 0),
+        tokens_7d=agg.get("tokens_7d", 0),
+        tokens_30d=agg.get("tokens_30d", 0),
+        requests_total=agg.get("requests_total", 0),
+        last_used_on=agg.get("last_used_on"),
+        rate_limit_status=credential.last_rate_limit_status if credential else None,
+        rate_limit_type=credential.last_rate_limit_type if credential else None,
+        utilization=credential.last_utilization if credential else None,
+        usage_limited_until=(
+            limited_until if limited_until and limited_until > utc_now() else None
+        ),
+    )
+
+
 @router.get("/status", response_model=CliOAuthStatusRead)
 async def get_cli_oauth_status(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> CliOAuthStatusRead:
     credential = await get_credential(db, current_user.id)
-    return _status_from_credential(credential)
+    status = _status_from_credential(credential)
+    agg = (await _usage_by_user(db, [current_user.id])).get(current_user.id)
+    if agg is not None:
+        status.tokens_7d = agg["tokens_7d"]
+        status.tokens_total = agg["tokens_total"]
+    return status
+
+
+@router.get("/admin/usage", response_model=CliUsageOverviewRead)
+async def get_cli_usage_overview(
+    skip: int = 0,
+    limit: int = 25,
+    search: str = "",
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+) -> CliUsageOverviewRead:
+    """Admin-only per-user CLI token usage + rate-limit status.
+
+    Lists users who have a CLI OAuth credential or any recorded usage. Token sums
+    are aggregated in the DB; a self-hosted install has few such users, so the
+    candidate list is sorted and paginated in Python."""
+    limit = max(1, min(limit, 100))
+    skip = max(0, skip)
+
+    usage = await _usage_by_user(db)
+    credentials = (await db.execute(select(CliOAuthCredential))).scalars().all()
+    cred_by_user = {credential.user_id: credential for credential in credentials}
+
+    candidate_ids = set(usage) | set(cred_by_user)
+    if not candidate_ids:
+        return CliUsageOverviewRead(items=[], total=0)
+
+    user_stmt = select(User).where(User.id.in_(candidate_ids))
+    term = search.strip()
+    if term:
+        user_stmt = user_stmt.where(User.username.ilike(f"%{term}%"))
+    users = list((await db.execute(user_stmt)).scalars().all())
+
+    # Highest consumers first; ties broken by username for a stable order.
+    users.sort(
+        key=lambda u: (
+            -usage.get(u.id, {}).get("tokens_total", 0),
+            u.username.lower(),
+        )
+    )
+    total = len(users)
+    page = users[skip : skip + limit]
+    items = [_usage_row(u, usage.get(u.id), cred_by_user.get(u.id)) for u in page]
+    return CliUsageOverviewRead(items=items, total=total)
 
 
 @router.post("/start", response_model=CliOAuthStartRead)

--- a/backend/models/cli_oauth.py
+++ b/backend/models/cli_oauth.py
@@ -1,12 +1,15 @@
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import Optional
 
 from sqlalchemy import (
     BigInteger,
     Column,
+    Date,
     DateTime,
+    Float,
     ForeignKey,
+    Integer,
     String,
     Text,
     UniqueConstraint,
@@ -87,4 +90,81 @@ class CliOAuthCredential(BaseDBModel, table=True):
     # to surface a reset time in Settings and to skip doomed spawns.
     usage_limited_until: Optional[datetime] = Field(
         default=None, sa_column=Column(DateTime, nullable=True)
+    )
+    # Latest-known rate-limit reading from the SDK's ``RateLimitEvent`` (advisory).
+    # ``last_utilization`` is the fraction (0.0-1.0) of the current window
+    # consumed; the CLI emits the event only on status transitions, so this is an
+    # opportunistic "most recent" value, not a guaranteed per-call reading. A
+    # subscription exposes no absolute remaining-token count. Surfaced in the
+    # admin CLI usage panel's quota column.
+    last_utilization: Optional[float] = Field(
+        default=None, sa_column=Column(Float, nullable=True)
+    )
+    last_rate_limit_status: Optional[str] = Field(
+        default=None, sa_column=Column(String(32), nullable=True)
+    )
+    last_rate_limit_type: Optional[str] = Field(
+        default=None, sa_column=Column(String(32), nullable=True)
+    )
+    last_rate_limit_at: Optional[datetime] = Field(
+        default=None, sa_column=Column(DateTime, nullable=True)
+    )
+
+
+class CliUsageDaily(BaseDBModel, table=True):
+    """Per-user, per-day rollup of subscription-CLI token usage.
+
+    One row per ``(user_id, provider, usage_date)`` (UTC date), upserted by the
+    worker-io CLI manager after each successful inference and read by the admin
+    usage panel. Stores only aggregate token counts — never prompt or response
+    content. A subscription is flat-rate, so ``total_cost_usd`` is the SDK's
+    notional API-equivalent figure: stored for reference, never surfaced as money.
+    """
+
+    __tablename__ = "cli_usage_daily"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "provider",
+            "usage_date",
+            name="uq_cli_usage_daily_user_provider_date",
+        ),
+    )
+
+    user_id: int = Field(
+        sa_column=Column(
+            BigInteger,
+            ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+    )
+    provider: str = Field(
+        default=CliOAuthProvider.CLAUDE_CODE.value,
+        sa_column=Column(String(32), nullable=False, index=True),
+    )
+    usage_date: date = Field(sa_column=Column(Date, nullable=False, index=True))
+    input_tokens: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False, server_default="0"),
+    )
+    output_tokens: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False, server_default="0"),
+    )
+    cache_read_input_tokens: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False, server_default="0"),
+    )
+    cache_creation_input_tokens: int = Field(
+        default=0,
+        sa_column=Column(BigInteger, nullable=False, server_default="0"),
+    )
+    request_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default="0"),
+    )
+    total_cost_usd: float = Field(
+        default=0.0,
+        sa_column=Column(Float, nullable=False, server_default="0"),
     )

--- a/backend/processing/cli/manager.py
+++ b/backend/processing/cli/manager.py
@@ -20,8 +20,9 @@ import logging
 import os
 import queue
 import threading
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
 from sqlmodel import Session, select
 
@@ -31,6 +32,7 @@ from backend.models.cli_oauth import (
     CliOAuthCredential,
     CliOAuthCredentialStatus,
     CliOAuthProvider,
+    CliUsageDaily,
 )
 from backend.processing.cli.env_scrub import scrubbed_environ, subscription_env_payload
 from backend.services.cli_oauth import oauth
@@ -53,6 +55,34 @@ _SYSTEM_PROMPT = (
     "output — no preamble, no commentary, no questions. When the instructions "
     "ask for JSON, return only valid JSON."
 )
+
+
+@dataclass
+class _RateLimitReading:
+    """Latest-known rate-limit status from a ``RateLimitEvent`` (any status).
+
+    ``utilization`` is the fraction (0.0-1.0) of the current window consumed; the
+    CLI emits the event only on status transitions, so this is opportunistic.
+    """
+
+    status: Optional[str]
+    rate_limit_type: Optional[str]
+    utilization: Optional[float]
+
+
+@dataclass
+class _TurnUsage:
+    """Token usage from a turn's terminal ``ResultMessage`` plus any rate-limit
+    reading seen while draining the query. Threaded out of the async drivers so
+    the sync entry points persist it (the drivers keep no DB work of their own)."""
+
+    usage: Optional[dict[str, Any]] = None
+    total_cost_usd: Optional[float] = None
+    reading: Optional[_RateLimitReading] = None
+
+    @property
+    def has_data(self) -> bool:
+        return self.usage is not None or self.reading is not None
 
 
 class CliOAuthUnavailableError(RuntimeError):
@@ -103,12 +133,14 @@ class CliConversationManager:
         """Resolve a fresh token, run one non-streaming turn, return the text."""
         access_token = self._resolve_access_token(user_id)
         try:
-            return asyncio.run(
+            text, usage = asyncio.run(
                 self._arun_single_turn(user_id, prompt, access_token, model, timeout)
             )
         except CliUsageLimitError as exc:
             self._persist_usage_limited(user_id, exc.resets_at)
             raise
+        self._record_usage(user_id, usage)
+        return text
 
     def stream_single_turn(
         self,
@@ -126,12 +158,15 @@ class CliConversationManager:
         """
         access_token = self._resolve_access_token(user_id)
         chunk_queue: "queue.Queue[tuple[str, object]]" = queue.Queue()
+        # Populated by the driver thread with the turn's usage on a clean drain;
+        # persisted below on this (sync) thread once the stream completes.
+        usage_sink: list[_TurnUsage] = []
 
         def _drive() -> None:
             async def _run() -> None:
                 try:
                     async for chunk in self._astream_single_turn(
-                        user_id, prompt, access_token, model, timeout
+                        user_id, prompt, access_token, model, timeout, usage_sink
                     ):
                         chunk_queue.put(("chunk", chunk))
                 except Exception as exc:  # noqa: BLE001 - relayed to the consumer
@@ -156,6 +191,10 @@ class CliConversationManager:
                     break
         finally:
             thread.join(timeout=5)
+            # Record the turn's usage on this (sync) thread, mirroring the
+            # _persist_usage_limited call above. Empty on an errored turn.
+            if usage_sink:
+                self._record_usage(user_id, usage_sink[0])
 
     # ---- token lifecycle (sync DB; async only for the httpx refresh) ----
 
@@ -276,6 +315,73 @@ class CliConversationManager:
                 resets_at,
             )
 
+    def _record_usage(self, user_id: int, turn: _TurnUsage) -> None:
+        """Persist a completed turn's token usage (daily rollup) and latest
+        rate-limit reading. Best-effort: usage accounting must never break
+        inference, so any failure is logged and swallowed."""
+        if not turn.has_data:
+            return
+        try:
+            with get_sync_session() as session:
+                if turn.usage is not None:
+                    self._increment_daily_usage(
+                        session, user_id, turn.usage, turn.total_cost_usd
+                    )
+                if turn.reading is not None:
+                    self._store_rate_limit_reading(session, user_id, turn.reading)
+                session.commit()
+        except Exception:  # noqa: BLE001 - accounting must not break inference
+            logger.exception("Failed to record CLI usage for user %s", user_id)
+
+    def _increment_daily_usage(
+        self,
+        session: Session,
+        user_id: int,
+        usage: dict[str, Any],
+        cost: Optional[float],
+    ) -> None:
+        # Read-modify-write on today's (user, provider, date) rollup row. A rare
+        # race between two concurrent turns can lose one increment; acceptable
+        # for an advisory usage panel, and it matches _persist_usage_limited.
+        today = utc_now().date()
+        row = session.exec(
+            select(CliUsageDaily).where(
+                CliUsageDaily.user_id == user_id,
+                CliUsageDaily.provider == self._provider,
+                CliUsageDaily.usage_date == today,
+            )
+        ).first()
+        if row is None:
+            row = CliUsageDaily(
+                user_id=user_id, provider=self._provider, usage_date=today
+            )
+        row.input_tokens += _as_int(usage.get("input_tokens"))
+        row.output_tokens += _as_int(usage.get("output_tokens"))
+        row.cache_read_input_tokens += _as_int(usage.get("cache_read_input_tokens"))
+        row.cache_creation_input_tokens += _as_int(
+            usage.get("cache_creation_input_tokens")
+        )
+        row.request_count += 1
+        row.total_cost_usd += float(cost or 0.0)
+        session.add(row)
+
+    def _store_rate_limit_reading(
+        self, session: Session, user_id: int, reading: _RateLimitReading
+    ) -> None:
+        credential = session.exec(
+            select(CliOAuthCredential).where(
+                CliOAuthCredential.user_id == user_id,
+                CliOAuthCredential.provider == self._provider,
+            )
+        ).first()
+        if credential is None:
+            return
+        credential.last_utilization = reading.utilization
+        credential.last_rate_limit_status = reading.status
+        credential.last_rate_limit_type = reading.rate_limit_type
+        credential.last_rate_limit_at = utc_now()
+        session.add(credential)
+
     # ---- async SDK drivers (wrapped by the sync entry points) ----
 
     def _build_options(
@@ -307,7 +413,7 @@ class CliConversationManager:
         access_token: str,
         model: Optional[str],
         timeout: int,
-    ) -> str:
+    ) -> tuple[str, _TurnUsage]:
         from claude_agent_sdk import (  # lazy: SDK only in worker-io
             AssistantMessage,
             ClaudeSDKError,
@@ -321,6 +427,7 @@ class CliConversationManager:
         parts: list[str] = []
         result_error: str | None = None
         rate_limit: tuple[Optional[datetime], Optional[str]] | None = None
+        turn_usage = _TurnUsage()
         with scrubbed_environ():
             try:
                 async with asyncio.timeout(timeout):
@@ -332,23 +439,28 @@ class CliConversationManager:
                             parts.extend(_assistant_text(message, TextBlock))
                         elif isinstance(message, RateLimitEvent):
                             rate_limit = _rate_limit_rejection(message) or rate_limit
+                            turn_usage.reading = (
+                                _rate_limit_reading(message) or turn_usage.reading
+                            )
                         elif isinstance(message, ResultMessage):
                             result_error = _result_error(message)
+                            _apply_result_usage(turn_usage, message)
             except (TimeoutError, ClaudeSDKError) as exc:
                 raise _query_exception(exc, timeout) from exc
         _raise_if_terminal(rate_limit, result_error)
         text = "".join(parts).strip()
         if not text:
             raise CliOAuthUnavailableError("CLI inference returned no text.")
-        return text
+        return text, turn_usage
 
-    async def _astream_single_turn(
+    async def _astream_single_turn(  # noqa: PLR0913 - cohesive SDK driver params
         self,
         user_id: int,
         prompt: str,
         access_token: str,
         model: Optional[str],
         timeout: int,
+        usage_sink: list[_TurnUsage],
     ):
         from claude_agent_sdk import (  # lazy: SDK only in worker-io
             AssistantMessage,
@@ -366,6 +478,7 @@ class CliConversationManager:
         streamed_any = False
         result_error: str | None = None
         rate_limit: tuple[Optional[datetime], Optional[str]] | None = None
+        turn_usage = _TurnUsage()
         with scrubbed_environ():
             try:
                 async with asyncio.timeout(timeout):
@@ -383,11 +496,18 @@ class CliConversationManager:
                                     yield block_text
                         elif isinstance(message, RateLimitEvent):
                             rate_limit = _rate_limit_rejection(message) or rate_limit
+                            turn_usage.reading = (
+                                _rate_limit_reading(message) or turn_usage.reading
+                            )
                         elif isinstance(message, ResultMessage):
                             result_error = _result_error(message)
+                            _apply_result_usage(turn_usage, message)
             except (TimeoutError, ClaudeSDKError) as exc:
                 raise _query_exception(exc, timeout) from exc
         _raise_if_terminal(rate_limit, result_error)
+        # Reached only on a clean drain (no terminal error); hand the turn's
+        # usage to the sync caller to persist.
+        usage_sink.append(turn_usage)
 
     @staticmethod
     def _user_cwd(user_id: int) -> str:
@@ -451,6 +571,51 @@ def _rate_limit_rejection(message):
         else None
     )
     return dt, getattr(info, "rate_limit_type", None)
+
+
+def _rate_limit_reading(message) -> Optional[_RateLimitReading]:
+    """Latest rate-limit reading from a RateLimitEvent (any status), or None.
+
+    Unlike ``_rate_limit_rejection`` this keeps non-rejection events too, so the
+    ``utilization`` fraction from ``allowed``/``allowed_warning`` events — the
+    only place a not-yet-exhausted reading arrives — is captured, not dropped.
+    """
+    info = getattr(message, "rate_limit_info", None)
+    if info is None:
+        return None
+    status = getattr(info, "status", None)
+    if status is None:
+        return None
+    utilization = getattr(info, "utilization", None)
+    return _RateLimitReading(
+        status=str(status),
+        rate_limit_type=getattr(info, "rate_limit_type", None),
+        utilization=(
+            float(utilization) if isinstance(utilization, (int, float)) else None
+        ),
+    )
+
+
+def _apply_result_usage(turn: _TurnUsage, message) -> None:
+    """Copy token usage + notional cost from a ResultMessage into ``turn``.
+
+    ``usage`` is the Anthropic-shaped dict (input/output/cache tokens);
+    ``total_cost_usd`` is a notional API-equivalent figure for a flat-rate
+    subscription (stored, never surfaced as real money)."""
+    usage = getattr(message, "usage", None)
+    if isinstance(usage, dict):
+        turn.usage = usage
+    cost = getattr(message, "total_cost_usd", None)
+    if isinstance(cost, (int, float)):
+        turn.total_cost_usd = float(cost)
+
+
+def _as_int(value: Any) -> int:
+    """Coerce a possibly-missing usage field to a non-negative int."""
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
 
 
 def _usage_limit_message(

--- a/backend/processing/cli_backend.py
+++ b/backend/processing/cli_backend.py
@@ -35,8 +35,14 @@ logger = logging.getLogger(__name__)
 __all__ = ["CliLLMBackend", "CliOAuthUnavailableError"]
 
 # Curated model list — a subscription exposes no models endpoint, so the picker
-# uses this static set. Kept provider-neutral in ordering (most→least capable).
-_CLI_MODELS = ("claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001")
+# uses this static set. Ordered most→least capable. Full, unambiguous ids (no
+# bare "Claude Sonnet"): both Sonnet 5 and Sonnet 4.6 are offered.
+_CLI_MODELS = (
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+)
 
 
 class CliLLMBackend(LLMBackend):

--- a/backend/tests/test_cli_manager.py
+++ b/backend/tests/test_cli_manager.py
@@ -23,7 +23,7 @@ from backend.core.encryption import decrypt_secret, encrypt_secret
 # Register every ORM model so SQLAlchemy can configure the mapper reached via the
 # credential's user_id FK.
 from backend.models import registry  # noqa: F401
-from backend.models.cli_oauth import CliOAuthCredential
+from backend.models.cli_oauth import CliOAuthCredential, CliUsageDaily
 from backend.processing.cli.env_scrub import (
     OAUTH_TOKEN_ENV_VAR,
     SCRUBBED_ENV_VARS,
@@ -34,8 +34,13 @@ from backend.processing.cli.manager import (
     CliConversationManager,
     CliOAuthUnavailableError,
     CliUsageLimitError,
+    _apply_result_usage,
+    _as_int,
     _classify_sdk_error,
+    _rate_limit_reading,
     _rate_limit_rejection,
+    _RateLimitReading,
+    _TurnUsage,
     _usage_limit_message,
 )
 from backend.services.cli_oauth import oauth
@@ -56,7 +61,29 @@ CREATE TABLE cli_oauth_credentials (
     oauth_client_id VARCHAR(512),
     last_refreshed_at TIMESTAMP,
     usage_limited_until TIMESTAMP,
+    last_utilization FLOAT,
+    last_rate_limit_status VARCHAR(32),
+    last_rate_limit_type VARCHAR(32),
+    last_rate_limit_at TIMESTAMP,
     CONSTRAINT uq_cli_oauth_credential_user_provider UNIQUE (user_id, provider)
+)
+"""
+
+_CREATE_CLI_USAGE_DAILY = """
+CREATE TABLE cli_usage_daily (
+    id INTEGER PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    user_id BIGINT NOT NULL,
+    provider VARCHAR(32) NOT NULL,
+    usage_date DATE NOT NULL,
+    input_tokens BIGINT NOT NULL DEFAULT 0,
+    output_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_input_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_creation_input_tokens BIGINT NOT NULL DEFAULT 0,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    total_cost_usd FLOAT NOT NULL DEFAULT 0,
+    CONSTRAINT uq_cli_usage_daily_user_provider_date UNIQUE (user_id, provider, usage_date)
 )
 """
 
@@ -69,6 +96,7 @@ def _sqlite_engine():
     )
     with engine.begin() as conn:
         conn.execute(text(_CREATE_CLI_OAUTH_CREDENTIALS))
+        conn.execute(text(_CREATE_CLI_USAGE_DAILY))
     return engine
 
 
@@ -334,3 +362,114 @@ def test_usage_limit_message_includes_reset_and_window():
     assert "usage limit" in message.lower()
     assert "five_hour" in message
     assert "15:30" in message
+
+
+# --- token-usage accounting ---
+
+
+def _read_usage(engine) -> list[CliUsageDaily]:
+    with Session(engine) as session:
+        return session.exec(
+            select(CliUsageDaily).where(CliUsageDaily.user_id == 1)
+        ).all()
+
+
+def test_apply_result_usage_reads_tokens_and_cost():
+    turn = _TurnUsage()
+    message = SimpleNamespace(
+        usage={
+            "input_tokens": 120,
+            "output_tokens": 45,
+            "cache_read_input_tokens": 10,
+            "cache_creation_input_tokens": 5,
+        },
+        total_cost_usd=0.0123,
+    )
+    _apply_result_usage(turn, message)
+    assert turn.usage is not None and turn.usage["input_tokens"] == 120
+    assert turn.total_cost_usd == 0.0123
+    assert turn.has_data
+
+
+def test_apply_result_usage_ignores_missing_fields():
+    turn = _TurnUsage()
+    _apply_result_usage(turn, SimpleNamespace(usage=None, total_cost_usd=None))
+    assert turn.usage is None
+    assert turn.total_cost_usd is None
+    assert not turn.has_data
+
+
+def test_rate_limit_reading_captures_any_status():
+    warning = SimpleNamespace(
+        rate_limit_info=SimpleNamespace(
+            status="allowed_warning", utilization=0.83, rate_limit_type="five_hour"
+        )
+    )
+    reading = _rate_limit_reading(warning)
+    assert reading is not None
+    assert reading.status == "allowed_warning"
+    assert reading.utilization == 0.83
+    assert reading.rate_limit_type == "five_hour"
+    # Not a RateLimitEvent -> None (unlike _rate_limit_rejection, this keeps
+    # non-rejection events, but still returns None when there is no info).
+    assert _rate_limit_reading(SimpleNamespace()) is None
+
+
+def test_as_int_coerces_defensively():
+    assert _as_int(7) == 7
+    assert _as_int(None) == 0
+    assert _as_int("nope") == 0
+    assert _as_int(-4) == 0
+
+
+def test_record_usage_increments_daily_rollup(monkeypatch):
+    engine = _sqlite_engine()
+    _seed(engine, expires_at=utc_now() + timedelta(hours=2))
+    monkeypatch.setattr(
+        "backend.processing.cli.manager.get_sync_session", lambda: Session(engine)
+    )
+    manager = CliConversationManager()
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "cache_read_input_tokens": 8,
+        "cache_creation_input_tokens": 2,
+    }
+    manager._record_usage(
+        1,
+        _TurnUsage(
+            usage=usage,
+            total_cost_usd=0.01,
+            reading=_RateLimitReading("allowed_warning", "five_hour", 0.5),
+        ),
+    )
+    # A second turn the same day accumulates into the same (user, provider, date)
+    # row rather than creating a duplicate.
+    manager._record_usage(1, _TurnUsage(usage=usage, total_cost_usd=0.01))
+
+    rows = _read_usage(engine)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.input_tokens == 200
+    assert row.output_tokens == 80
+    assert row.cache_read_input_tokens == 16
+    assert row.cache_creation_input_tokens == 4
+    assert row.request_count == 2
+    assert row.total_cost_usd == pytest.approx(0.02)
+
+    # The latest rate-limit reading landed on the credential row.
+    cred = _read(engine)
+    assert cred.last_utilization == 0.5
+    assert cred.last_rate_limit_status == "allowed_warning"
+    assert cred.last_rate_limit_type == "five_hour"
+    assert cred.last_rate_limit_at is not None
+
+
+def test_record_usage_without_data_is_noop(monkeypatch):
+    engine = _sqlite_engine()
+    _seed(engine, expires_at=utc_now() + timedelta(hours=2))
+    monkeypatch.setattr(
+        "backend.processing.cli.manager.get_sync_session", lambda: Session(engine)
+    )
+    CliConversationManager()._record_usage(1, _TurnUsage())
+    assert _read_usage(engine) == []

--- a/backend/tests/test_cli_oauth_api.py
+++ b/backend/tests/test_cli_oauth_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from types import SimpleNamespace
 
 from fastapi import FastAPI
@@ -12,13 +13,16 @@ from sqlalchemy.pool import StaticPool
 
 from backend.api.deps import get_current_user, get_db
 from backend.api.v1.endpoints import cli_oauth
+from backend.api.v1.endpoints.cli_oauth import _usage_by_user, _usage_row
 from backend.core.encryption import decrypt_secret
 
 # Register every ORM model so the User mapper (reached via the credential FK)
 # configures cleanly when the endpoint queries the credential table.
 from backend.models import registry  # noqa: F401
+from backend.models.cli_oauth import CliOAuthCredential, CliUsageDaily
 from backend.services.cli_oauth import oauth
 from backend.services.cli_oauth.persistence import get_credential
+from backend.utils.time import utc_now
 
 # SQLite-friendly DDL (INTEGER PRIMARY KEY autoincrements; the model's BigInteger
 # PK is sequence-backed only on Postgres).
@@ -36,12 +40,36 @@ CREATE TABLE cli_oauth_credentials (
     oauth_client_id VARCHAR(512),
     last_refreshed_at TIMESTAMP,
     usage_limited_until TIMESTAMP,
+    last_utilization FLOAT,
+    last_rate_limit_status VARCHAR(32),
+    last_rate_limit_type VARCHAR(32),
+    last_rate_limit_at TIMESTAMP,
     CONSTRAINT uq_cli_oauth_credential_user_provider UNIQUE (user_id, provider)
 )
 """
 
+_CREATE_CLI_USAGE_DAILY = """
+CREATE TABLE cli_usage_daily (
+    id INTEGER PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    user_id BIGINT NOT NULL,
+    provider VARCHAR(32) NOT NULL,
+    usage_date DATE NOT NULL,
+    input_tokens BIGINT NOT NULL DEFAULT 0,
+    output_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_input_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_creation_input_tokens BIGINT NOT NULL DEFAULT 0,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    total_cost_usd FLOAT NOT NULL DEFAULT 0,
+    CONSTRAINT uq_cli_usage_daily_user_provider_date UNIQUE (user_id, provider, usage_date)
+)
+"""
 
-async def _build_app(user_id: int = 1):
+
+async def _build_app(
+    user_id: int = 1, *, role: str = "owner", is_superuser: bool = True
+):
     engine = create_async_engine(
         "sqlite+aiosqlite://",
         connect_args={"check_same_thread": False},
@@ -49,6 +77,7 @@ async def _build_app(user_id: int = 1):
     )
     async with engine.begin() as conn:
         await conn.execute(text(_CREATE_CLI_OAUTH_CREDENTIALS))
+        await conn.execute(text(_CREATE_CLI_USAGE_DAILY))
     maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     app = FastAPI()
@@ -60,9 +89,24 @@ async def _build_app(user_id: int = 1):
 
     app.dependency_overrides[get_db] = override_db
     app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
-        id=user_id, username="alice"
+        id=user_id, username="alice", role=role, is_superuser=is_superuser
     )
     return engine, maker, app
+
+
+async def _seed_usage(maker, *, user_id, usage_date, input_tokens, output_tokens):
+    async with maker() as session:
+        session.add(
+            CliUsageDaily(
+                user_id=user_id,
+                provider="claude_code",
+                usage_date=usage_date,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                request_count=1,
+            )
+        )
+        await session.commit()
 
 
 class _FakeOAuth:
@@ -282,3 +326,115 @@ def test_status_reports_and_hides_usage_limit():
     )
     # Past its reset -> not surfaced, so the UI clears itself.
     assert _status_from_credential(stale).usage_limited_until is None
+
+
+# --- usage accounting (self-view + admin overview) ---
+
+
+def test_usage_by_user_windows_sum_input_plus_output():
+    async def _run():
+        engine, maker, _app = await _build_app()
+        try:
+            today = utc_now().date()
+            await _seed_usage(
+                maker, user_id=1, usage_date=today, input_tokens=100, output_tokens=40
+            )
+            await _seed_usage(
+                maker,
+                user_id=1,
+                usage_date=today - timedelta(days=10),
+                input_tokens=10,
+                output_tokens=5,
+            )
+            await _seed_usage(
+                maker,
+                user_id=1,
+                usage_date=today - timedelta(days=40),
+                input_tokens=1,
+                output_tokens=1,
+            )
+            async with maker() as db:
+                agg = (await _usage_by_user(db))[1]
+            assert agg["tokens_total"] == 157  # 140 + 15 + 2 (all windows)
+            assert agg["tokens_7d"] == 140  # today only
+            assert agg["tokens_30d"] == 155  # today + 10 days ago
+            assert agg["requests_total"] == 3
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_usage_row_maps_credential_and_quota_fields():
+    future = utc_now() + timedelta(hours=1)
+    credential = CliOAuthCredential(
+        user_id=1,
+        provider="claude_code",
+        status="active",
+        usage_limited_until=future,
+        last_utilization=0.72,
+        last_rate_limit_status="allowed_warning",
+        last_rate_limit_type="five_hour",
+    )
+    row = _usage_row(
+        SimpleNamespace(id=1, username="alice"),
+        {
+            "tokens_total": 500,
+            "tokens_7d": 120,
+            "tokens_30d": 300,
+            "requests_total": 4,
+        },
+        credential,
+    )
+    assert row.connected is True
+    assert row.tokens_total == 500 and row.tokens_7d == 120
+    assert row.utilization == 0.72
+    assert row.rate_limit_status == "allowed_warning"
+    assert row.usage_limited_until == future
+
+    # No credential -> not connected and quota fields empty.
+    bare = _usage_row(SimpleNamespace(id=2, username="bob"), None, None)
+    assert bare.connected is False
+    assert bare.tokens_total == 0
+    assert bare.utilization is None
+    assert bare.usage_limited_until is None
+
+
+def test_status_includes_self_usage():
+    async def _run():
+        engine, maker, app = await _build_app()
+        try:
+            await _seed_usage(
+                maker,
+                user_id=1,
+                usage_date=utc_now().date(),
+                input_tokens=90,
+                output_tokens=10,
+            )
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://testserver"
+            ) as ac:
+                body = (await ac.get("/cli-oauth/status")).json()
+                assert body["tokens_7d"] == 100
+                assert body["tokens_total"] == 100
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_admin_usage_forbidden_for_non_admin():
+    async def _run():
+        engine, _maker, app = await _build_app(role="user", is_superuser=False)
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://testserver"
+            ) as ac:
+                r = await ac.get("/cli-oauth/admin/usage")
+                assert r.status_code == 403
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())

--- a/backend/tests/test_cli_oauth_credential.py
+++ b/backend/tests/test_cli_oauth_credential.py
@@ -41,6 +41,10 @@ CREATE TABLE cli_oauth_credentials (
     oauth_client_id VARCHAR(512),
     last_refreshed_at TIMESTAMP,
     usage_limited_until TIMESTAMP,
+    last_utilization FLOAT,
+    last_rate_limit_status VARCHAR(32),
+    last_rate_limit_type VARCHAR(32),
+    last_rate_limit_at TIMESTAMP,
     CONSTRAINT uq_cli_oauth_credential_user_provider UNIQUE (user_id, provider)
 )
 """

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -60,12 +60,13 @@ Nojoin's built-in MCP connector ([MCP.md](MCP.md)) issues OAuth 2.1 access token
 
 ## CLI OAuth Subscription Access
 
-Nojoin can route a user's AI inference through their own Claude Pro/Max subscription (the per-user **CLI OAuth** usage model, off by default). See [ADR-0002](adr/0002-cli-oauth-subscription-mode.md) for the accepted-risk decision — this uses a consumer subscription contrary to Anthropic's terms.
+Nojoin can route a user's AI inference through their own Claude Pro/Max subscription (the per-user **CLI OAuth** AI-routing option, off by default). See [ADR-0002](adr/0002-cli-oauth-subscription-mode.md) for the accepted-risk decision — this uses a consumer subscription contrary to Anthropic's terms.
 
 - The subscription OAuth token is stored **encrypted at rest** (`encrypt_secret`, one row per user), never in `User.settings`, never logged, and never returned by the API.
 - Inference runs as a **tools-off, single-turn** Claude Code subprocess in the `worker-io` lane, as the image's non-root user, under a wall-clock timeout. With tools disabled, an untrusted transcript can only produce text, not act — so no dedicated OS sandbox is used (see ADR-0002).
 - The subprocess environment is **scrubbed** so an install-wide `ANTHROPIC_API_KEY` (or `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_USE_*`) cannot out-rank the user's subscription token; only `CLAUDE_CODE_OAUTH_TOKEN` is injected. This invariant is locked by a unit test.
 - CLI OAuth is **swappable and non-load-bearing**: any failure (auth, usage limit) degrades to the user's configured BYOK/Ollama secondary. Usage limits set a best-effort reset time surfaced in Settings.
+- Usage accounting stores **aggregate counts only**: a per-user daily rollup of token counts and request totals, plus the latest rate-limit reading, so administrators can review subscription usage. Prompt and response **content is never stored**, and the SDK's notional per-turn cost is kept for reference but never surfaced as money (a subscription is flat-rate).
 - Disconnecting (Settings > AI) deletes the encrypted credential and wipes the user's per-user CLI working directory.
 
 ## JWT Signing Key Rotation

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -134,7 +134,7 @@ That live lane now works in the background to support Meeting Edge and to speed 
 
 Meeting Edge uses the recent live transcript window, an internally maintained rolling summary of the meeting so far (decisions, open threads, and action items), its own previous suggestions (so guidance stays fresh instead of repeating), your optional focus text, your manual notes, and linked calendar context when available.
 
-It can surface live questions, missed points, and quick concept help during a meeting. In **Settings > AI**, you can optionally choose a separate Meeting Edge model for the current provider and tune the **Meeting Edge Technical Context** slider to make concept explanations stricter or more detailed. If the model field is empty, Nojoin reuses your main AI model.
+It can surface live questions, missed points, and quick concept help during a meeting. In **Settings > AI > Meeting Edge**, everyone can tune the per-user **Technical context** slider to make concept explanations stricter or more detailed; administrators can additionally enable or disable Meeting Edge install-wide and choose a separate Meeting Edge model (if left empty, Nojoin reuses the main model).
 
 ## Importing Recordings
 
@@ -215,11 +215,11 @@ Settings are grouped by task.
 
 - **Profile**: account details and password changes.
 - **Capture**: microphone selection, shared-audio gain, microphone gain, browser audio-processing toggles, and a local mic input test for browser recording.
-- **AI**: provider configuration, model choices, automatic meeting intelligence, Meeting Edge model selection, and secondary LLM provider fallback.
+- **AI**: per-user AI routing (the server's configured provider, or your own Claude subscription), the server provider and model, Meeting Edge, automatic meeting intelligence, language, and secondary-provider fallback. Install-wide controls (provider, models, the Ollama endpoint, fallback, and "Enable Meeting Edge") are shown only to administrators; a non-admin sees a read-only summary of the active provider instead.
 - **Transcription**: transcription backend and model choices.
 - **Calendar**: user calendar connections and timezone behaviour.
 - **Help**: tours and support surfaces.
-- **Admin**: user, system, provider, release, and maintenance settings for administrators.
+- **Admin**: user, invitations, CLI usage, system, provider, release, and maintenance settings for administrators.
 
 ### Language Preferences
 
@@ -236,9 +236,13 @@ Language preferences are per-user. Per-meeting overrides, full interface transla
 
 ### CLI OAuth (Claude subscription)
 
-As an alternative to Ollama or a BYOK API key, you can route your AI through your own Claude Pro/Max subscription. In **Settings > AI**, connect your subscription in the "Claude subscription (CLI OAuth)" panel (open the grant link, then paste back the code Anthropic shows you), then choose **CLI OAuth** as your usage model. Pick a model for notes/chat and, optionally, a faster live model for Meeting Edge.
+Instead of using the server's configured provider, you can route your own AI through your Claude Pro/Max subscription. In **Settings > AI > AI routing**, connect your subscription in the "Claude subscription (CLI OAuth)" panel (open the grant link, then paste back the code Anthropic shows you), then set routing to **My Claude subscription**. Pick a model for notes/chat and, optionally, a faster live model for Meeting Edge. Once you start using it, the panel shows your recent token usage.
 
-Because this uses your subscription quota, a cheaper model conserves *quota*, not money. If you reach your limit, Nojoin shows a reset time and falls back to your secondary provider (if configured). Disconnecting removes your stored credential.
+Because this uses your subscription quota, a cheaper model conserves *quota*, not money. If you reach your limit, Nojoin shows a reset time and falls back to the server's secondary provider (if the administrator has configured one). Disconnecting removes your stored credential.
+
+### CLI usage and quota (admin)
+
+Administrators can review per-user Claude-subscription usage under **Settings > Administration > CLI usage & quota**: a searchable table of each user's token usage over the last 7 days, last 30 days, and lifetime, alongside their rate-limit status. Tokens count what Nojoin sent through each user's own subscription. A subscription exposes no live "remaining quota" figure, so the status column reflects the rate-limit signal (OK, approaching a limit, or limited until a reset time) rather than a balance. Usage is shown in tokens, never money — a subscription is flat-rate, so a per-turn currency figure would be misleading.
 
 ### Secondary LLM Provider
 

--- a/frontend/src/components/settings/AISettings.tsx
+++ b/frontend/src/components/settings/AISettings.tsx
@@ -62,12 +62,14 @@ const WHISPER_MODELS = [
   { id: "turbo", label: "Turbo", params: "809 M", vram: "~6 GB", speed: "~8x" },
 ];
 
-// Curated CLI OAuth models (a subscription exposes no models endpoint). Mirrors
-// the backend's CliLLMBackend list; most-capable first.
-const CLI_MODEL_OPTIONS = [
-  "claude-opus-4-8",
-  "claude-sonnet-5",
-  "claude-haiku-4-5-20251001",
+// Curated CLI OAuth models (a subscription exposes no models endpoint). Ids
+// mirror the backend's _CLI_MODELS (most-capable first); `label` is the full,
+// unambiguous model name shown in the picker — never a bare "Claude Sonnet".
+const CLI_MODEL_OPTIONS: { id: string; label: string }[] = [
+  { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
+  { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
 ];
 
 interface AISettingsProps {
@@ -357,10 +359,10 @@ export default function AISettings({
                       }
                       className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
                     >
-                      <option value="">Default (Claude Sonnet)</option>
+                      <option value="">Default (Claude Code default model)</option>
                       {CLI_MODEL_OPTIONS.map((model) => (
-                        <option key={model} value={model}>
-                          {model}
+                        <option key={model.id} value={model.id}>
+                          {model.label}
                         </option>
                       ))}
                     </select>
@@ -384,8 +386,8 @@ export default function AISettings({
                     >
                       <option value="">Same as CLI model</option>
                       {CLI_MODEL_OPTIONS.map((model) => (
-                        <option key={model} value={model}>
-                          {model}
+                        <option key={model.id} value={model.id}>
+                          {model.label}
                         </option>
                       ))}
                     </select>

--- a/frontend/src/components/settings/AISettings.tsx
+++ b/frontend/src/components/settings/AISettings.tsx
@@ -1,85 +1,38 @@
 "use client";
 
 import { useState } from "react";
-import { LanguageRegistry, Settings } from "@/types";
-import {
-  Check,
-  X,
-  Loader2,
-  Trash2,
-  HelpCircle,
-  Info,
-  RefreshCw,
-  Cpu,
-  Server,
-} from "lucide-react";
+
+import { Settings } from "@/types";
 import { fuzzyMatch } from "@/lib/searchUtils";
-import {
-  clampMeetingEdgeContextLevel,
-  MEETING_EDGE_CONTEXT_OPTIONS,
-} from "@/lib/meetingEdgeContext";
-import { listModels } from "@/lib/api";
-import Tooltip from "@/components/ui/Tooltip";
-import { Switch } from "@/components/ui/Switch";
-import CliOAuthPanel from "./CliOAuthPanel";
 import SettingsCallout from "./SettingsCallout";
-import SettingsPanel from "./SettingsPanel";
-import SettingsSection from "./SettingsSection";
-import WhisperModelModal from "./WhisperModelModal";
+import AiRoutingSection from "./AiRoutingSection";
+import ServerProviderSection from "./ServerProviderSection";
+import MeetingEdgeSection from "./MeetingEdgeSection";
+import SecondaryProviderSection from "./SecondaryProviderSection";
+import AiAutomaticEnhancementSection from "./AiAutomaticEnhancementSection";
+import AiLanguageSection from "./AiLanguageSection";
+import AiHuggingFaceSection from "./AiHuggingFaceSection";
+import AiTranscriptionSection from "./AiTranscriptionSection";
+import AiModelDependenciesSection from "./AiModelDependenciesSection";
 import { useAISettingsModels } from "./useAISettingsModels";
-import {
-  DEFAULT_OLLAMA_CONTEXT_WINDOW,
-  checkLlmConfigured as checkLlmConfiguredFor,
-  getModelOptionsForProvider as getModelOptionsFor,
-  getSecondaryProviderApiKey as getSecondaryApiKeyFor,
-  getSecondaryProviderLiveModel as getSecondaryLiveModelFor,
-  getSecondaryProviderModel as getSecondaryModelFor,
-  getSelectedModelForProvider as getSelectedModelFor,
-  parseContextWindow as parseContextWindowValue,
-  withSecondaryProviderLiveModel,
-  withSecondaryProviderModel,
-  withSelectedModelForProvider,
-} from "./aiSettingsModels";
-
-const WHISPER_MODELS = [
-  { id: "tiny", label: "Tiny", params: "39 M", vram: "~1 GB", speed: "~10x" },
-  { id: "base", label: "Base", params: "74 M", vram: "~1 GB", speed: "~7x" },
-  { id: "small", label: "Small", params: "244 M", vram: "~2 GB", speed: "~4x" },
-  {
-    id: "medium",
-    label: "Medium",
-    params: "769 M",
-    vram: "~5 GB",
-    speed: "~2x",
-  },
-  {
-    id: "large",
-    label: "Large",
-    params: "1550 M",
-    vram: "~10 GB",
-    speed: "1x",
-  },
-  { id: "turbo", label: "Turbo", params: "809 M", vram: "~6 GB", speed: "~8x" },
-];
-
-// Curated CLI OAuth models (a subscription exposes no models endpoint). Ids
-// mirror the backend's _CLI_MODELS (most-capable first); `label` is the full,
-// unambiguous model name shown in the picker — never a bare "Claude Sonnet".
-const CLI_MODEL_OPTIONS: { id: string; label: string }[] = [
-  { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
-  { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
-  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-  { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
-];
 
 interface AISettingsProps {
   settings: Settings;
+  /** Debounced apply (1s) for continuous controls: sliders, numbers, text. */
   onUpdate: (newSettings: Settings) => void;
+  /** Immediate save; wrapped by `persistNow` for discrete controls. */
   onPersist?: (newSettings: Settings) => Promise<void>;
   searchQuery?: string;
   isAdmin?: boolean;
 }
 
+/**
+ * Orchestrator for the Settings > AI page. Owns the model-discovery hook and
+ * the CLI connection flag, computes search visibility, and composes the AI
+ * sections. Provider/model/Ollama/fallback controls are install-wide (admin
+ * only) and are simply not rendered for non-admins, so nothing they could edit
+ * is silently discarded on save.
+ */
 export default function AISettings({
   settings,
   onUpdate,
@@ -87,97 +40,35 @@ export default function AISettings({
   searchQuery = "",
   isAdmin = false,
 }: AISettingsProps) {
-  const [showWhisperModal, setShowWhisperModal] = useState(false);
-  // Gates the "CLI OAuth" usage-model option on a live subscription credential;
+  // Gates the CLI OAuth routing option on a live subscription credential;
   // updated by CliOAuthPanel as its connection status changes.
   const [cliConnected, setCliConnected] = useState(false);
 
-  const {
-    validating,
-    validationMsg,
-    modelStatus,
-    languageRegistry,
-    deleting,
-    availableModels,
-    setAvailableModels,
-    fetchingModels,
-    setFetchingModels,
-    secondaryAvailableModels,
-    setSecondaryAvailableModels,
-    secondaryFetchingModels,
-    setSecondaryFetchingModels,
-    handleValidate,
-    handleDeleteModel,
-  } = useAISettingsModels({ settings, onPersist });
+  const models = useAISettingsModels({ settings, onPersist });
 
-  const persistSettingsUpdate = (updates: Settings) => {
+  // Apply a change and save it immediately, for discrete controls (selects,
+  // switches, routing radios). Continuous controls use `onUpdate` (1s debounce).
+  const persistNow = (updates: Settings) => {
     onUpdate(updates);
     if (!onPersist) {
       return;
     }
-
     void onPersist(updates).catch((error) => {
       console.error("Failed to persist AI settings update", error);
     });
   };
 
-  const checkLlmConfigured = () => checkLlmConfiguredFor(settings);
-
-  const getSelectedModelForProvider = (kind: "main" | "live") =>
-    getSelectedModelFor(settings, kind);
-
-  const parseContextWindow = (value: string): number =>
-    parseContextWindowValue(value);
-
-  const updateSelectedModelForProvider = (
-    kind: "main" | "live",
-    value: string,
-  ) => {
-    persistSettingsUpdate(withSelectedModelForProvider(settings, kind, value));
-  };
-
-  const getSecondaryProviderApiKey = (
-    provider: Settings["secondary_llm_provider"],
-  ): string => getSecondaryApiKeyFor(settings, provider);
-
-  const getSecondaryProviderModel = (
-    provider: Settings["secondary_llm_provider"],
-  ): string => getSecondaryModelFor(settings, provider);
-
-  const getSecondaryProviderLiveModel = (
-    provider: Settings["secondary_llm_provider"],
-  ): string => getSecondaryLiveModelFor(settings, provider);
-
-  const updateSecondaryProviderModel = (
-    provider: Settings["secondary_llm_provider"],
-    value: string,
-  ) => {
-    const updates = withSecondaryProviderModel(settings, provider, value);
-    if (updates) {
-      onUpdate(updates);
-    }
-  };
-
-  const updateSecondaryProviderLiveModel = (
-    provider: Settings["secondary_llm_provider"],
-    value: string,
-  ) => {
-    const updates = withSecondaryProviderLiveModel(settings, provider, value);
-    if (updates) {
-      onUpdate(updates);
-    }
-  };
-
-  const getModelOptionsForProvider = (kind: "main" | "live") =>
-    getModelOptionsFor(settings, availableModels, kind);
-
-  // Search Logic
+  // Search logic
   const showLLM = fuzzyMatch(searchQuery, [
     "llm",
     "provider",
     "gemini",
     "openai",
     "anthropic",
+    "ollama",
+    "ai routing",
+    "routing",
+    "usage model",
     "meeting edge",
     "technical context",
     "glossary",
@@ -188,7 +79,8 @@ export default function AISettings({
     "live assistant",
     "api key",
     "model",
-    "usage model",
+    "fallback",
+    "secondary",
     "cli oauth",
     "subscription",
     "claude subscription",
@@ -219,6 +111,7 @@ export default function AISettings({
     "whisper",
     "speech to text",
     "parakeet",
+    "canary",
     "engine",
   ]);
   const showDependencies = fuzzyMatch(searchQuery, [
@@ -235,23 +128,6 @@ export default function AISettings({
   const showHFSection = isAdmin && (!hasSearch || showHF);
   const showTranscriptionSection = isAdmin && (!hasSearch || showTranscription);
   const showDependenciesSection = isAdmin && (!hasSearch || showDependencies);
-  const mainModelOptions = getModelOptionsForProvider("main");
-  const liveModelOptions = getModelOptionsForProvider("live");
-  const meetingEdgeContextLevel = clampMeetingEdgeContextLevel(
-    settings.meeting_edge_context_level,
-  );
-  const selectedMeetingEdgeContextOption =
-    MEETING_EDGE_CONTEXT_OPTIONS.find(
-      (option) => option.value === meetingEdgeContextLevel,
-    ) ?? MEETING_EDGE_CONTEXT_OPTIONS[1];
-  const selectedTranscriptionBackend: keyof LanguageRegistry["engine_capabilities"] =
-    settings.transcription_backend === "canary"
-      ? "canary"
-      : settings.transcription_backend === "parakeet"
-        ? "parakeet"
-        : "whisper";
-  const transcriptionLanguageCapability =
-    languageRegistry?.engine_capabilities[selectedTranscriptionBackend];
 
   if (
     !showLLMSection &&
@@ -273,980 +149,76 @@ export default function AISettings({
   return (
     <div className="space-y-8">
       {showLLMSection && (
-        <SettingsSection
-          eyebrow="AI"
-          title="Provider and model preferences"
-          description={
-            isAdmin
-              ? "Configure provider credentials, default models, and local endpoints."
-              : "Choose which configured provider, model, and local endpoint this account prefers."
-          }
-          width="wide"
-        >
-          <div className="mx-auto max-w-3xl space-y-4">
-            <SettingsPanel className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {/* Provider Information (Read-only) */}
-              <div className="col-span-2 p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center justify-between">
-                <div>
-                  <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                    Active AI Provider: <span className="capitalize text-orange-600 dark:text-orange-400">{settings.llm_provider || "None"}</span>
-                  </div>
-                  <p className="text-xs text-gray-500 mt-1">
-                    AI services are configured globally in the server&apos;s environment variable file (<code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">.env</code>).
-                  </p>
-                </div>
-                <div>
-                  {checkLlmConfigured() ? (
-                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-400">
-                      Configured via Server (.env)
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-400">
-                      Not Configured
-                    </span>
-                  )}
-                </div>
-              </div>
-
-              {/* Usage model (per-user). Only cli_oauth changes resolution;
-                  the other values follow the server-configured provider. CLI
-                  OAuth is disabled until connect support ships. */}
-              <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  AI usage model
-                </label>
-                <select
-                  value={settings.usage_model || ""}
-                  onChange={(e) =>
-                    persistSettingsUpdate({
-                      ...settings,
-                      usage_model: e.target.value ? e.target.value : null,
-                    })
-                  }
-                  className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-                >
-                  <option value="">Use server-configured provider</option>
-                  <option value="ollama">Ollama (local)</option>
-                  <option value="byok">BYOK (bring your own API key)</option>
-                  <option value="cli_oauth" disabled={!cliConnected}>
-                    CLI OAuth — route through your Claude subscription
-                    {cliConnected ? "" : " (connect below first)"}
-                  </option>
-                </select>
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
-                  <Info className="w-3 h-3" />
-                  Route inference through your own Anthropic/OpenAI subscription.
-                  Connect it below, then pick CLI OAuth here.
-                </p>
-              </div>
-
-              <CliOAuthPanel onConnectedChange={setCliConnected} />
-
-              {settings.usage_model === "cli_oauth" && (
-                <div className="col-span-2 grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      CLI model
-                    </label>
-                    <select
-                      value={settings.cli_model || ""}
-                      onChange={(e) =>
-                        persistSettingsUpdate({
-                          ...settings,
-                          cli_model: e.target.value ? e.target.value : null,
-                        })
-                      }
-                      className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-                    >
-                      <option value="">Default (Claude Code default model)</option>
-                      {CLI_MODEL_OPTIONS.map((model) => (
-                        <option key={model.id} value={model.id}>
-                          {model.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                      Notes, titles, speaker inference, and chat.
-                    </p>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      CLI live model (Meeting Edge)
-                    </label>
-                    <select
-                      value={settings.cli_live_model || ""}
-                      onChange={(e) =>
-                        persistSettingsUpdate({
-                          ...settings,
-                          cli_live_model: e.target.value ? e.target.value : null,
-                        })
-                      }
-                      className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-                    >
-                      <option value="">Same as CLI model</option>
-                      {CLI_MODEL_OPTIONS.map((model) => (
-                        <option key={model.id} value={model.id}>
-                          {model.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                      Live Meeting Edge. A faster model keeps guidance responsive
-                      and conserves quota.
-                    </p>
-                  </div>
-                </div>
-              )}
-
-              {/* API URL Display for Ollama */}
-              {settings.llm_provider === "ollama" && (
-                <div className="col-span-2 md:col-span-1">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                    Ollama API URL
-                  </label>
-                  <div className="relative">
-                    <input
-                      type="text"
-                      value={settings.ollama_api_url || "http://host.docker.internal:11434"}
-                      disabled={true}
-                      className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100/50 dark:bg-gray-800/50 text-gray-500 dark:text-gray-400 cursor-not-allowed outline-none"
-                    />
-                    <Server className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                  </div>
-                  <p className="mt-1 text-xs text-yellow-600 dark:text-yellow-400 flex items-center gap-1">
-                    <Info className="w-3 h-3" />
-                    Local models run on your hardware. Performance depends on your GPU/CPU.
-                  </p>
-                </div>
-              )}
-
-              {settings.llm_provider === "ollama" && (
-                <div className="col-span-2 md:col-span-1">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                    Ollama context window
-                  </label>
-                  <input
-                    type="number"
-                    min={1024}
-                    step={1024}
-                    value={settings.ollama_context_window || DEFAULT_OLLAMA_CONTEXT_WINDOW}
-                    onChange={(e) =>
-                      persistSettingsUpdate({
-                        ...settings,
-                        ollama_context_window: parseContextWindow(e.target.value),
-                      })
-                    }
-                    className="w-full px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    Passed to Ollama as <code>num_ctx</code> for full-context meeting prompts.
-                  </p>
-                </div>
-              )}
-
-              {/* Model */}
-              <div className={settings.llm_provider === "ollama" ? "" : "col-span-2 md:col-span-1"}>
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex justify-between">
-                  <Tooltip
-                    content="Select the specific model to use for this provider."
-                    position="right"
-                  >
-                    <span className="flex items-center gap-1 cursor-help">
-                      Model <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
-                    </span>
-                  </Tooltip>
-                  <button
-                    onClick={() => {
-                      const provider = settings.llm_provider || "gemini";
-                      const url = provider === "ollama" ? settings.ollama_api_url : undefined;
-                      setFetchingModels(true);
-                      listModels(provider, "", url)
-                        .then((res) => setAvailableModels(res.models))
-                        .catch(console.error)
-                        .finally(() => setFetchingModels(false));
-                    }}
-                    disabled={fetchingModels || !checkLlmConfigured()}
-                    className="text-xs text-orange-500 hover:text-orange-600 flex items-center gap-1 disabled:opacity-50"
-                  >
-                    <RefreshCw
-                      className={`w-3 h-3 ${fetchingModels ? "animate-spin" : ""}`}
-                    />{" "}
-                    Refresh
-                  </button>
-                </label>
-                <select
-                  value={getSelectedModelForProvider("main")}
-                  onChange={(e) =>
-                    updateSelectedModelForProvider("main", e.target.value)
-                  }
-                  disabled={mainModelOptions.length === 0 || !checkLlmConfigured()}
-                  className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50"
-                >
-                  <option value="" disabled>
-                    Select a model...
-                  </option>
-                  {mainModelOptions.map((model) => (
-                    <option key={model} value={model}>
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <div className="mb-2 flex items-center justify-between gap-3">
-                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1">
-                    <Tooltip
-                      content="Optional separate model for Meeting Edge live meeting guidance. Leave it blank to reuse the main AI model."
-                      position="right"
-                    >
-                      <span className="flex items-center gap-1 cursor-help">
-                        Meeting Edge model <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
-                      </span>
-                    </Tooltip>
-                  </label>
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
-                      Enable Meeting Edge
-                    </span>
-                    <Switch
-                      checked={settings.enable_meeting_edge !== false}
-                      onCheckedChange={(checked) =>
-                        onUpdate({ ...settings, enable_meeting_edge: checked })
-                      }
-                    />
-                  </div>
-                </div>
-                <select
-                  value={getSelectedModelForProvider("live")}
-                  onChange={(e) =>
-                    updateSelectedModelForProvider("live", e.target.value)
-                  }
-                  disabled={
-                    settings.enable_meeting_edge === false ||
-                    liveModelOptions.length === 0 ||
-                    !checkLlmConfigured()
-                  }
-                  className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50"
-                >
-                  <option value="">Use main model</option>
-                  {liveModelOptions.map((model) => (
-                    <option key={`meeting-edge-${model}`} value={model}>
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div className="md:col-span-2 rounded-xl border border-orange-200/70 bg-orange-50/45 p-4 dark:border-orange-500/20 dark:bg-orange-500/5">
-                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium text-gray-900 dark:text-white">
-                      Meeting Edge Technical Context
-                    </div>
-                    <p className="mt-1 text-xs leading-5 text-gray-600 dark:text-gray-300">
-                      Control how readily Meeting Edge explains terms in the Technical Context section.
-                    </p>
-                  </div>
-                  <span className="inline-flex items-center rounded-full border border-orange-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-orange-700 dark:border-orange-500/20 dark:bg-gray-900 dark:text-orange-300">
-                    {selectedMeetingEdgeContextOption.label || `Level ${selectedMeetingEdgeContextOption.value}`}
-                  </span>
-                </div>
-
-                <input
-                  type="range"
-                  min={1}
-                  max={5}
-                  step={1}
-                  value={meetingEdgeContextLevel}
-                  onChange={(e) =>
-                    onUpdate({
-                      ...settings,
-                      meeting_edge_context_level: Number(e.target.value),
-                    })
-                  }
-                  disabled={settings.enable_meeting_edge === false}
-                  aria-label="Meeting Edge Technical Context sensitivity"
-                  className="mt-4 w-full accent-orange-500 disabled:cursor-not-allowed disabled:opacity-50"
-                />
-
-                <div className="mt-3 grid grid-cols-5 gap-2 text-center text-[11px] font-medium text-gray-500 dark:text-gray-400">
-                  {MEETING_EDGE_CONTEXT_OPTIONS.map((option) => (
-                    <span key={option.value}>{option.label}</span>
-                  ))}
-                </div>
-
-                <p className="mt-3 text-xs leading-5 text-gray-600 dark:text-gray-300">
-                  {selectedMeetingEdgeContextOption.description}
-                </p>
-              </div>
-
-              {/* Validation Connection Button */}
-              {checkLlmConfigured() && (
-                <div className="md:col-span-2">
-                  <button
-                    onClick={() => handleValidate(settings.llm_provider || "gemini")}
-                    disabled={Boolean(validating)}
-                    className="px-4 py-2.5 bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 flex items-center gap-2 text-sm font-semibold"
-                  >
-                    {validating === settings.llm_provider ? (
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                    ) : (
-                      <Check className="w-4 h-4" />
-                    )}
-                    Validate API Connection
-                  </button>
-                  {validationMsg && validationMsg.provider === settings.llm_provider && (
-                    <p
-                      className={`mt-2 text-sm font-semibold ${validationMsg.type === "success" ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
-                    >
-                      {validationMsg.msg}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
-            </SettingsPanel>
-          </div>
-        </SettingsSection>
+        <AiRoutingSection
+          settings={settings}
+          onPersist={persistNow}
+          isAdmin={isAdmin}
+          cliConnected={cliConnected}
+          onCliConnectedChange={setCliConnected}
+        />
       )}
 
-      {showLLMSection && settings.secondary_llm_provider && (
-        <SettingsSection
-          eyebrow="AI"
-          title="Secondary provider"
-          description={
-            isAdmin
-              ? "When the primary provider is unavailable, Nojoin falls back to this secondary provider."
-              : "Configure your preferred secondary provider for when the primary is unavailable."
-          }
-          width="wide"
-        >
-          <div className="mx-auto max-w-3xl space-y-4">
-            <SettingsPanel className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {/* Secondary Provider Information */}
-              <div className="col-span-2 p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center justify-between">
-                <div>
-                  <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                    Secondary AI Provider: <span className="capitalize text-orange-600 dark:text-orange-400">{settings.secondary_llm_provider}</span>
-                  </div>
-                  <p className="text-xs text-gray-500 mt-1">
-                    Configured via <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">SECONDARY_LLM_PROVIDER</code> in the server&apos;s <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">.env</code> file.
-                  </p>
-                </div>
-                <div>
-                  {(() => {
-                    const sp = settings.secondary_llm_provider;
-                    const hasKey = sp === "ollama"
-                      ? Boolean(settings.secondary_ollama_api_url)
-                      : Boolean(getSecondaryProviderApiKey(sp));
-                    return hasKey ? (
-                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-400">
-                        Configured
-                      </span>
-                    ) : (
-                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-400">
-                        Not Configured
-                      </span>
-                    );
-                  })()}
-                </div>
-              </div>
-
-              {/* Secondary Ollama API URL */}
-              {settings.secondary_llm_provider === "ollama" && (
-                <div className="col-span-2 md:col-span-1">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                    Secondary Ollama API URL
-                  </label>
-                  <div className="relative">
-                    <input
-                      type="text"
-                      value={settings.secondary_ollama_api_url || "http://host.docker.internal:11434"}
-                      onChange={(e) => onUpdate({ ...settings, secondary_ollama_api_url: e.target.value })}
-                      className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-                    />
-                    <Server className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                  </div>
-                </div>
-              )}
-
-              {settings.secondary_llm_provider === "ollama" && (
-                <div className="col-span-2 md:col-span-1">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                    Secondary Ollama context window
-                  </label>
-                  <input
-                    type="number"
-                    min={1024}
-                    step={1024}
-                    value={settings.secondary_ollama_context_window || DEFAULT_OLLAMA_CONTEXT_WINDOW}
-                    onChange={(e) =>
-                      persistSettingsUpdate({
-                        ...settings,
-                        secondary_ollama_context_window: parseContextWindow(e.target.value),
-                      })
-                    }
-                    className="w-full px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-                  />
-                </div>
-              )}
-
-              {/* Secondary Model */}
-              <div className={settings.secondary_llm_provider === "ollama" ? "" : "col-span-2 md:col-span-1"}>
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex justify-between">
-                  <Tooltip
-                    content="Select the model for the secondary provider. Used when the primary is unavailable."
-                    position="right"
-                  >
-                    <span className="flex items-center gap-1 cursor-help">
-                      Secondary Model <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
-                    </span>
-                  </Tooltip>
-                  <button
-                    onClick={() => {
-                      const sp = settings.secondary_llm_provider || "gemini";
-                      const url = sp === "ollama" ? settings.secondary_ollama_api_url : undefined;
-                      setSecondaryFetchingModels(true);
-                      listModels(sp, "", url)
-                        .then((res) => setSecondaryAvailableModels(res.models))
-                        .catch(console.error)
-                        .finally(() => setSecondaryFetchingModels(false));
-                    }}
-                    disabled={secondaryFetchingModels}
-                    className="text-xs text-orange-500 hover:text-orange-600 flex items-center gap-1 disabled:opacity-50"
-                  >
-                    <RefreshCw className={`w-3 h-3 ${secondaryFetchingModels ? "animate-spin" : ""}`} /> Refresh
-                  </button>
-                </label>
-                <select
-                  value={getSecondaryProviderModel(settings.secondary_llm_provider)}
-                  onChange={(e) => {
-                    const sp = settings.secondary_llm_provider;
-                    updateSecondaryProviderModel(sp, e.target.value);
-                  }}
-                  disabled={secondaryAvailableModels.length === 0}
-                  className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50"
-                >
-                  <option value="" disabled>
-                    Select a model...
-                  </option>
-                  {secondaryAvailableModels.map((model) => (
-                    <option key={`secondary-${model}`} value={model}>
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <div className="mb-2">
-                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1">
-                    <Tooltip
-                      content="Optional separate model for Meeting Edge when using the secondary provider. Leave it blank to reuse the secondary main model."
-                      position="right"
-                    >
-                      <span className="flex items-center gap-1 cursor-help">
-                        Secondary Meeting Edge model <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
-                      </span>
-                    </Tooltip>
-                  </label>
-                </div>
-                <select
-                  value={getSecondaryProviderLiveModel(settings.secondary_llm_provider)}
-                  onChange={(e) => {
-                    const sp = settings.secondary_llm_provider;
-                    updateSecondaryProviderLiveModel(sp, e.target.value);
-                  }}
-                  disabled={secondaryAvailableModels.length === 0}
-                  className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50"
-                >
-                  <option value="">Use secondary main model</option>
-                  {secondaryAvailableModels.map((model) => (
-                    <option key={`secondary-live-${model}`} value={model}>
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Validate Secondary Connection */}
-              {(() => {
-                const sp = settings.secondary_llm_provider;
-                const hasConfig = sp === "ollama"
-                  ? Boolean(settings.secondary_ollama_api_url)
-                  : Boolean(getSecondaryProviderApiKey(sp));
-                return hasConfig ? (
-                  <div className="md:col-span-2">
-                    <button
-                      onClick={() => handleValidate(sp || "gemini")}
-                      disabled={Boolean(validating)}
-                      className="px-4 py-2.5 bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 flex items-center gap-2 text-sm font-semibold"
-                    >
-                      {validating === sp ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        <Check className="w-4 h-4" />
-                      )}
-                      Validate Secondary Connection
-                    </button>
-                    {validationMsg && validationMsg.provider === sp && (
-                      <p
-                        className={`mt-2 text-sm font-semibold ${validationMsg.type === "success" ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
-                      >
-                        {validationMsg.msg}
-                      </p>
-                    )}
-                  </div>
-                ) : null;
-              })()}
-            </div>
-            </SettingsPanel>
-          </div>
-        </SettingsSection>
+      {showLLMSection && isAdmin && (
+        <ServerProviderSection
+          settings={settings}
+          onUpdate={onUpdate}
+          onPersist={persistNow}
+          models={models}
+        />
       )}
 
-      {!showLLMSection && !settings.secondary_llm_provider && showLLM && (
-        <SettingsSection
-          eyebrow="AI"
-          title="Secondary provider"
-          description="No secondary provider is configured. Add SECONDARY_LLM_PROVIDER to your .env file to enable automatic fallback when the primary provider is unavailable."
-          width="compact"
-        >
-          <SettingsPanel variant="field" className="mx-auto max-w-2xl">
-            <p className="text-xs contrast-helper">
-              The secondary provider is configured via environment variables in the server&apos;s <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">.env</code> file.
-              When set, all AI features (transcription intelligence, Meeting Edge, chat, speaker inference) will automatically fall back to this provider if the primary fails.
-            </p>
-          </SettingsPanel>
-        </SettingsSection>
+      {showLLMSection && (
+        <MeetingEdgeSection
+          settings={settings}
+          onUpdate={onUpdate}
+          onPersist={persistNow}
+          isAdmin={isAdmin}
+          models={models}
+        />
+      )}
+
+      {showLLMSection && isAdmin && (
+        <SecondaryProviderSection
+          settings={settings}
+          onUpdate={onUpdate}
+          onPersist={persistNow}
+          models={models}
+        />
       )}
 
       {showAutomaticEnhancementSection && (
-        <SettingsSection
-          eyebrow="AI"
-          title="Automatic enhancement"
-          description="Control how AI-generated titles are written for your meetings and summaries."
-          width="compact"
-        >
-          <SettingsPanel variant="field" className="mx-auto max-w-2xl flex items-start gap-3">
-            <div className="flex-1">
-              <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
-                <Cpu className="h-4 w-4 text-orange-500" />
-                Prefer short titles
-              </div>
-              <p className="mt-2 text-xs contrast-helper">
-                Use concise 3-5 word AI-generated meeting titles instead of longer descriptive ones.
-              </p>
-            </div>
-            <Switch
-              checked={settings.prefer_short_titles !== false}
-              onCheckedChange={(checked) =>
-                onUpdate({ ...settings, prefer_short_titles: checked })
-              }
-            />
-          </SettingsPanel>
-        </SettingsSection>
+        <AiAutomaticEnhancementSection
+          settings={settings}
+          onPersist={persistNow}
+        />
       )}
 
       {showLanguageSection && (
-        <SettingsSection
-          eyebrow="AI"
-          title="Language preferences"
-          description="Choose the source language used for transcription and the language used for generated meeting titles and notes."
-          width="regular"
-        >
-          <SettingsPanel className="mx-auto max-w-3xl space-y-6">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Transcription language
-              </label>
-              <select
-                value={settings.transcription_language || "auto"}
-                onChange={(event) =>
-                  onUpdate({
-                    ...settings,
-                    transcription_language: event.target.value,
-                  })
-                }
-                disabled={
-                  !languageRegistry ||
-                  transcriptionLanguageCapability?.forced_language === false
-                }
-                className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-60"
-              >
-                {!languageRegistry && <option value="auto">Loading languages...</option>}
-                {languageRegistry?.transcription_languages.map((language) => (
-                  <option key={language.code} value={language.code}>
-                    {language.label}
-                  </option>
-                ))}
-              </select>
-              <p className="mt-2 text-xs contrast-helper">
-                {transcriptionLanguageCapability?.guidance ||
-                  "Language capabilities are loading."}
-              </p>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Notes generation language
-              </label>
-              <select
-                value={settings.notes_language || "english"}
-                onChange={(event) =>
-                  onUpdate({
-                    ...settings,
-                    notes_language: event.target.value,
-                  })
-                }
-                disabled={!languageRegistry}
-                className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-60"
-              >
-                {!languageRegistry && <option value="english">Loading languages...</option>}
-                {languageRegistry?.notes_languages.map((language) => (
-                  <option key={language.code} value={language.code}>
-                    {language.label}
-                  </option>
-                ))}
-              </select>
-              <p className="mt-2 text-xs contrast-helper">
-                This controls generated titles, headings, summaries, detailed notes, and action items. JSON field names remain stable.
-              </p>
-            </div>
-
-            {(settings.notes_language || "english") === "custom" && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Custom notes language or style instruction
-                </label>
-                <input
-                  type="text"
-                  value={settings.notes_language_custom_instruction || ""}
-                  onChange={(event) =>
-                    onUpdate({
-                      ...settings,
-                      notes_language_custom_instruction: event.target.value,
-                    })
-                  }
-                  maxLength={languageRegistry?.custom_instruction_max_length || 300}
-                  placeholder="e.g. Formal Canadian French with concise executive-style headings"
-                  className="w-full p-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-                />
-                <p className="mt-2 text-xs contrast-helper">
-                  Required for Custom. This can control language, regional conventions, tone, and heading style.
-                </p>
-              </div>
-            )}
-          </SettingsPanel>
-        </SettingsSection>
+        <AiLanguageSection
+          settings={settings}
+          onUpdate={onUpdate}
+          onPersist={persistNow}
+          languageRegistry={models.languageRegistry}
+        />
       )}
 
-      {showHFSection && (
-        <SettingsSection
-          eyebrow="Administration"
-          title="Hugging Face access"
-          description="View status of the installation token required for diarization and related model downloads."
-          width="regular"
-        >
-          <SettingsPanel className="mx-auto max-w-3xl space-y-4">
-            <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl">
-              <div>
-                <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-                  Hugging Face Integration
-                </div>
-                <p className="text-xs text-gray-500 mt-1">
-                  The access token is configured globally in the server&apos;s environment variable file (<code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">.env</code>).
-                </p>
-              </div>
-              <div>
-                {settings.hf_token ? (
-                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-400">
-                    Configured via Server (.env)
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-400">
-                    Missing Config
-                  </span>
-                )}
-              </div>
-            </div>
-            <p className="text-xs contrast-helper">
-              Required for Pyannote speaker diarization. Ensure you have accepted the user agreement for <code>pyannote/speaker-diarization-community-1</code> on Hugging Face.
-            </p>
-          </SettingsPanel>
-        </SettingsSection>
-      )}
+      {showHFSection && <AiHuggingFaceSection settings={settings} />}
 
       {showTranscriptionSection && (
-        <SettingsSection
-          eyebrow="Administration"
-          title="Transcription model"
-          description="Choose the engine Nojoin uses for live and final transcription during normal recording."
-          width="regular"
-        >
-          <SettingsPanel className="mx-auto max-w-3xl space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                <Tooltip
-                  content="Select the transcription engine used for speech to text."
-                  position="right"
-                >
-                  <span className="flex items-center gap-1 cursor-help">
-                    Transcription engine{" "}
-                    <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
-                  </span>
-                </Tooltip>
-              </label>
-              <select
-                value={settings.transcription_backend || "whisper"}
-                onChange={(e) =>
-                  onUpdate({
-                    ...settings,
-                    transcription_backend: e.target.value,
-                  })
-                }
-                disabled={!isAdmin}
-                className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-              >
-                <option value="whisper">Whisper</option>
-                <option value="parakeet">Parakeet (NVIDIA)</option>
-                <option value="canary">Canary 1B (NVIDIA)</option>
-              </select>
-            </div>
-            {(settings.transcription_backend || "whisper") === "parakeet" ? (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Parakeet Model
-                </label>
-                <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
-                  <div className="flex-1">
-                    <div className="font-semibold text-gray-900 dark:text-white">
-                      {settings.parakeet_model || "parakeet-tdt-0.6b-v3"}
-                    </div>
-                    <p className="mt-1 text-xs contrast-helper">
-                      Fast NVIDIA transcription with slightly lower accuracy and fewer supported languages than Whisper.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ) : (settings.transcription_backend || "whisper") === "canary" ? (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Canary Model
-                </label>
-                <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
-                  <div className="flex-1">
-                    <div className="font-semibold text-gray-900 dark:text-white">
-                      {settings.canary_model || "nemo-canary-1b-v2"}
-                    </div>
-                    <p className="mt-1 text-xs contrast-helper">
-                      Current active model for transcription.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ) : (
-            <div>
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
-                Whisper Model Size
-                <div className="group relative">
-                  <HelpCircle className="w-4 h-4 text-gray-500 dark:text-gray-400 cursor-help" />
-                  <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-80 p-4 bg-gray-900 text-white text-xs rounded-lg shadow-xl z-50 pointer-events-none">
-                    <div className="font-bold mb-2 text-sm">
-                      Available Models
-                    </div>
-                    <div className="grid grid-cols-5 gap-2 border-b border-gray-700 pb-2 mb-2 font-semibold">
-                      <div className="col-span-1">Size</div>
-                      <div className="col-span-1">Params</div>
-                      <div className="col-span-1">VRAM</div>
-                      <div className="col-span-1">Speed</div>
-                    </div>
-                    {WHISPER_MODELS.map((m) => (
-                      <div key={m.id} className="grid grid-cols-5 gap-2 mb-1">
-                        <div className="col-span-1 font-medium text-orange-400">
-                          {m.label}
-                        </div>
-                        <div className="col-span-1 text-gray-300">
-                          {m.params}
-                        </div>
-                        <div className="col-span-1 text-gray-300">{m.vram}</div>
-                        <div className="col-span-1 text-gray-300">
-                          {m.speed}
-                        </div>
-                      </div>
-                    ))}
-                    <div className="mt-2 text-gray-300 italic">
-                      Turbo is the recommended default for best balance of speed
-                      and accuracy.
-                    </div>
-                  </div>
-                </div>
-              </label>
-
-              <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold text-gray-900 dark:text-white">
-                      {WHISPER_MODELS.find(
-                        (m) =>
-                          m.id === (settings.whisper_model_size || "turbo"),
-                      )?.label || settings.whisper_model_size}
-                    </span>
-                    <span className="text-sm text-gray-500">
-                      (
-                      {
-                        WHISPER_MODELS.find(
-                          (m) =>
-                            m.id === (settings.whisper_model_size || "turbo"),
-                        )?.vram
-                      }{" "}
-                      VRAM)
-                    </span>
-                  </div>
-                  <p className="mt-1 text-xs contrast-helper">
-                    Current active model for transcription.
-                  </p>
-                </div>
-                <button
-                  onClick={() => setShowWhisperModal(true)}
-                  disabled={!isAdmin}
-                  className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
-                >
-                  Change Model
-                </button>
-              </div>
-              <p className="mt-2 text-xs contrast-helper">
-                Click &apos;Change Model&apos; to select a different Whisper
-                model variant. Missing model files are prepared automatically after the change is saved.
-              </p>
-            </div>
-            )}
-            <WhisperModelModal
-              isOpen={showWhisperModal}
-              onClose={() => setShowWhisperModal(false)}
-              currentSize={settings.whisper_model_size || "turbo"}
-              isAdmin={isAdmin}
-              onUpdate={(newSize) =>
-                onUpdate({ ...settings, whisper_model_size: newSize })
-              }
-            />
-          </SettingsPanel>
-        </SettingsSection>
+        <AiTranscriptionSection
+          settings={settings}
+          onPersist={persistNow}
+          isAdmin={isAdmin}
+        />
       )}
 
       {showDependenciesSection && (
-        <SettingsSection
-          eyebrow="Administration"
-          title="Model dependencies"
-          description="Inspect and manage local AI model assets on the server."
-        >
-          <SettingsPanel className="mx-auto max-w-3xl space-y-6">
-            <div className="bg-gray-50 dark:bg-gray-900/50 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
-              <div className="space-y-3">
-                {[
-                  {
-                    id: "whisper",
-                    label: "Whisper (Transcription)",
-                    desc: "OpenAI Whisper model for speech-to-text. (MIT License)",
-                  },
-                  {
-                    id: "parakeet",
-                    label: "Parakeet ASR Model (Transcription)",
-                    desc: "NVIDIA FastConformer ASR model.",
-                  },
-                  {
-                    id: "canary",
-                    label: "Canary ASR Model (Transcription)",
-                    desc: "NVIDIA Canary 1B multi-lingual ASR model.",
-                  },
-                  {
-                    id: "pyannote",
-                    label: "Pyannote (Diarization)",
-                    desc: "Speaker diarization model weights.",
-                  },
-                  {
-                    id: "embedding",
-                    label: "Voice Embedding",
-                    desc: "Speaker identification model weights.",
-                  },
-                  {
-                    id: "segmentation",
-                    label: "Segmentation Refinement",
-                    desc: "Pyannote segmentation-3.0 model weights.",
-                  },
-                ].map((model) => (
-                  <div
-                    key={model.id}
-                    className="flex justify-between items-center p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
-                  >
-                    <div>
-                      <div className="text-sm font-medium text-gray-900 dark:text-white">
-                        {model.label}
-                      </div>
-                      <div className="text-xs contrast-helper">{model.desc}</div>
-                    </div>
-                    <div className="flex items-center gap-3">
-                      {modelStatus?.[model.id]?.downloaded ? (
-                        <>
-                          <span className="text-xs bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400 px-2.5 py-1 rounded-full flex items-center gap-1 font-medium">
-                            <Check className="w-3 h-3" /> Ready
-                          </span>
-                          {modelStatus?.[model.id]?.source === "bundled" && (
-                            <span className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400 px-2.5 py-1 rounded-full font-medium">
-                              Bundled
-                            </span>
-                          )}
-                          <button
-                            onClick={() => handleDeleteModel(model.id)}
-                            disabled={
-                              deleting === model.id ||
-                              !isAdmin ||
-                              modelStatus?.[model.id]?.source === "bundled"
-                            }
-                            className="text-gray-500 dark:text-gray-400 hover:text-red-500 transition-colors p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md disabled:opacity-50"
-                            title={
-                              modelStatus?.[model.id]?.source === "bundled"
-                                ? "Bundled repo asset"
-                                : "Delete Model"
-                            }
-                          >
-                            {deleting === model.id ? (
-                              <Loader2 className="w-4 h-4 animate-spin" />
-                            ) : (
-                              <Trash2 className="w-4 h-4" />
-                            )}
-                          </button>
-                        </>
-                      ) : (
-                        <div className="flex flex-col items-end">
-                          <span className="text-xs bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400 px-2.5 py-1 rounded-full flex items-center gap-1 font-medium">
-                            <X className="w-3 h-3" /> Missing
-                          </span>
-                          {modelStatus?.[model.id]?.checked_paths && modelStatus[model.id].checked_paths.length > 0 && (
-                            <span
-                              className="mt-1 max-w-[200px] truncate cursor-help text-[10px] text-gray-500 dark:text-gray-400"
-                              title={`Checked paths:\n${modelStatus[model.id].checked_paths.join("\n")}`}
-                            >
-                              Hover for debug info
-                            </span>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <p className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 text-center text-xs contrast-helper">
-                Required default models are prepared automatically. Parakeet and
-                Canary models are prepared after their settings are saved.
-              </p>
-            </div>
-          </SettingsPanel>
-        </SettingsSection>
+        <AiModelDependenciesSection
+          modelStatus={models.modelStatus}
+          deleting={models.deleting}
+          handleDeleteModel={models.handleDeleteModel}
+          isAdmin={isAdmin}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/settings/AdminSettings.tsx
+++ b/frontend/src/components/settings/AdminSettings.tsx
@@ -1,5 +1,6 @@
 import { fuzzyMatch } from "@/lib/searchUtils";
 import UsersTab from "./UsersTab";
+import CliUsageTab from "./CliUsageTab";
 import InvitesTab from "./InvitesTab";
 import BackupRestore from "./BackupRestore";
 import SystemTab from "./SystemTab";
@@ -26,6 +27,16 @@ export default function AdminSettings({
     "permissions",
     "access",
     "superuser",
+  ]);
+  const showUsage = !searchQuery || fuzzyMatch(searchQuery, [
+    "cli usage",
+    "usage",
+    "tokens",
+    "quota",
+    "subscription",
+    "claude subscription",
+    "consumption",
+    "rate limit",
   ]);
   const showInvites = !searchQuery || fuzzyMatch(searchQuery, [
     "invite",
@@ -64,6 +75,7 @@ export default function AdminSettings({
 
   if (
     !showUsers &&
+    !showUsage &&
     !showInvites &&
     !showCalendar &&
     !showSystem &&
@@ -88,6 +100,17 @@ export default function AdminSettings({
           width="full"
         >
           <UsersTab />
+        </SettingsSection>
+      )}
+
+      {showUsage && (
+        <SettingsSection
+          eyebrow="Administration"
+          title="CLI usage & quota"
+          description="Per-user Claude subscription (CLI OAuth) token usage and rate-limit status."
+          width="full"
+        >
+          <CliUsageTab />
         </SettingsSection>
       )}
 

--- a/frontend/src/components/settings/AiAutomaticEnhancementSection.tsx
+++ b/frontend/src/components/settings/AiAutomaticEnhancementSection.tsx
@@ -1,0 +1,49 @@
+import { Cpu } from "lucide-react";
+
+import { Settings } from "@/types";
+import { Switch } from "@/components/ui/Switch";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+
+interface AiAutomaticEnhancementSectionProps {
+  settings: Settings;
+  /** Apply and save immediately (the switch is a discrete control). */
+  onPersist: (newSettings: Settings) => void;
+}
+
+/** "Automatic enhancement" AI section (per-user). */
+export default function AiAutomaticEnhancementSection({
+  settings,
+  onPersist,
+}: AiAutomaticEnhancementSectionProps) {
+  return (
+    <SettingsSection
+      eyebrow="AI"
+      title="Automatic enhancement"
+      description="Control how AI-generated titles are written for your meetings and summaries."
+      width="compact"
+    >
+      <SettingsPanel
+        variant="field"
+        className="mx-auto max-w-2xl flex items-start gap-3"
+      >
+        <div className="flex-1">
+          <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+            <Cpu className="h-4 w-4 text-orange-500" />
+            Prefer short titles
+          </div>
+          <p className="mt-2 text-xs contrast-helper">
+            Use concise 3-5 word AI-generated meeting titles instead of longer
+            descriptive ones.
+          </p>
+        </div>
+        <Switch
+          checked={settings.prefer_short_titles !== false}
+          onCheckedChange={(checked) =>
+            onPersist({ ...settings, prefer_short_titles: checked })
+          }
+        />
+      </SettingsPanel>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/AiHuggingFaceSection.tsx
+++ b/frontend/src/components/settings/AiHuggingFaceSection.tsx
@@ -1,0 +1,56 @@
+import { Settings } from "@/types";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+
+interface AiHuggingFaceSectionProps {
+  settings: Settings;
+}
+
+/** Admin-only "Hugging Face access" section. Extracted verbatim from
+ * {@link AISettings} so behaviour is unchanged. */
+export default function AiHuggingFaceSection({
+  settings,
+}: AiHuggingFaceSectionProps) {
+  return (
+    <SettingsSection
+      eyebrow="Administration"
+      title="Hugging Face access"
+      description="View status of the installation token required for diarization and related model downloads."
+      width="regular"
+    >
+      <SettingsPanel className="mx-auto max-w-3xl space-y-4">
+        <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl">
+          <div>
+            <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+              Hugging Face Integration
+            </div>
+            <p className="text-xs text-gray-500 mt-1">
+              The access token is configured globally in the server&apos;s
+              environment variable file (
+              <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                .env
+              </code>
+              ).
+            </p>
+          </div>
+          <div>
+            {settings.hf_token ? (
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-400">
+                Configured via Server (.env)
+              </span>
+            ) : (
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-400">
+                Missing Config
+              </span>
+            )}
+          </div>
+        </div>
+        <p className="text-xs contrast-helper">
+          Required for Pyannote speaker diarization. Ensure you have accepted the
+          user agreement for{" "}
+          <code>pyannote/speaker-diarization-community-1</code> on Hugging Face.
+        </p>
+      </SettingsPanel>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/AiLanguageSection.tsx
+++ b/frontend/src/components/settings/AiLanguageSection.tsx
@@ -1,0 +1,128 @@
+import { LanguageRegistry, Settings } from "@/types";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+
+interface AiLanguageSectionProps {
+  settings: Settings;
+  /** Debounced apply (the free-text custom instruction). */
+  onUpdate: (newSettings: Settings) => void;
+  /** Apply and save immediately (the language selects). */
+  onPersist: (newSettings: Settings) => void;
+  languageRegistry: LanguageRegistry | null;
+}
+
+/** "Language preferences" AI section (per-user). */
+export default function AiLanguageSection({
+  settings,
+  onUpdate,
+  onPersist,
+  languageRegistry,
+}: AiLanguageSectionProps) {
+  const selectedTranscriptionBackend: keyof LanguageRegistry["engine_capabilities"] =
+    settings.transcription_backend === "canary"
+      ? "canary"
+      : settings.transcription_backend === "parakeet"
+        ? "parakeet"
+        : "whisper";
+  const transcriptionLanguageCapability =
+    languageRegistry?.engine_capabilities[selectedTranscriptionBackend];
+
+  return (
+    <SettingsSection
+      eyebrow="AI"
+      title="Language preferences"
+      description="Choose the source language used for transcription and the language used for generated meeting titles and notes."
+      width="regular"
+    >
+      <SettingsPanel className="mx-auto max-w-3xl space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Transcription language
+          </label>
+          <select
+            value={settings.transcription_language || "auto"}
+            onChange={(event) =>
+              onPersist({
+                ...settings,
+                transcription_language: event.target.value,
+              })
+            }
+            disabled={
+              !languageRegistry ||
+              transcriptionLanguageCapability?.forced_language === false
+            }
+            className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-60"
+          >
+            {!languageRegistry && (
+              <option value="auto">Loading languages...</option>
+            )}
+            {languageRegistry?.transcription_languages.map((language) => (
+              <option key={language.code} value={language.code}>
+                {language.label}
+              </option>
+            ))}
+          </select>
+          <p className="mt-2 text-xs contrast-helper">
+            {transcriptionLanguageCapability?.guidance ||
+              "Language capabilities are loading."}
+          </p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Notes generation language
+          </label>
+          <select
+            value={settings.notes_language || "english"}
+            onChange={(event) =>
+              onPersist({
+                ...settings,
+                notes_language: event.target.value,
+              })
+            }
+            disabled={!languageRegistry}
+            className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-60"
+          >
+            {!languageRegistry && (
+              <option value="english">Loading languages...</option>
+            )}
+            {languageRegistry?.notes_languages.map((language) => (
+              <option key={language.code} value={language.code}>
+                {language.label}
+              </option>
+            ))}
+          </select>
+          <p className="mt-2 text-xs contrast-helper">
+            This controls generated titles, headings, summaries, detailed notes,
+            and action items. JSON field names remain stable.
+          </p>
+        </div>
+
+        {(settings.notes_language || "english") === "custom" && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Custom notes language or style instruction
+            </label>
+            <input
+              type="text"
+              value={settings.notes_language_custom_instruction || ""}
+              onChange={(event) =>
+                onUpdate({
+                  ...settings,
+                  notes_language_custom_instruction: event.target.value,
+                })
+              }
+              maxLength={languageRegistry?.custom_instruction_max_length || 300}
+              placeholder="e.g. Formal Canadian French with concise executive-style headings"
+              className="w-full p-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
+            />
+            <p className="mt-2 text-xs contrast-helper">
+              Required for Custom. This can control language, regional
+              conventions, tone, and heading style.
+            </p>
+          </div>
+        )}
+      </SettingsPanel>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/AiModelDependenciesSection.tsx
+++ b/frontend/src/components/settings/AiModelDependenciesSection.tsx
@@ -1,0 +1,136 @@
+import { Check, Loader2, Trash2, X } from "lucide-react";
+
+import { SystemModelStatus } from "@/types";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+
+interface AiModelDependenciesSectionProps {
+  modelStatus: SystemModelStatus | null;
+  deleting: string | null;
+  handleDeleteModel: (modelName: string) => void;
+  isAdmin: boolean;
+}
+
+const DEPENDENCY_MODELS = [
+  {
+    id: "whisper",
+    label: "Whisper (Transcription)",
+    desc: "OpenAI Whisper model for speech-to-text. (MIT License)",
+  },
+  {
+    id: "parakeet",
+    label: "Parakeet ASR Model (Transcription)",
+    desc: "NVIDIA FastConformer ASR model.",
+  },
+  {
+    id: "canary",
+    label: "Canary ASR Model (Transcription)",
+    desc: "NVIDIA Canary 1B multi-lingual ASR model.",
+  },
+  {
+    id: "pyannote",
+    label: "Pyannote (Diarization)",
+    desc: "Speaker diarization model weights.",
+  },
+  {
+    id: "embedding",
+    label: "Voice Embedding",
+    desc: "Speaker identification model weights.",
+  },
+  {
+    id: "segmentation",
+    label: "Segmentation Refinement",
+    desc: "Pyannote segmentation-3.0 model weights.",
+  },
+];
+
+/** Admin-only "Model dependencies" section. Extracted verbatim from
+ * {@link AISettings} so behaviour is unchanged. */
+export default function AiModelDependenciesSection({
+  modelStatus,
+  deleting,
+  handleDeleteModel,
+  isAdmin,
+}: AiModelDependenciesSectionProps) {
+  return (
+    <SettingsSection
+      eyebrow="Administration"
+      title="Model dependencies"
+      description="Inspect and manage local AI model assets on the server."
+    >
+      <SettingsPanel className="mx-auto max-w-3xl space-y-6">
+        <div className="bg-gray-50 dark:bg-gray-900/50 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+          <div className="space-y-3">
+            {DEPENDENCY_MODELS.map((model) => (
+              <div
+                key={model.id}
+                className="flex justify-between items-center p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm"
+              >
+                <div>
+                  <div className="text-sm font-medium text-gray-900 dark:text-white">
+                    {model.label}
+                  </div>
+                  <div className="text-xs contrast-helper">{model.desc}</div>
+                </div>
+                <div className="flex items-center gap-3">
+                  {modelStatus?.[model.id]?.downloaded ? (
+                    <>
+                      <span className="text-xs bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400 px-2.5 py-1 rounded-full flex items-center gap-1 font-medium">
+                        <Check className="w-3 h-3" /> Ready
+                      </span>
+                      {modelStatus?.[model.id]?.source === "bundled" && (
+                        <span className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400 px-2.5 py-1 rounded-full font-medium">
+                          Bundled
+                        </span>
+                      )}
+                      <button
+                        onClick={() => handleDeleteModel(model.id)}
+                        disabled={
+                          deleting === model.id ||
+                          !isAdmin ||
+                          modelStatus?.[model.id]?.source === "bundled"
+                        }
+                        className="text-gray-500 dark:text-gray-400 hover:text-red-500 transition-colors p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md disabled:opacity-50"
+                        title={
+                          modelStatus?.[model.id]?.source === "bundled"
+                            ? "Bundled repo asset"
+                            : "Delete Model"
+                        }
+                      >
+                        {deleting === model.id ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="w-4 h-4" />
+                        )}
+                      </button>
+                    </>
+                  ) : (
+                    <div className="flex flex-col items-end">
+                      <span className="text-xs bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400 px-2.5 py-1 rounded-full flex items-center gap-1 font-medium">
+                        <X className="w-3 h-3" /> Missing
+                      </span>
+                      {modelStatus?.[model.id]?.checked_paths &&
+                        modelStatus[model.id].checked_paths.length > 0 && (
+                          <span
+                            className="mt-1 max-w-[200px] truncate cursor-help text-[10px] text-gray-500 dark:text-gray-400"
+                            title={`Checked paths:\n${modelStatus[model.id].checked_paths.join("\n")}`}
+                          >
+                            Hover for debug info
+                          </span>
+                        )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <p className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 text-center text-xs contrast-helper">
+            Required default models are prepared automatically. Parakeet and
+            Canary models are prepared after their settings are saved.
+          </p>
+        </div>
+      </SettingsPanel>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/AiRoutingSection.tsx
+++ b/frontend/src/components/settings/AiRoutingSection.tsx
@@ -1,0 +1,255 @@
+import type { ReactNode } from "react";
+import { Check, Cloud, Info, Server } from "lucide-react";
+
+import { Settings } from "@/types";
+import { cn } from "@/lib/cn";
+import CliOAuthPanel from "./CliOAuthPanel";
+import SettingsCallout from "./SettingsCallout";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+import SettingsStatusBadge from "./SettingsStatusBadge";
+import { checkLlmConfigured } from "./aiSettingsModels";
+import { CLI_MODEL_OPTIONS } from "./cliModels";
+
+const SELECT_CLASS =
+  "w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all";
+
+interface AiRoutingSectionProps {
+  settings: Settings;
+  /** Apply and save immediately (discrete controls). */
+  onPersist: (newSettings: Settings) => void;
+  isAdmin: boolean;
+  cliConnected: boolean;
+  onCliConnectedChange: (connected: boolean) => void;
+}
+
+/**
+ * Per-user "AI routing" section. The user picks between the server-configured
+ * provider and routing inference through their own Claude subscription (CLI
+ * OAuth). Only the controls relevant to the active choice are shown. The two
+ * former no-op options (Ollama/BYOK) were removed — they never changed
+ * resolution (they fell through to the server provider).
+ */
+export default function AiRoutingSection({
+  settings,
+  onPersist,
+  isAdmin,
+  cliConnected,
+  onCliConnectedChange,
+}: AiRoutingSectionProps) {
+  const isCli = settings.usage_model === "cli_oauth";
+  const providerConfigured = checkLlmConfigured(settings);
+  const activeProvider = settings.llm_provider || "none";
+  const secondaryProvider = settings.secondary_llm_provider;
+
+  const chooseServer = () => {
+    if (!isCli) return;
+    onPersist({ ...settings, usage_model: null });
+  };
+  const chooseCli = () => {
+    if (isCli || !cliConnected) return;
+    onPersist({ ...settings, usage_model: "cli_oauth" });
+  };
+
+  return (
+    <SettingsSection
+      eyebrow="AI"
+      title="AI routing"
+      description="Choose how AI runs for your account. This is a per-user preference and does not change anything for other users."
+      width="wide"
+    >
+      <div className="mx-auto max-w-3xl space-y-4">
+        <div
+          role="radiogroup"
+          aria-label="AI routing"
+          className="grid gap-3 sm:grid-cols-2"
+        >
+          <RoutingCard
+            selected={!isCli}
+            onSelect={chooseServer}
+            icon={<Server className="h-4 w-4" />}
+            title="Use server default"
+            description="AI runs on the provider your server administrator configured."
+          />
+          <RoutingCard
+            selected={isCli}
+            disabled={!cliConnected && !isCli}
+            onSelect={chooseCli}
+            icon={<Cloud className="h-4 w-4" />}
+            title="My Claude subscription"
+            description={
+              cliConnected || isCli
+                ? "Route AI through your own Claude Pro/Max subscription."
+                : "Connect your subscription below to enable this option."
+            }
+          />
+        </div>
+
+        <CliOAuthPanel onConnectedChange={onCliConnectedChange} />
+
+        {isCli ? (
+          <div className="space-y-4">
+            {!cliConnected && (
+              <SettingsCallout tone="warning">
+                Your Claude subscription is not connected right now. Reconnect it
+                above, or switch to the server default, so AI keeps working.
+              </SettingsCallout>
+            )}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Model for your subscription
+                </label>
+                <select
+                  value={settings.cli_model || ""}
+                  onChange={(e) =>
+                    onPersist({
+                      ...settings,
+                      cli_model: e.target.value ? e.target.value : null,
+                    })
+                  }
+                  className={SELECT_CLASS}
+                >
+                  <option value="">
+                    Claude&apos;s default (currently a Sonnet)
+                  </option>
+                  {CLI_MODEL_OPTIONS.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.label}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs contrast-helper">
+                  Used for notes, titles, speaker inference, and chat.
+                </p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Meeting Edge model for your subscription
+                </label>
+                <select
+                  value={settings.cli_live_model || ""}
+                  onChange={(e) =>
+                    onPersist({
+                      ...settings,
+                      cli_live_model: e.target.value ? e.target.value : null,
+                    })
+                  }
+                  className={SELECT_CLASS}
+                >
+                  <option value="">Same as the model above</option>
+                  {CLI_MODEL_OPTIONS.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.label}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs contrast-helper">
+                  Used for live Meeting Edge. A faster model keeps guidance
+                  responsive and conserves your subscription quota.
+                </p>
+              </div>
+            </div>
+            <SettingsCallout tone="info">
+              <span className="flex items-start gap-2">
+                <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>
+                  When your subscription is unavailable or usage-limited, Nojoin
+                  falls back to the server&apos;s secondary provider
+                  {secondaryProvider ? (
+                    <>
+                      {" "}
+                      (
+                      <span className="capitalize">{secondaryProvider}</span>)
+                    </>
+                  ) : (
+                    " (if the administrator has configured one)"
+                  )}
+                  .
+                </span>
+              </span>
+            </SettingsCallout>
+          </div>
+        ) : (
+          <SettingsPanel
+            variant="subtle"
+            className="flex items-center justify-between gap-3"
+          >
+            <div>
+              <div className="text-sm font-semibold text-gray-900 dark:text-white">
+                Server provider:{" "}
+                <span className="capitalize text-orange-600 dark:text-orange-400">
+                  {activeProvider}
+                </span>
+              </div>
+              <p className="mt-1 text-xs contrast-helper">
+                {isAdmin
+                  ? "Configured on this server. Change the provider and model in the Server provider section below."
+                  : "Configured by your server administrator. Every account on the server default shares this provider."}
+              </p>
+            </div>
+            <SettingsStatusBadge
+              tone={providerConfigured ? "success" : "warning"}
+            >
+              {providerConfigured ? "Configured" : "Not configured"}
+            </SettingsStatusBadge>
+          </SettingsPanel>
+        )}
+      </div>
+    </SettingsSection>
+  );
+}
+
+function RoutingCard({
+  selected,
+  disabled = false,
+  onSelect,
+  icon,
+  title,
+  description,
+}: {
+  selected: boolean;
+  disabled?: boolean;
+  onSelect: () => void;
+  icon: ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      disabled={disabled}
+      onClick={onSelect}
+      className={cn(
+        "flex flex-col gap-2 rounded-2xl border p-4 text-left transition-all",
+        selected
+          ? "border-orange-500 bg-orange-50/60 shadow-sm dark:border-orange-500/50 dark:bg-orange-500/10"
+          : "border-gray-200 bg-white hover:border-gray-300 hover:shadow-sm dark:border-gray-700 dark:bg-gray-950/60 dark:hover:border-gray-600",
+        disabled &&
+          "cursor-not-allowed opacity-60 hover:border-gray-200 hover:shadow-none dark:hover:border-gray-700",
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
+          <span className={selected ? "text-orange-500" : "contrast-icon-muted"}>
+            {icon}
+          </span>
+          {title}
+        </span>
+        <span
+          className={cn(
+            "flex h-5 w-5 items-center justify-center rounded-full border",
+            selected
+              ? "border-orange-500 bg-orange-500 text-white"
+              : "border-gray-300 dark:border-gray-600",
+          )}
+        >
+          {selected && <Check className="h-3 w-3" />}
+        </span>
+      </div>
+      <p className="text-xs leading-5 contrast-helper">{description}</p>
+    </button>
+  );
+}

--- a/frontend/src/components/settings/AiTranscriptionSection.tsx
+++ b/frontend/src/components/settings/AiTranscriptionSection.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { HelpCircle } from "lucide-react";
+
+import { Settings } from "@/types";
+import Tooltip from "@/components/ui/Tooltip";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+import WhisperModelModal from "./WhisperModelModal";
+
+const WHISPER_MODELS = [
+  { id: "tiny", label: "Tiny", params: "39 M", vram: "~1 GB", speed: "~10x" },
+  { id: "base", label: "Base", params: "74 M", vram: "~1 GB", speed: "~7x" },
+  { id: "small", label: "Small", params: "244 M", vram: "~2 GB", speed: "~4x" },
+  {
+    id: "medium",
+    label: "Medium",
+    params: "769 M",
+    vram: "~5 GB",
+    speed: "~2x",
+  },
+  {
+    id: "large",
+    label: "Large",
+    params: "1550 M",
+    vram: "~10 GB",
+    speed: "1x",
+  },
+  { id: "turbo", label: "Turbo", params: "809 M", vram: "~6 GB", speed: "~8x" },
+];
+
+interface AiTranscriptionSectionProps {
+  settings: Settings;
+  /** Apply and save immediately (engine and model are discrete controls). */
+  onPersist: (newSettings: Settings) => void;
+  isAdmin: boolean;
+}
+
+/** Admin-only "Transcription model" section. */
+export default function AiTranscriptionSection({
+  settings,
+  onPersist,
+  isAdmin,
+}: AiTranscriptionSectionProps) {
+  const [showWhisperModal, setShowWhisperModal] = useState(false);
+
+  return (
+    <SettingsSection
+      eyebrow="Administration"
+      title="Transcription model"
+      description="Choose the engine Nojoin uses for live and final transcription during normal recording."
+      width="regular"
+    >
+      <SettingsPanel className="mx-auto max-w-3xl space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            <Tooltip
+              content="Select the transcription engine used for speech to text."
+              position="right"
+            >
+              <span className="flex items-center gap-1 cursor-help">
+                Transcription engine{" "}
+                <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
+              </span>
+            </Tooltip>
+          </label>
+          <select
+            value={settings.transcription_backend || "whisper"}
+            onChange={(e) =>
+              onPersist({
+                ...settings,
+                transcription_backend: e.target.value,
+              })
+            }
+            disabled={!isAdmin}
+            className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
+          >
+            <option value="whisper">Whisper</option>
+            <option value="parakeet">Parakeet (NVIDIA)</option>
+            <option value="canary">Canary 1B (NVIDIA)</option>
+          </select>
+        </div>
+        {(settings.transcription_backend || "whisper") === "parakeet" ? (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Parakeet Model
+            </label>
+            <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
+              <div className="flex-1">
+                <div className="font-semibold text-gray-900 dark:text-white">
+                  {settings.parakeet_model || "parakeet-tdt-0.6b-v3"}
+                </div>
+                <p className="mt-1 text-xs contrast-helper">
+                  Fast NVIDIA transcription with slightly lower accuracy and
+                  fewer supported languages than Whisper.
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : (settings.transcription_backend || "whisper") === "canary" ? (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Canary Model
+            </label>
+            <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
+              <div className="flex-1">
+                <div className="font-semibold text-gray-900 dark:text-white">
+                  {settings.canary_model || "nemo-canary-1b-v2"}
+                </div>
+                <p className="mt-1 text-xs contrast-helper">
+                  Current active model for transcription.
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+              Whisper Model Size
+              <div className="group relative">
+                <HelpCircle className="w-4 h-4 text-gray-500 dark:text-gray-400 cursor-help" />
+                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-80 p-4 bg-gray-900 text-white text-xs rounded-lg shadow-xl z-50 pointer-events-none">
+                  <div className="font-bold mb-2 text-sm">Available Models</div>
+                  <div className="grid grid-cols-5 gap-2 border-b border-gray-700 pb-2 mb-2 font-semibold">
+                    <div className="col-span-1">Size</div>
+                    <div className="col-span-1">Params</div>
+                    <div className="col-span-1">VRAM</div>
+                    <div className="col-span-1">Speed</div>
+                  </div>
+                  {WHISPER_MODELS.map((m) => (
+                    <div key={m.id} className="grid grid-cols-5 gap-2 mb-1">
+                      <div className="col-span-1 font-medium text-orange-400">
+                        {m.label}
+                      </div>
+                      <div className="col-span-1 text-gray-300">{m.params}</div>
+                      <div className="col-span-1 text-gray-300">{m.vram}</div>
+                      <div className="col-span-1 text-gray-300">{m.speed}</div>
+                    </div>
+                  ))}
+                  <div className="mt-2 text-gray-300 italic">
+                    Turbo is the recommended default for best balance of speed
+                    and accuracy.
+                  </div>
+                </div>
+              </div>
+            </label>
+
+            <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-gray-900 dark:text-white">
+                    {WHISPER_MODELS.find(
+                      (m) => m.id === (settings.whisper_model_size || "turbo"),
+                    )?.label || settings.whisper_model_size}
+                  </span>
+                  <span className="text-sm text-gray-500">
+                    (
+                    {
+                      WHISPER_MODELS.find(
+                        (m) => m.id === (settings.whisper_model_size || "turbo"),
+                      )?.vram
+                    }{" "}
+                    VRAM)
+                  </span>
+                </div>
+                <p className="mt-1 text-xs contrast-helper">
+                  Current active model for transcription.
+                </p>
+              </div>
+              <button
+                onClick={() => setShowWhisperModal(true)}
+                disabled={!isAdmin}
+                className="px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
+              >
+                Change Model
+              </button>
+            </div>
+            <p className="mt-2 text-xs contrast-helper">
+              Click &apos;Change Model&apos; to select a different Whisper model
+              variant. Missing model files are prepared automatically after the
+              change is saved.
+            </p>
+          </div>
+        )}
+        <WhisperModelModal
+          isOpen={showWhisperModal}
+          onClose={() => setShowWhisperModal(false)}
+          currentSize={settings.whisper_model_size || "turbo"}
+          isAdmin={isAdmin}
+          onUpdate={(newSize) =>
+            onPersist({ ...settings, whisper_model_size: newSize })
+          }
+        />
+      </SettingsPanel>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/CliOAuthPanel.tsx
+++ b/frontend/src/components/settings/CliOAuthPanel.tsx
@@ -18,6 +18,13 @@ function parseUtcDate(value?: string | null): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/** Compact token count, e.g. 1.2M / 340K / 512. */
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
 /**
  * Connect panel for routing AI through a user's own Claude subscription.
  *
@@ -156,6 +163,19 @@ export default function CliOAuthPanel({
           configured) is used until then.
         </p>
       )}
+
+      {connected &&
+        typeof status?.tokens_7d === "number" &&
+        status.tokens_7d > 0 && (
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            You&apos;ve used {formatTokens(status.tokens_7d)} tokens in the last
+            7 days
+            {typeof status?.tokens_total === "number"
+              ? ` (${formatTokens(status.tokens_total)} all time)`
+              : ""}
+            .
+          </p>
+        )}
 
       {!connected && (
         <button

--- a/frontend/src/components/settings/CliOAuthPanel.tsx
+++ b/frontend/src/components/settings/CliOAuthPanel.tsx
@@ -23,8 +23,9 @@ function parseUtcDate(value?: string | null): Date | null {
  *
  * Nojoin drives the PKCE OAuth: "Connect" opens Anthropic's authorize page in a
  * new tab and a modal to paste back the code Anthropic shows. Nojoin exchanges
- * the code server-side and stores the tokens encrypted. Selecting CLI OAuth as
- * the active usage model is enabled in a later milestone.
+ * the code server-side and stores the tokens encrypted. Once connected, the
+ * user selects "My Claude subscription" in the AI routing section to route
+ * inference through it.
  */
 export default function CliOAuthPanel({
   onConnectedChange,

--- a/frontend/src/components/settings/CliUsageTab.tsx
+++ b/frontend/src/components/settings/CliUsageTab.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useState } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+
+import { CliUsageRow } from "@/types";
+import { getCliUsageOverview } from "@/lib/api/cliOauth";
+import { useNotificationStore } from "@/lib/notificationStore";
+import SettingsCallout from "./SettingsCallout";
+import SettingsPanel from "./SettingsPanel";
+
+const PAGE_SIZE = 10;
+
+/** Compact token count, e.g. 1.2M / 340K / 512. */
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+// Backend datetimes are naive UTC; ensure Date parses them as UTC.
+function parseUtcDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const iso = /[zZ]|[+-]\d\d:?\d\d$/.test(value) ? value : `${value}Z`;
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+type QuotaTone = "success" | "warning" | "error" | "neutral";
+
+const TONE_CLASS: Record<QuotaTone, string> = {
+  success:
+    "bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300",
+  warning: "bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-300",
+  error: "bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300",
+  neutral: "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300",
+};
+
+/**
+ * Map a row to a quota pill. A Claude subscription exposes no live remaining
+ * quota, so this reflects the rate-limit signal (status + reset time) plus the
+ * best-effort utilisation percentage of the current window when known.
+ */
+function quotaPill(row: CliUsageRow): { label: string; tone: QuotaTone } {
+  const limitedUntil = parseUtcDate(row.usage_limited_until);
+  const util =
+    typeof row.utilization === "number"
+      ? Math.round(row.utilization * 100)
+      : null;
+
+  if (limitedUntil && limitedUntil.getTime() > Date.now()) {
+    return {
+      label: `Limited until ${limitedUntil.toLocaleString()}`,
+      tone: "error",
+    };
+  }
+  if (!row.connected) {
+    return { label: "Not connected", tone: "neutral" };
+  }
+  if (row.rate_limit_status === "allowed_warning") {
+    return {
+      label: util !== null ? `Approaching (${util}%)` : "Approaching",
+      tone: "warning",
+    };
+  }
+  return { label: util !== null ? `OK (${util}%)` : "OK", tone: "success" };
+}
+
+/**
+ * Admin-only table of per-user CLI (Claude subscription) token usage and
+ * rate-limit status. Read-only; the data is written by the worker as users run
+ * inference through their own subscriptions.
+ */
+export default function CliUsageTab() {
+  const [rows, setRows] = useState<CliUsageRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const { addNotification } = useNotificationStore();
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 500);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const fetchUsage = async () => {
+    setLoading(true);
+    try {
+      const data = await getCliUsageOverview(
+        (page - 1) * PAGE_SIZE,
+        PAGE_SIZE,
+        debouncedSearch,
+      );
+      setRows(data.items);
+      setTotal(data.total);
+    } catch {
+      addNotification({ message: "Failed to load CLI usage", type: "error" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, debouncedSearch]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-4">
+      <SettingsCallout tone="info">
+        Tokens are what Nojoin sent through each user&apos;s own Claude
+        subscription. A subscription exposes no live remaining-quota figure, so
+        status shows the rate-limit signal (OK, approaching, or limited), not a
+        balance.
+      </SettingsCallout>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative w-full sm:max-w-xs">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400" />
+          <input
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            placeholder="Search users..."
+            className="w-full pl-9 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
+        </div>
+        <button
+          onClick={fetchUsage}
+          disabled={loading}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-300 dark:border-gray-700 px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 transition hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </button>
+      </div>
+
+      <SettingsPanel className="overflow-hidden p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm text-gray-800 dark:text-gray-200 whitespace-nowrap">
+            <thead className="bg-gray-100 dark:bg-gray-900/80 text-gray-800 dark:text-gray-100 uppercase font-medium">
+              <tr>
+                <th className="px-4 py-3">User</th>
+                <th className="px-4 py-3 text-right">Last 7 days</th>
+                <th className="px-4 py-3 text-right">Last 30 days</th>
+                <th className="px-4 py-3 text-right">Lifetime</th>
+                <th className="px-4 py-3 text-right">Requests</th>
+                <th className="px-4 py-3">Quota status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-300 dark:divide-gray-600">
+              {loading ? (
+                <tr>
+                  <td colSpan={6} className="p-4 text-center">
+                    <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+                  </td>
+                </tr>
+              ) : rows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="p-6 text-center text-gray-500 dark:text-gray-400"
+                  >
+                    No CLI subscription usage recorded yet.
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row) => {
+                  const pill = quotaPill(row);
+                  const lastUsed = parseUtcDate(row.last_used_on);
+                  return (
+                    <tr
+                      key={row.user_id}
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700/40"
+                    >
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-gray-900 dark:text-white">
+                          {row.username}
+                        </div>
+                        {lastUsed && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400">
+                            Last used {lastUsed.toLocaleDateString()}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        {formatTokens(row.tokens_7d)}
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        {formatTokens(row.tokens_30d)}
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        {formatTokens(row.tokens_total)}
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        {row.requests_total}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`px-2 py-0.5 rounded text-xs ${TONE_CLASS[pill.tone]}`}
+                        >
+                          {pill.label}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex items-center justify-between border-t border-gray-200 dark:border-gray-700 px-4 py-3">
+          <div className="text-sm contrast-helper">
+            Showing {rows.length > 0 ? (page - 1) * PAGE_SIZE + 1 : 0} to{" "}
+            {Math.min(page * PAGE_SIZE, total)} of {total} users
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="p-1 rounded text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages}
+              className="p-1 rounded text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+            >
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+      </SettingsPanel>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/MeetingEdgeSection.tsx
+++ b/frontend/src/components/settings/MeetingEdgeSection.tsx
@@ -1,0 +1,186 @@
+import { HelpCircle } from "lucide-react";
+
+import { Settings } from "@/types";
+import {
+  clampMeetingEdgeContextLevel,
+  MEETING_EDGE_CONTEXT_OPTIONS,
+} from "@/lib/meetingEdgeContext";
+import Tooltip from "@/components/ui/Tooltip";
+import { Switch } from "@/components/ui/Switch";
+import SettingsCallout from "./SettingsCallout";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+import SettingsStatusBadge from "./SettingsStatusBadge";
+import type { AISettingsModels } from "./useAISettingsModels";
+import {
+  getModelOptionsForProvider,
+  getSelectedModelForProvider,
+  withSelectedModelForProvider,
+} from "./aiSettingsModels";
+
+const SELECT_CLASS =
+  "w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50";
+
+interface MeetingEdgeSectionProps {
+  settings: Settings;
+  /** Debounced apply (the technical-context slider). */
+  onUpdate: (newSettings: Settings) => void;
+  /** Apply and save immediately (the enable toggle and model select). */
+  onPersist: (newSettings: Settings) => void;
+  isAdmin: boolean;
+  models: AISettingsModels;
+}
+
+/**
+ * "Meeting Edge" section. Mixed scope, so scope is labelled per control:
+ * `enable_meeting_edge` and the live model are install-wide (admin only, hidden
+ * for non-admins), while `meeting_edge_context_level` is a genuine per-user
+ * preference shown to everyone.
+ */
+export default function MeetingEdgeSection({
+  settings,
+  onUpdate,
+  onPersist,
+  isAdmin,
+  models,
+}: MeetingEdgeSectionProps) {
+  const enabled = settings.enable_meeting_edge !== false;
+  const contextLevel = clampMeetingEdgeContextLevel(
+    settings.meeting_edge_context_level,
+  );
+  const selectedOption =
+    MEETING_EDGE_CONTEXT_OPTIONS.find(
+      (option) => option.value === contextLevel,
+    ) ?? MEETING_EDGE_CONTEXT_OPTIONS[1];
+  const liveModelOptions = getModelOptionsForProvider(
+    settings,
+    models.availableModels,
+    "live",
+  );
+  const selectedLiveModel = getSelectedModelForProvider(settings, "live");
+
+  return (
+    <SettingsSection
+      eyebrow="AI"
+      title="Meeting Edge"
+      description="Live, in-meeting guidance that surfaces context and clarifies terms while you record."
+      width="wide"
+    >
+      <div className="mx-auto max-w-3xl space-y-4">
+        <SettingsPanel className="space-y-6">
+          {isAdmin ? (
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white">
+                  Enable Meeting Edge
+                </div>
+                <p className="mt-1 text-xs contrast-helper">
+                  Turns the live advisory card and its model calls on for every
+                  account on this server.
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <SettingsStatusBadge tone="neutral">Admin-wide</SettingsStatusBadge>
+                <Switch
+                  checked={enabled}
+                  onCheckedChange={(checked) =>
+                    onPersist({ ...settings, enable_meeting_edge: checked })
+                  }
+                />
+              </div>
+            </div>
+          ) : (
+            !enabled && (
+              <SettingsCallout tone="neutral">
+                Meeting Edge is currently turned off by your server
+                administrator.
+              </SettingsCallout>
+            )
+          )}
+
+          {isAdmin && (
+            <div>
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
+                <Tooltip
+                  content="Optional separate model for live Meeting Edge guidance. Leave blank to reuse the main server model."
+                  position="right"
+                >
+                  <span className="flex items-center gap-1 cursor-help">
+                    Meeting Edge model{" "}
+                    <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
+                  </span>
+                </Tooltip>
+                <SettingsStatusBadge tone="neutral">Admin-wide</SettingsStatusBadge>
+              </label>
+              <select
+                value={selectedLiveModel}
+                onChange={(e) =>
+                  onPersist(withSelectedModelForProvider(settings, "live", e.target.value))
+                }
+                disabled={!enabled || liveModelOptions.length === 0}
+                className={SELECT_CLASS}
+              >
+                <option value="">Use main model</option>
+                {liveModelOptions.map((model) => (
+                  <option key={`meeting-edge-${model}`} value={model}>
+                    {model}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs contrast-helper">
+                A faster model keeps live guidance responsive.
+              </p>
+            </div>
+          )}
+
+          <div className="rounded-xl border border-orange-200/70 bg-orange-50/45 p-4 dark:border-orange-500/20 dark:bg-orange-500/5">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+                  Technical context
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.14em] contrast-helper">
+                    Your preference
+                  </span>
+                </div>
+                <p className="mt-1 text-xs leading-5 text-gray-600 dark:text-gray-300">
+                  Control how readily Meeting Edge explains terms in the Technical
+                  Context section.
+                </p>
+              </div>
+              <span className="inline-flex items-center rounded-full border border-orange-200 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-orange-700 dark:border-orange-500/20 dark:bg-gray-900 dark:text-orange-300">
+                {selectedOption.label || `Level ${selectedOption.value}`}
+              </span>
+            </div>
+
+            <input
+              type="range"
+              min={1}
+              max={5}
+              step={1}
+              value={contextLevel}
+              onChange={(e) =>
+                onUpdate({
+                  ...settings,
+                  meeting_edge_context_level: Number(e.target.value),
+                })
+              }
+              disabled={!enabled}
+              aria-label="Meeting Edge Technical Context sensitivity"
+              className="mt-4 w-full accent-orange-500 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+
+            <div className="mt-3 grid grid-cols-5 gap-2 text-center text-[11px] font-medium text-gray-500 dark:text-gray-400">
+              {MEETING_EDGE_CONTEXT_OPTIONS.map((option) => (
+                <span key={option.value}>{option.label}</span>
+              ))}
+            </div>
+
+            <p className="mt-3 text-xs leading-5 text-gray-600 dark:text-gray-300">
+              {selectedOption.description}
+            </p>
+          </div>
+        </SettingsPanel>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/SecondaryProviderSection.tsx
+++ b/frontend/src/components/settings/SecondaryProviderSection.tsx
@@ -1,0 +1,275 @@
+import { Check, HelpCircle, Loader2, RefreshCw, Server } from "lucide-react";
+
+import { Settings } from "@/types";
+import { listModels } from "@/lib/api";
+import Tooltip from "@/components/ui/Tooltip";
+import SettingsCallout from "./SettingsCallout";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+import SettingsStatusBadge from "./SettingsStatusBadge";
+import type { AISettingsModels } from "./useAISettingsModels";
+import {
+  DEFAULT_OLLAMA_CONTEXT_WINDOW,
+  getSecondaryProviderApiKey,
+  getSecondaryProviderLiveModel,
+  getSecondaryProviderModel,
+  parseContextWindow,
+  withSecondaryProviderLiveModel,
+  withSecondaryProviderModel,
+} from "./aiSettingsModels";
+
+const SELECT_CLASS =
+  "w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50";
+
+interface SecondaryProviderSectionProps {
+  settings: Settings;
+  /** Debounced apply (Ollama URL and context window). */
+  onUpdate: (newSettings: Settings) => void;
+  /** Apply and save immediately (model selects). */
+  onPersist: (newSettings: Settings) => void;
+  models: AISettingsModels;
+}
+
+/**
+ * Admin-only "Fallback provider" section. All secondary_* fields are
+ * install-wide (and some are .env-overridden), so the orchestrator renders this
+ * only for admins. Used automatically when the primary provider — or a user's
+ * CLI subscription — is unavailable.
+ */
+export default function SecondaryProviderSection({
+  settings,
+  onUpdate,
+  onPersist,
+  models,
+}: SecondaryProviderSectionProps) {
+  const sp = settings.secondary_llm_provider;
+
+  if (!sp) {
+    return (
+      <SettingsSection
+        eyebrow="AI"
+        title="Fallback provider"
+        badge={<SettingsStatusBadge tone="neutral">Managed by server</SettingsStatusBadge>}
+        description="Used automatically when the primary provider is unavailable."
+        width="wide"
+      >
+        <SettingsCallout tone="neutral" className="mx-auto max-w-3xl">
+          No fallback provider is configured. Set{" "}
+          <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+            SECONDARY_LLM_PROVIDER
+          </code>{" "}
+          in the server&apos;s{" "}
+          <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+            .env
+          </code>{" "}
+          file to enable automatic fallback for all AI features when the primary
+          provider fails.
+        </SettingsCallout>
+      </SettingsSection>
+    );
+  }
+
+  const isOllama = sp === "ollama";
+  const configured = isOllama
+    ? Boolean(settings.secondary_ollama_api_url)
+    : Boolean(getSecondaryProviderApiKey(settings, sp));
+  const secondaryModel = getSecondaryProviderModel(settings, sp);
+  const secondaryLiveModel = getSecondaryProviderLiveModel(settings, sp);
+
+  const refreshModels = () => {
+    const url = isOllama ? settings.secondary_ollama_api_url : undefined;
+    models.setSecondaryFetchingModels(true);
+    listModels(sp, "", url)
+      .then((res) => models.setSecondaryAvailableModels(res.models))
+      .catch(console.error)
+      .finally(() => models.setSecondaryFetchingModels(false));
+  };
+
+  const applyModel = (value: string) => {
+    const updates = withSecondaryProviderModel(settings, sp, value);
+    if (updates) onPersist(updates);
+  };
+  const applyLiveModel = (value: string) => {
+    const updates = withSecondaryProviderLiveModel(settings, sp, value);
+    if (updates) onPersist(updates);
+  };
+
+  return (
+    <SettingsSection
+      eyebrow="AI"
+      title="Fallback provider"
+      badge={<SettingsStatusBadge tone="neutral">Managed by server</SettingsStatusBadge>}
+      description="Used automatically when the primary provider — or a user's own Claude subscription — is unavailable."
+      width="wide"
+    >
+      <div className="mx-auto max-w-3xl space-y-4">
+        <SettingsPanel className="space-y-6">
+          <div className="p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center justify-between gap-3">
+            <div>
+              <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                Secondary AI provider:{" "}
+                <span className="capitalize text-orange-600 dark:text-orange-400">
+                  {sp}
+                </span>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                Configured via{" "}
+                <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                  SECONDARY_LLM_PROVIDER
+                </code>{" "}
+                in the server&apos;s{" "}
+                <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                  .env
+                </code>{" "}
+                file.
+              </p>
+            </div>
+            <SettingsStatusBadge tone={configured ? "success" : "warning"}>
+              {configured ? "Configured" : "Not configured"}
+            </SettingsStatusBadge>
+          </div>
+
+          {isOllama && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Secondary Ollama API URL
+                </label>
+                <div className="relative">
+                  <input
+                    type="text"
+                    value={
+                      settings.secondary_ollama_api_url ||
+                      "http://host.docker.internal:11434"
+                    }
+                    onChange={(e) =>
+                      onUpdate({
+                        ...settings,
+                        secondary_ollama_api_url: e.target.value,
+                      })
+                    }
+                    className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
+                  />
+                  <Server className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Secondary Ollama context window
+                </label>
+                <input
+                  type="number"
+                  min={1024}
+                  step={1024}
+                  value={
+                    settings.secondary_ollama_context_window ||
+                    DEFAULT_OLLAMA_CONTEXT_WINDOW
+                  }
+                  onChange={(e) =>
+                    onUpdate({
+                      ...settings,
+                      secondary_ollama_context_window: parseContextWindow(
+                        e.target.value,
+                      ),
+                    })
+                  }
+                  className="w-full px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
+                />
+              </div>
+            </div>
+          )}
+
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex justify-between">
+              <Tooltip
+                content="The model for the fallback provider. Used when the primary is unavailable."
+                position="right"
+              >
+                <span className="flex items-center gap-1 cursor-help">
+                  Model{" "}
+                  <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
+                </span>
+              </Tooltip>
+              <button
+                onClick={refreshModels}
+                disabled={models.secondaryFetchingModels}
+                className="text-xs text-orange-500 hover:text-orange-600 flex items-center gap-1 disabled:opacity-50"
+              >
+                <RefreshCw
+                  className={`w-3 h-3 ${models.secondaryFetchingModels ? "animate-spin" : ""}`}
+                />{" "}
+                Refresh
+              </button>
+            </label>
+            <select
+              value={secondaryModel}
+              onChange={(e) => applyModel(e.target.value)}
+              disabled={models.secondaryAvailableModels.length === 0}
+              className={SELECT_CLASS}
+            >
+              <option value="" disabled>
+                Select a model...
+              </option>
+              {models.secondaryAvailableModels.map((model) => (
+                <option key={`secondary-${model}`} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-1">
+              <Tooltip
+                content="Optional separate model for Meeting Edge when using the fallback provider. Leave blank to reuse the fallback model."
+                position="right"
+              >
+                <span className="flex items-center gap-1 cursor-help">
+                  Meeting Edge model{" "}
+                  <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
+                </span>
+              </Tooltip>
+            </label>
+            <select
+              value={secondaryLiveModel}
+              onChange={(e) => applyLiveModel(e.target.value)}
+              disabled={models.secondaryAvailableModels.length === 0}
+              className={SELECT_CLASS}
+            >
+              <option value="">Use fallback model</option>
+              {models.secondaryAvailableModels.map((model) => (
+                <option key={`secondary-live-${model}`} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {configured && (
+            <div>
+              <button
+                onClick={() => models.handleValidate(sp || "gemini")}
+                disabled={Boolean(models.validating)}
+                className="px-4 py-2.5 bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 flex items-center gap-2 text-sm font-semibold"
+              >
+                {models.validating === sp ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Check className="w-4 h-4" />
+                )}
+                Validate fallback connection
+              </button>
+              {models.validationMsg && models.validationMsg.provider === sp && (
+                <p
+                  className={`mt-2 text-sm font-semibold ${models.validationMsg.type === "success" ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
+                >
+                  {models.validationMsg.msg}
+                </p>
+              )}
+            </div>
+          )}
+        </SettingsPanel>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/ServerProviderSection.tsx
+++ b/frontend/src/components/settings/ServerProviderSection.tsx
@@ -1,0 +1,215 @@
+import { Check, HelpCircle, Info, Loader2, RefreshCw, Server } from "lucide-react";
+
+import { Settings } from "@/types";
+import { listModels } from "@/lib/api";
+import Tooltip from "@/components/ui/Tooltip";
+import SettingsPanel from "./SettingsPanel";
+import SettingsSection from "./SettingsSection";
+import SettingsStatusBadge from "./SettingsStatusBadge";
+import type { AISettingsModels } from "./useAISettingsModels";
+import {
+  DEFAULT_OLLAMA_CONTEXT_WINDOW,
+  checkLlmConfigured,
+  getModelOptionsForProvider,
+  getSelectedModelForProvider,
+  parseContextWindow,
+  withSelectedModelForProvider,
+} from "./aiSettingsModels";
+
+const SELECT_CLASS =
+  "w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50";
+
+interface ServerProviderSectionProps {
+  settings: Settings;
+  /** Debounced apply (continuous controls such as the context window). */
+  onUpdate: (newSettings: Settings) => void;
+  /** Apply and save immediately (discrete controls such as the model). */
+  onPersist: (newSettings: Settings) => void;
+  models: AISettingsModels;
+}
+
+/**
+ * Admin-only "Server provider" section. Every field here is install-wide (see
+ * config_manager.INSTALL_WIDE_AI_SETTING_KEYS) and some are overridden by the
+ * server's .env; the orchestrator renders this section only for admins so
+ * non-admins never see controls whose edits would be silently discarded.
+ */
+export default function ServerProviderSection({
+  settings,
+  onUpdate,
+  onPersist,
+  models,
+}: ServerProviderSectionProps) {
+  const providerConfigured = checkLlmConfigured(settings);
+  const mainModelOptions = getModelOptionsForProvider(
+    settings,
+    models.availableModels,
+    "main",
+  );
+  const selectedMainModel = getSelectedModelForProvider(settings, "main");
+  const isOllama = settings.llm_provider === "ollama";
+  const provider = settings.llm_provider || "gemini";
+
+  const refreshModels = () => {
+    const url = provider === "ollama" ? settings.ollama_api_url : undefined;
+    models.setFetchingModels(true);
+    listModels(provider, "", url)
+      .then((res) => models.setAvailableModels(res.models))
+      .catch(console.error)
+      .finally(() => models.setFetchingModels(false));
+  };
+
+  return (
+    <SettingsSection
+      eyebrow="AI"
+      title="Server provider"
+      badge={<SettingsStatusBadge tone="neutral">Managed by server</SettingsStatusBadge>}
+      description="The provider and model this server uses for every account on the server default. Some fields are set in the server's .env file and shown here for reference."
+      width="wide"
+    >
+      <div className="mx-auto max-w-3xl space-y-4">
+        <SettingsPanel className="space-y-6">
+          <div className="p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center justify-between gap-3">
+            <div>
+              <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                Active AI provider:{" "}
+                <span className="capitalize text-orange-600 dark:text-orange-400">
+                  {settings.llm_provider || "None"}
+                </span>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                The provider and API keys are configured in the server&apos;s
+                environment variable file (
+                <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                  .env
+                </code>
+                ).
+              </p>
+            </div>
+            <SettingsStatusBadge tone={providerConfigured ? "success" : "warning"}>
+              {providerConfigured ? "Configured via server (.env)" : "Not configured"}
+            </SettingsStatusBadge>
+          </div>
+
+          {isOllama && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Ollama API URL
+                </label>
+                <div className="relative">
+                  <input
+                    type="text"
+                    value={
+                      settings.ollama_api_url ||
+                      "http://host.docker.internal:11434"
+                    }
+                    disabled
+                    className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100/50 dark:bg-gray-800/50 text-gray-500 dark:text-gray-400 cursor-not-allowed outline-none"
+                  />
+                  <Server className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                </div>
+                <p className="mt-1 text-xs text-yellow-600 dark:text-yellow-400 flex items-center gap-1">
+                  <Info className="w-3 h-3" />
+                  Local models run on your hardware. Performance depends on your
+                  GPU/CPU.
+                </p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Ollama context window
+                </label>
+                <input
+                  type="number"
+                  min={1024}
+                  step={1024}
+                  value={
+                    settings.ollama_context_window ||
+                    DEFAULT_OLLAMA_CONTEXT_WINDOW
+                  }
+                  onChange={(e) =>
+                    onUpdate({
+                      ...settings,
+                      ollama_context_window: parseContextWindow(e.target.value),
+                    })
+                  }
+                  className="w-full px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
+                />
+                <p className="mt-1 text-xs contrast-helper">
+                  Passed to Ollama as <code>num_ctx</code> for full-context
+                  meeting prompts.
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex justify-between">
+              <Tooltip
+                content="The model this provider uses for notes, titles, speaker inference, and chat."
+                position="right"
+              >
+                <span className="flex items-center gap-1 cursor-help">
+                  Model{" "}
+                  <HelpCircle className="w-3 h-3 text-gray-500 dark:text-gray-400" />
+                </span>
+              </Tooltip>
+              <button
+                onClick={refreshModels}
+                disabled={models.fetchingModels || !providerConfigured}
+                className="text-xs text-orange-500 hover:text-orange-600 flex items-center gap-1 disabled:opacity-50"
+              >
+                <RefreshCw
+                  className={`w-3 h-3 ${models.fetchingModels ? "animate-spin" : ""}`}
+                />{" "}
+                Refresh
+              </button>
+            </label>
+            <select
+              value={selectedMainModel}
+              onChange={(e) =>
+                onPersist(withSelectedModelForProvider(settings, "main", e.target.value))
+              }
+              disabled={mainModelOptions.length === 0 || !providerConfigured}
+              className={SELECT_CLASS}
+            >
+              <option value="" disabled>
+                Select a model...
+              </option>
+              {mainModelOptions.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {providerConfigured && (
+            <div>
+              <button
+                onClick={() => models.handleValidate(settings.llm_provider || "gemini")}
+                disabled={Boolean(models.validating)}
+                className="px-4 py-2.5 bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 flex items-center gap-2 text-sm font-semibold"
+              >
+                {models.validating === settings.llm_provider ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Check className="w-4 h-4" />
+                )}
+                Validate API connection
+              </button>
+              {models.validationMsg &&
+                models.validationMsg.provider === settings.llm_provider && (
+                  <p
+                    className={`mt-2 text-sm font-semibold ${models.validationMsg.type === "success" ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
+                  >
+                    {models.validationMsg.msg}
+                  </p>
+                )}
+            </div>
+          )}
+        </SettingsPanel>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/cliModels.ts
+++ b/frontend/src/components/settings/cliModels.ts
@@ -1,0 +1,21 @@
+// Curated CLI OAuth models (a subscription exposes no models endpoint). Ids
+// mirror the backend's _CLI_MODELS (most-capable first); `label` is the full,
+// unambiguous model name shown in pickers and usage tables — never a bare
+// "Claude Sonnet", since the list now holds two Sonnets.
+export interface CliModelOption {
+  id: string;
+  label: string;
+}
+
+export const CLI_MODEL_OPTIONS: CliModelOption[] = [
+  { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
+  { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+  { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
+];
+
+/** Full model name for a stored CLI model id, falling back to the raw id. */
+export function cliModelLabel(id?: string | null): string {
+  if (!id) return "";
+  return CLI_MODEL_OPTIONS.find((model) => model.id === id)?.label ?? id;
+}

--- a/frontend/src/lib/api/cliOauth.ts
+++ b/frontend/src/lib/api/cliOauth.ts
@@ -1,8 +1,20 @@
-import type { CliOAuthStatus } from "@/types";
+import type { CliOAuthStatus, CliUsageOverview } from "@/types";
 import api from "./client";
 
 export const getCliOAuthStatus = async (): Promise<CliOAuthStatus> => {
   const response = await api.get<CliOAuthStatus>("/cli-oauth/status");
+  return response.data;
+};
+
+/** Admin-only: per-user CLI token usage + rate-limit status (paginated). */
+export const getCliUsageOverview = async (
+  skip = 0,
+  limit = 25,
+  search = "",
+): Promise<CliUsageOverview> => {
+  const response = await api.get<CliUsageOverview>("/cli-oauth/admin/usage", {
+    params: { skip, limit, search },
+  });
   return response.data;
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -332,7 +332,10 @@ export interface Settings {
   theme?: string;
   timezone?: string;
   llm_provider?: string;
-  usage_model?: string | null;
+  // Per-user AI routing. "cli_oauth" routes through the user's Claude
+  // subscription; the legacy "ollama"/"byok" values are no-ops kept only for
+  // back-compat (they resolve via the install-wide llm_provider unchanged).
+  usage_model?: "ollama" | "byok" | "cli_oauth" | null;
   cli_model?: string | null;
   cli_live_model?: string | null;
   gemini_api_key?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -383,6 +383,30 @@ export interface CliOAuthStatus {
   token_expires_at?: string | null;
   connected_at?: string | null;
   usage_limited_until?: string | null;
+  // This user's own recorded CLI token usage (input + output).
+  tokens_7d?: number | null;
+  tokens_total?: number | null;
+}
+
+/** One user's CLI usage + quota status for the admin overview table. */
+export interface CliUsageRow {
+  user_id: number;
+  username: string;
+  connected: boolean;
+  tokens_total: number;
+  tokens_7d: number;
+  tokens_30d: number;
+  requests_total: number;
+  last_used_on?: string | null;
+  rate_limit_status?: string | null;
+  rate_limit_type?: string | null;
+  utilization?: number | null;
+  usage_limited_until?: string | null;
+}
+
+export interface CliUsageOverview {
+  items: CliUsageRow[];
+  total: number;
 }
 
 export interface LanguageChoice {


### PR DESCRIPTION
## Description

Overhauls the **Settings → AI** page and adds a per-user **CLI usage & quota** admin panel — two coherent workstreams on top of the model-picker precursor already on this branch. No settings API wire shape or LLM-resolver semantics changed.

### 1. Settings → AI redesign
The page's information architecture was incoherent: users couldn't tell which controls were theirs vs the server's, some options did nothing, and non-admin edits to install-wide fields were silently discarded after the UI reported "All changes saved". The 1251-line single component is split into focused sections and reorganised around the per-user routing choice:

- **AI routing** (per-user): a two-way choice — "Use server default" vs "My Claude subscription (CLI OAuth)". The two former no-op options (Ollama / BYOK) are removed — they never changed resolution; they fell through to the server-configured provider (confirmed in the source comment at `config_manager.py:166-169`). Only the controls relevant to the active choice are shown.
- **Server provider** and **Fallback provider**: install-wide, admin-only, and now **hidden for non-admins** — previously they looked editable but their writes were stripped at `settings.py:346-348`. A non-admin sees a read-only summary of the active provider in the routing card instead.
- **Meeting Edge**: consolidates the scattered enable toggle + model + technical-context slider, with each control's scope labelled. The enable toggle and model are admin-wide; the technical-context slider is a genuine per-user preference and stays visible for everyone.
- Naming pass ("usage model" → "AI routing"), consistent persist timing (discrete controls save immediately, continuous controls debounce), full CLI model names, and the stale `CliOAuthPanel` docstring fixed. The lower sections (automatic enhancement, language, and the admin-only Hugging Face / transcription / dependencies) were extracted verbatim.

### 2. Per-user CLI usage & quota (new)
Admins can now see how many tokens each user has run through their own Claude subscription, under **Settings → Administration → CLI usage & quota** (7-day / 30-day / lifetime, with rate-limit status). Each user also sees their own recent usage in the connect panel.

The Agent SDK reports token usage on each turn's terminal `ResultMessage`, but the manager was discarding it. It's now captured and persisted as a **per-user daily rollup** (`cli_usage_daily`), written best-effort from the worker-io manager after each successful turn. `user_id` is already in scope at the call site, so attribution is free.

**Honest scope on "quota":** a Claude *subscription* exposes no live remaining-token figure — only a rate-limit status and reset time. The SDK's `RateLimitInfo.utilization` (fraction of the current window consumed) was also being discarded; it is now captured as a best-effort "latest known" reading, so the status column can show "Approaching (78%)" when available — but there is deliberately no invented balance. Usage is shown in **tokens, never money**: a subscription is flat-rate, so the SDK's notional per-turn cost is stored for reference but never surfaced.

### Commits
1. `refactor(settings-ai)` — split + redesign the AI page (routing/server/Meeting Edge/fallback), decisions above.
2. `feat(cli-oauth)` — record per-user token usage as daily rollups + capture rate-limit utilisation.
3. `feat(admin)` — the admin usage & quota panel (endpoint + table) + self-usage line.
4. `test(cli-oauth)` — backfill the new credential columns into a hand-written test DDL.
5. `docs` — USAGE + SECURITY.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

(Also a non-behavioural refactor of the AI settings component.)

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 830 passing
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` — 181 passing
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — single head `c9f21a7de4b3`

## Migration impact

- [ ] No database migration in this PR.
- [x] Adds an Alembic migration (`c9f21a7de4b3`, revises `b30103edc480`). Single checked-in head preserved; no committed revisions deleted or renamed. **Upgrade:** adds four nullable advisory columns to `cli_oauth_credentials` (`last_utilization`, `last_rate_limit_status`, `last_rate_limit_type`, `last_rate_limit_at`) and creates `cli_usage_daily` (per-user, per-day token rollup; unique on `(user_id, provider, usage_date)`; FK → `users` ON DELETE CASCADE). **Downgrade:** drops the table and the four columns. Purely additive; no backfill.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated `docs/USAGE.md` (routing rename, non-admin behaviour, the admin usage panel) and `docs/SECURITY.md` (aggregate-only usage accounting; content never stored).

## Security impact

- [ ] No security-sensitive change.
- [x] Touches per-user data exposure. A new admin-gated endpoint (`get_current_admin_user`) returns per-user token totals + rate-limit status. Only **aggregate counts** are stored — never prompt/response content — and the notional per-turn cost is never surfaced as money. `docs/SECURITY.md` boundaries preserved and updated. No change to auth, tokens, or encryption.

## Manual verification

- **As an admin:** Settings → AI shows the reorganised routing card, an admin-only Server provider section, the consolidated Meeting Edge block, and the admin-only Fallback provider. Settings → Administration → CLI usage & quota renders the per-user table; after driving a CLI-OAuth inference (notes/chat), the user's row increments (7-day / lifetime) on Refresh.
- **As a non-admin:** the Server provider and Fallback sections are gone; the routing card shows a read-only "Server provider: X" summary; the per-user Meeting Edge technical-context slider is still present and editable; switching routing to "My Claude subscription" reveals only the CLI model pickers; the model dropdowns list Opus 4.8 / Sonnet 5 / Sonnet 4.6 / Haiku 4.5 by full name.
- Confirmed the CLI OAuth connect panel shows the "usage this week" self line once usage is recorded, and the amber "Usage limited" / reset-time path is unchanged.
- Does not touch browser capture or the recordings context menu, so those flows are unaffected (RecordingCard/Sidebar sync rule N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
