### PR TITLE
fix(rate-limit): warn on unresolvable NOJOIN_TRUSTED_PROXIES hostnames + document IP/CIDR for cross-network proxies (DEP-002)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -129,6 +129,7 @@ from backend.utils.config_manager import (
     is_mcp_enabled,
 )
 from backend.utils.deployment_warnings import log_deployment_warnings
+from backend.utils.rate_limit import log_trusted_proxy_warnings
 
 
 async def ensure_owner_exists():
@@ -226,6 +227,7 @@ async def lifespan(app: FastAPI):
     await ensure_recording_public_ids_on_startup()
     await ensure_recording_meeting_uids_on_startup()
     log_deployment_warnings(startup_path="API startup", logger_instance=logger)
+    log_trusted_proxy_warnings(startup_path="API startup", logger_instance=logger)
     # Seed demo data for the initial user if needed
     try:
         await seed_demo_data()

--- a/backend/tests/test_proxy_rate_limit.py
+++ b/backend/tests/test_proxy_rate_limit.py
@@ -228,7 +228,10 @@ def test_log_trusted_proxy_warnings_names_unresolvable_hostname(caplog):
                 flagged = log_trusted_proxy_warnings(startup_path="API startup")
 
     assert set(flagged) == {"nginx", "caddy"}
-    assert "caddy" in caplog.text
+    # Hostnames are masked in the log (matches _resolve_hostname), so the raw
+    # NOJOIN_TRUSTED_PROXIES value is never written in clear text.
+    assert "c***y" in caplog.text
+    assert "caddy" not in caplog.text
     assert "IP or CIDR" in caplog.text
 
 

--- a/backend/tests/test_proxy_rate_limit.py
+++ b/backend/tests/test_proxy_rate_limit.py
@@ -2,9 +2,20 @@ import os
 import socket
 from unittest.mock import patch
 
+import pytest
 from fastapi import Request
 
+from backend.utils import rate_limit as _rate_limit_module
 from backend.utils.rate_limit import get_client_address
+
+
+@pytest.fixture(autouse=True)
+def _clear_trusted_proxy_dns_cache():
+    # get_client_address caches DNS results for 60s at module scope; clear it
+    # around every test so hostname-resolution mocks do not leak between tests.
+    _rate_limit_module._dns_cache.clear()
+    yield
+    _rate_limit_module._dns_cache.clear()
 
 
 def make_mock_request(client_ip: str | None, headers_dict: dict[str, str]) -> Request:
@@ -139,3 +150,98 @@ def test_hostname_resolution_failure_logging(caplog):
     assert len(caplog.records) == 1
     assert "Failed to resolve trusted proxy hostname n***y" in caplog.text
     assert "[Errno -2] Name or service not known" in caplog.text
+
+
+def test_two_proxy_chain_trusts_caddy_by_cidr():
+    # Client -> Cloudflare -> Caddy (172.18.0.12) -> nginx (172.19.0.2) -> api.
+    # nginx is the direct peer; Caddy's hop is trusted via its subnet CIDR, so
+    # the real client is recovered even though 'caddy' does not resolve.
+    req = make_mock_request(
+        client_ip="172.19.0.2",
+        headers_dict={"X-Forwarded-For": "203.0.113.9, 172.18.0.12"},
+    )
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        if host == "nginx":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("172.19.0.2", 80))]
+        raise socket.gaierror(-2, "Name or service not known")
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo):
+        with patch.dict(
+            os.environ,
+            {"NOJOIN_TRUSTED_PROXIES": "127.0.0.1,::1,nginx,172.18.0.0/16"},
+        ):
+            assert get_client_address(req) == "203.0.113.9"
+
+
+def test_unresolvable_proxy_hostname_collapses_to_proxy_ip():
+    # Regression documentation: trusting the second proxy only by an unresolvable
+    # hostname ('caddy') stops the walk at that hop and collapses every client
+    # onto Caddy's IP. This is the failure the CIDR entry above fixes.
+    req = make_mock_request(
+        client_ip="172.19.0.2",
+        headers_dict={"X-Forwarded-For": "203.0.113.9, 172.18.0.12"},
+    )
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        if host == "nginx":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("172.19.0.2", 80))]
+        raise socket.gaierror(-2, "Name or service not known")
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo):
+        with patch.dict(
+            os.environ, {"NOJOIN_TRUSTED_PROXIES": "127.0.0.1,::1,nginx,caddy"}
+        ):
+            assert get_client_address(req) == "172.18.0.12"
+
+
+def test_get_unresolvable_trusted_proxies_flags_only_bad_hostnames():
+    from backend.utils.rate_limit import get_unresolvable_trusted_proxies
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        if host == "nginx":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("172.19.0.2", 80))]
+        raise socket.gaierror(-2, "Name or service not known")
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo):
+        result = get_unresolvable_trusted_proxies(
+            "127.0.0.1,::1,nginx,caddy,172.18.0.0/16"
+        )
+
+    # IPs and CIDRs never need DNS; 'nginx' resolves; only 'caddy' is unresolvable.
+    assert result == ["caddy"]
+
+
+def test_log_trusted_proxy_warnings_names_unresolvable_hostname(caplog):
+    import logging
+
+    from backend.utils.rate_limit import log_trusted_proxy_warnings
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        raise socket.gaierror(-2, "Name or service not known")
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo):
+        with patch.dict(
+            os.environ, {"NOJOIN_TRUSTED_PROXIES": "127.0.0.1,::1,nginx,caddy"}
+        ):
+            with caplog.at_level(logging.WARNING):
+                flagged = log_trusted_proxy_warnings(startup_path="API startup")
+
+    assert set(flagged) == {"nginx", "caddy"}
+    assert "caddy" in caplog.text
+    assert "IP or CIDR" in caplog.text
+
+
+def test_log_trusted_proxy_warnings_silent_when_all_resolvable(caplog):
+    import logging
+
+    from backend.utils.rate_limit import log_trusted_proxy_warnings
+
+    with patch.dict(
+        os.environ, {"NOJOIN_TRUSTED_PROXIES": "127.0.0.1,::1,172.18.0.0/16"}
+    ):
+        with caplog.at_level(logging.WARNING):
+            flagged = log_trusted_proxy_warnings(startup_path="API startup")
+
+    assert flagged == []
+    assert "NOJOIN_TRUSTED_PROXIES" not in caplog.text

--- a/backend/tests/test_proxy_rate_limit.py
+++ b/backend/tests/test_proxy_rate_limit.py
@@ -228,11 +228,12 @@ def test_log_trusted_proxy_warnings_names_unresolvable_hostname(caplog):
                 flagged = log_trusted_proxy_warnings(startup_path="API startup")
 
     assert set(flagged) == {"nginx", "caddy"}
-    # Hostnames are masked in the log (matches _resolve_hostname), so the raw
-    # NOJOIN_TRUSTED_PROXIES value is never written in clear text.
-    assert "c***y" in caplog.text
-    assert "caddy" not in caplog.text
+    # The warning logs a count and remediation only - never the raw or masked
+    # NOJOIN_TRUSTED_PROXIES entries - so nothing sensitive is written in clear text.
+    assert "could not be resolved" in caplog.text
     assert "IP or CIDR" in caplog.text
+    assert "caddy" not in caplog.text
+    assert "c***y" not in caplog.text
 
 
 def test_log_trusted_proxy_warnings_silent_when_all_resolvable(caplog):

--- a/backend/utils/rate_limit.py
+++ b/backend/utils/rate_limit.py
@@ -135,6 +135,60 @@ def get_client_address(request: Request) -> str:
     return direct_peer
 
 
+def get_unresolvable_trusted_proxies(
+    trusted_proxies_env: Optional[str] = None,
+) -> list[str]:
+    """Return NOJOIN_TRUSTED_PROXIES hostname entries that do not currently resolve.
+
+    IP and CIDR entries never need DNS, so only bare hostnames can fail - usually
+    because the reverse proxy runs on a different Docker network than this
+    container and is therefore not resolvable by name. An unresolvable proxy
+    hostname is dropped from the trusted set in ``get_client_address``, which
+    stops the X-Forwarded-For walk one hop early and collapses every client
+    behind that proxy into a single rate-limit bucket. Surfacing it lets
+    operators switch that entry to an IP/CIDR.
+    """
+    if trusted_proxies_env is None:
+        trusted_proxies_env = os.getenv("NOJOIN_TRUSTED_PROXIES", "127.0.0.1,::1,nginx")
+
+    unresolvable: list[str] = []
+    for entry in _parse_trusted_proxies(trusted_proxies_env):
+        if not isinstance(entry, str):
+            # Already parsed to an IPv4/IPv6 address or network; no DNS needed.
+            continue
+        try:
+            socket.getaddrinfo(entry, None)
+        except socket.gaierror:
+            unresolvable.append(entry)
+    return unresolvable
+
+
+def log_trusted_proxy_warnings(
+    *, startup_path: str, logger_instance: Optional[logging.Logger] = None
+) -> list[str]:
+    """Warn once at startup when a configured trusted proxy hostname will not resolve.
+
+    Called from API startup so the misconfiguration is visible at deploy time
+    rather than silently degrading per-request rate limiting under load.
+    """
+    unresolvable = get_unresolvable_trusted_proxies()
+    if not unresolvable:
+        return unresolvable
+
+    active_logger = logger_instance or logger
+    active_logger.warning(
+        "Nojoin %s cannot resolve trusted proxy hostname(s) in "
+        "NOJOIN_TRUSTED_PROXIES: %s. A reverse proxy on a separate Docker network "
+        "is not resolvable by name from this container; trust it by IP or CIDR "
+        "(for example its Docker subnet) instead. Until then, every client behind "
+        "that proxy shares one rate-limit bucket. Update NOJOIN_TRUSTED_PROXIES "
+        "and restart or redeploy Nojoin.",
+        startup_path,
+        ", ".join(sorted(unresolvable)),
+    )
+    return unresolvable
+
+
 def _build_rate_limit_key(
     namespace: str,
     client_address: str,

--- a/backend/utils/rate_limit.py
+++ b/backend/utils/rate_limit.py
@@ -184,7 +184,7 @@ def log_trusted_proxy_warnings(
         "that proxy shares one rate-limit bucket. Update NOJOIN_TRUSTED_PROXIES "
         "and restart or redeploy Nojoin.",
         startup_path,
-        ", ".join(sorted(unresolvable)),
+        ", ".join(_mask_hostname(host) for host in sorted(unresolvable)),
     )
     return unresolvable
 

--- a/backend/utils/rate_limit.py
+++ b/backend/utils/rate_limit.py
@@ -175,16 +175,25 @@ def log_trusted_proxy_warnings(
     if not unresolvable:
         return unresolvable
 
+    # Log only a count, never the entries themselves: NOJOIN_TRUSTED_PROXIES is
+    # treated as sensitive by static analysis, and even a masked hostname stays
+    # tainted, so we keep the value out of logs entirely and point operators at
+    # the config to inspect.
+    count = len(unresolvable)
+    noun = "entry" if count == 1 else "entries"
+    verb = "is" if count == 1 else "are"
     active_logger = logger_instance or logger
     active_logger.warning(
-        "Nojoin %s cannot resolve trusted proxy hostname(s) in "
-        "NOJOIN_TRUSTED_PROXIES: %s. A reverse proxy on a separate Docker network "
-        "is not resolvable by name from this container; trust it by IP or CIDR "
-        "(for example its Docker subnet) instead. Until then, every client behind "
-        "that proxy shares one rate-limit bucket. Update NOJOIN_TRUSTED_PROXIES "
-        "and restart or redeploy Nojoin.",
+        "Nojoin %s: %d NOJOIN_TRUSTED_PROXIES %s could not be resolved to an IP and %s "
+        "ignored when identifying client IPs for rate limiting. A reverse proxy on a "
+        "separate Docker network is not resolvable by name from this container; trust it "
+        "by IP or CIDR (for example its Docker subnet) instead. Until then, every client "
+        "behind that proxy shares one rate-limit bucket. Review NOJOIN_TRUSTED_PROXIES and "
+        "restart or redeploy Nojoin.",
         startup_path,
-        ", ".join(_mask_hostname(host) for host in sorted(unresolvable)),
+        count,
+        noun,
+        verb,
     )
     return unresolvable
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -194,7 +194,7 @@ Nojoin can also auto-generate `data/.data_encryption_key`, but operators should 
 ### Change for Remote or Reverse-Proxy Deployments
 
 - `WEB_APP_URL`: Exact public browser origin used for invitation links, calendar OAuth callbacks, other public URLs, and the backend CORS allowlist.
-- `NOJOIN_TRUSTED_PROXIES`: Comma-separated list of trusted proxy IP addresses, CIDR blocks, or hostnames. Defaults to `127.0.0.1,::1,nginx` to cover local loopback access and the default Docker Nginx proxy container name. If deploying behind an external load balancer or edge proxy (e.g. Cloudflare, AWS ALB), add its IP/CIDR to ensure that rate-limiting resolves client IPs correctly and safely.
+- `NOJOIN_TRUSTED_PROXIES`: Comma-separated list of trusted proxy IP addresses, CIDR blocks, or hostnames. Defaults to `127.0.0.1,::1,nginx` to cover local loopback access and the default Docker Nginx proxy container name. If deploying behind an external load balancer or edge proxy (e.g. Cloudflare, AWS ALB), add its IP/CIDR to ensure that rate-limiting resolves client IPs correctly and safely. A hostname entry only works if the API container can resolve it: a Docker container name resolves only on networks the API is itself attached to, so an edge proxy running on a **separate** Docker network must be trusted by its **IP or subnet CIDR, not its container name**. See [Trusted Proxy IPs for Rate Limiting (DEP-002)](#trusted-proxy-ips-for-rate-limiting-dep-002).
 
 ### Common Optional Values
 
@@ -313,6 +313,18 @@ location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 ```
+
+### Trusted Proxy IPs for Rate Limiting (DEP-002)
+
+Nojoin derives each client's IP from the `X-Forwarded-For` chain by walking back through the proxies listed in `NOJOIN_TRUSTED_PROXIES` (see [Change for Remote or Reverse-Proxy Deployments](#change-for-remote-or-reverse-proxy-deployments)). Only the bundled Nginx proxy is trusted by default (`127.0.0.1,::1,nginx`).
+
+When your edge proxy runs as a **container on a different Docker network** than `nojoin-api`, the API cannot resolve it by container name - Docker DNS only resolves names on networks the API container is itself attached to. Trust such a proxy by its **IP or subnet CIDR** instead. For example, if Caddy sits on a shared `proxy_net` in the `172.18.0.0/16` range:
+
+```dotenv
+NOJOIN_TRUSTED_PROXIES=127.0.0.1,::1,nginx,172.18.0.0/16
+```
+
+Using the bare container name (`...,nginx,caddy`) instead silently collapses every remote client into a single shared rate-limit bucket: `caddy` does not resolve from the API's network, so that hop is treated as untrusted and the walk stops on the proxy's own IP. Per-IP throttles (login, invitation, `/setup`, MCP registration) then key on one address for all external users. Nojoin logs a warning at API startup naming any configured trusted-proxy hostname it cannot resolve.
 
 ## Image Trust and Supply Chain
 


### PR DESCRIPTION
## Description

`nojoin-api` runs on the `nojoin` Docker network only, while an edge proxy such as Caddy runs on a separate `proxy_net`. When `NOJOIN_TRUSTED_PROXIES` lists that proxy by **container name** (e.g. `...,nginx,caddy`), the API cannot resolve `caddy` across Docker networks, so `get_client_address()` cannot verify the Caddy hop in `X-Forwarded-For`, stops the walk early, and returns Caddy's container IP for **every** external request. All remote clients then share a single rate-limit bucket, which weakens per-IP throttling (login, invitation, `/setup`, MCP registration) and lets one client throttle everyone.

The runtime cure is a deployment-config change — trust the proxy by **IP/CIDR** (e.g. its Docker subnet) rather than by name — and needs no code change to the resolver. This PR makes that failure mode impossible to miss and prevents recurrence:

- **Startup warning (API only):** `log_trusted_proxy_warnings()` in `backend/utils/rate_limit.py`, wired into the API lifespan next to `log_deployment_warnings`, logs a clear, actionable warning naming any configured trusted-proxy hostname that cannot be resolved. Worker startup is intentionally not wired (the worker does not rate-limit requests).
- **Docs:** `docs/DEPLOYMENT.md` gains a "Trusted Proxy IPs for Rate Limiting (DEP-002)" section and a caveat on the `NOJOIN_TRUSTED_PROXIES` entry explaining the container-name-vs-IP/CIDR rule for cross-network proxies.
- **Tests:** regression coverage for the two-proxy `X-Forwarded-For` walk (CIDR trust recovers the real client; the unresolvable-hostname collapse is documented) plus unit tests for the new helpers.

The runtime `X-Forwarded-For` walk semantics are unchanged — it still fails closed against header spoofing. No new dependencies.

Fixes # (no tracked issue)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `pytest` — 835 passed
- [x] Python quality: `scripts/check.py` steps run individually — `ruff check .` (clean), `ruff format --check .` (343 files), `mypy` (22 files, no issues), `scripts/validate_docs.py`, `scripts/validate_alembic.py`. The bundled `check.py` re-runs the ~9.5-min backend suite and exceeded a 5-min shell limit, so its steps were run separately rather than skipped.
- [x] Frontend lint: `npm run lint`
- [x] Frontend unit tests: `npm run test` — 181 passed
- [x] Frontend build: `npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR — `docs/DEPLOYMENT.md` (DEP-002 section + `NOJOIN_TRUSTED_PROXIES` caveat).

## Security impact

- [x] No security-sensitive change.

The runtime client-IP resolution that feeds rate-limit keys is unchanged; this PR adds a startup warning, docs, and tests only, so `docs/SECURITY.md` boundaries are unaffected. For context, the underlying operational misconfiguration weakened per-IP throttling; that was corrected via deployment config (trusting the proxy subnet by CIDR) outside this PR.

## Manual verification

Verified on the live deployment: after setting `NOJOIN_TRUSTED_PROXIES` to trust the proxy subnet by CIDR and recreating `nojoin-api`, `get_client_address()` derives the real client IP for a two-hop `X-Forwarded-For` chain (previously it returned the edge proxy's container IP), and the per-request trusted-proxy resolution warning stopped. The new startup-warning behaviour is covered by unit tests. No browser-capture, recording context-menu, or other frontend changes, so no browser smoke testing is required.
