### PR TITLE
fix(frontend): make the mobile layout usable

### DIFF
--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -33,19 +33,26 @@ export default function DashboardLayout({
   return (
     <CaptureProvider>
       <CaptureShell>
-        <div className="flex h-screen w-full overflow-hidden">
+        {/* App shell: a column so the mobile top bar reserves the top row, with
+            the nav <-> main row filling the rest. `h-dvh` (dynamic viewport)
+            keeps the shell inside the visible area so the browser toolbar never
+            clips the bottom of scroll views. On desktop TopBar is hidden, so the
+            column collapses to the original single-row layout. */}
+        <div className="flex flex-col h-dvh w-full overflow-hidden">
           <TourGuide />
-          <MainNav />
-          {!isSettingsPage && !isPeoplePage && showSidebar && <Sidebar />}
+          <TopBar />
+          <div className="flex flex-1 min-h-0 w-full overflow-hidden">
+            <MainNav />
+            {!isSettingsPage && !isPeoplePage && showSidebar && <Sidebar />}
 
-          <main
-            ref={mainRef}
-            className="flex-1 overflow-y-auto relative flex flex-col min-w-0 h-full"
-          >
-            <TopBar />
-            {children}
-            <ServiceStatusAlerts />
-          </main>
+            <main
+              ref={mainRef}
+              className="flex-1 overflow-y-auto relative flex flex-col min-w-0 h-full"
+            >
+              {children}
+              <ServiceStatusAlerts />
+            </main>
+          </div>
         </div>
         <RecordingFloatingBadge />
       </CaptureShell>

--- a/frontend/src/app/(dashboard)/people/page.tsx
+++ b/frontend/src/app/(dashboard)/people/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
-import { Plus, Users } from "lucide-react";
+import { Plus, Users, Tag as TagIcon } from "lucide-react";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import {
   getGlobalSpeakers,
@@ -33,6 +33,9 @@ export default function PeoplePage() {
 
   // Selection State
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  // Mobile tag-filter drawer (inline pane on desktop)
+  const [isTagDrawerOpen, setIsTagDrawerOpen] = useState(false);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingPerson, setEditingPerson] = useState<GlobalSpeaker | null>(
@@ -281,6 +284,8 @@ export default function PeoplePage() {
         selectedTagIds={selectedTagIds}
         onToggleTag={handleToggleTag}
         onClearFilters={() => setSelectedTagIds([])}
+        mobileOpen={isTagDrawerOpen}
+        onMobileClose={() => setIsTagDrawerOpen(false)}
       />
 
       <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
@@ -297,13 +302,27 @@ export default function PeoplePage() {
                   Manage your contacts, speakers, and their associated details.
                 </p>
               </div>
-              <button
-                onClick={handleAddNew}
-                className="flex items-center gap-2 px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-colors shadow-sm font-medium"
-              >
-                <Plus className="w-5 h-5" />
-                Add Person
-              </button>
+              <div className="flex items-center gap-2 self-stretch sm:self-auto">
+                <button
+                  onClick={() => setIsTagDrawerOpen(true)}
+                  className="lg:hidden flex items-center gap-2 px-3 py-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-orange-300 transition-colors shadow-sm font-medium"
+                >
+                  <TagIcon className="w-5 h-5" />
+                  Tags
+                  {selectedTagIds.length > 0 && (
+                    <span className="ml-0.5 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold text-white bg-orange-600 rounded-full">
+                      {selectedTagIds.length}
+                    </span>
+                  )}
+                </button>
+                <button
+                  onClick={handleAddNew}
+                  className="flex-1 sm:flex-none flex items-center justify-center gap-2 px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-colors shadow-sm font-medium"
+                >
+                  <Plus className="w-5 h-5" />
+                  Add Person
+                </button>
+              </div>
             </div>
 
             {/* Filters */}

--- a/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingMainContent.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingMainContent.tsx
@@ -11,6 +11,8 @@ import {
   TranscriptSpeakerAssignment,
 } from "@/types";
 
+import SpeakerPanel from "@/components/SpeakerPanel";
+
 import RecordingHeader from "./RecordingHeader";
 import TranscriptSection from "./TranscriptSection";
 import NotesSection from "./NotesSection";
@@ -50,6 +52,9 @@ interface RecordingMainContentProps {
   onPause: () => void;
   onResume: () => void;
   onRenameSpeaker: (label: string, newName: string) => void | Promise<void>;
+  onColorChange: (speakerLabel: string, colorKey: string) => void;
+  onRefresh: () => void;
+  onSpeakerRenamed?: (oldName: string, newName: string) => Promise<void> | void;
   onUpdateSegmentSpeaker: (
     segment: TranscriptSegment,
     assignment: TranscriptSpeakerAssignment,
@@ -114,6 +119,9 @@ export default function RecordingMainContent({
   onPause,
   onResume,
   onRenameSpeaker,
+  onColorChange,
+  onRefresh,
+  onSpeakerRenamed,
   onUpdateSegmentSpeaker,
   onUpdateSegmentText,
   onFindAndReplace,
@@ -146,8 +154,16 @@ export default function RecordingMainContent({
           <button
             onClick={() => setIsMobileHeaderActionsOpen((current) => !current)}
             className={`pointer-events-auto inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border shadow-lg shadow-black/10 backdrop-blur-sm transition-colors dark:shadow-black/30 ${isMobileHeaderActionsOpen ? "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300" : "border-gray-200 bg-white/90 text-gray-700 hover:bg-white dark:border-gray-700 dark:bg-gray-800/90 dark:text-gray-300 dark:hover:bg-gray-800"}`}
-            title={isMobileHeaderActionsOpen ? "Hide meeting actions" : "Show meeting actions"}
-            aria-label={isMobileHeaderActionsOpen ? "Hide meeting actions" : "Show meeting actions"}
+            title={
+              isMobileHeaderActionsOpen
+                ? "Hide meeting actions"
+                : "Show meeting actions"
+            }
+            aria-label={
+              isMobileHeaderActionsOpen
+                ? "Hide meeting actions"
+                : "Show meeting actions"
+            }
           >
             <MoreHorizontal className="h-5 w-5" />
           </button>
@@ -172,9 +188,12 @@ export default function RecordingMainContent({
         onPause={() => setIsPlaying(false)}
       />
 
-      {/* Panel Tabs */}
+      {/* Panel Tabs. The Speakers tab is mobile-only; on desktop the speaker
+          panel lives in the side column. */}
       <div className="shrink-0 bg-gray-50 dark:bg-gray-900">
-        <div className="grid grid-cols-3 border-b-2 border-gray-200 dark:border-gray-700">
+        <div
+          className={`grid ${isMobile ? "grid-cols-4" : "grid-cols-3"} border-b-2 border-gray-200 dark:border-gray-700`}
+        >
           <button
             id="tab-transcript"
             onClick={() => setActivePanel("transcript")}
@@ -196,6 +215,15 @@ export default function RecordingMainContent({
           >
             <span className="truncate">Documents</span>
           </button>
+          {isMobile && (
+            <button
+              id="tab-speakers"
+              onClick={() => setActivePanel("speakers")}
+              className={tabClassName(activePanel === "speakers")}
+            >
+              <span className="truncate">Speakers</span>
+            </button>
+          )}
         </div>
       </div>
 
@@ -244,6 +272,28 @@ export default function RecordingMainContent({
           active={activePanel === "documents"}
           recordingId={recording.id}
         />
+
+        {isMobile && (
+          <div
+            className={`absolute inset-0 flex flex-col ${activePanel === "speakers" ? "z-10 visible" : "z-0 invisible"}`}
+          >
+            <SpeakerPanel
+              speakers={recording.speakers || []}
+              segments={transcriptSegments}
+              onPlaySegment={onPlaySegment}
+              recordingId={recording.id}
+              speakerColors={speakerColors}
+              onColorChange={onColorChange}
+              currentTime={currentTime}
+              isPlaying={isPlaying}
+              onPause={onPause}
+              onResume={onResume}
+              onRefresh={onRefresh}
+              globalSpeakers={globalSpeakers}
+              onSpeakerRenamed={onSpeakerRenamed}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/(dashboard)/recordings/[id]/_hooks/useRecordingDetail.ts
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_hooks/useRecordingDetail.ts
@@ -381,6 +381,15 @@ export function useRecordingDetail({ params }: UseRecordingDetailParams) {
     }
   }, [isMobile]);
 
+  // The "Speakers" panel is a mobile-only tab (desktop shows the speaker panel
+  // in the side column). Leaving mobile while it is active would blank the main
+  // content, so fall back to the transcript.
+  useEffect(() => {
+    if (!isMobile && activePanel === "speakers") {
+      setActivePanel("transcript");
+    }
+  }, [isMobile, activePanel, setActivePanel]);
+
   useEffect(() => {
     if (!recording) return;
 

--- a/frontend/src/app/(dashboard)/recordings/[id]/_hooks/useRecordingDetail.ts
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_hooks/useRecordingDetail.ts
@@ -127,12 +127,12 @@ export function useRecordingDetail({ params }: UseRecordingDetailParams) {
   const [showExportModal, setShowExportModal] = useState(false);
 
 
-  // Mobile State
-  const [isMobile, setIsMobile] = useState(false);
+  // Mobile State. `isMobile` comes from the shared viewport provider (single
+  // source of truth for the 1024px boundary) rather than a local resize listener.
   const [isMobileChatOpen, setIsMobileChatOpen] = useState(false);
   const [isMobileHeaderActionsOpen, setIsMobileHeaderActionsOpen] = useState(false);
   const [isPanelResizing, setIsPanelResizing] = useState(false);
-  const { isCompact } = useViewportDensity();
+  const { isCompact, isMobile } = useViewportDensity();
   useDragSelectionLock(isPanelResizing);
 
   // Notes History (separate from transcript history, can include null values)
@@ -374,14 +374,6 @@ export function useRecordingDetail({ params }: UseRecordingDetailParams) {
     // delta polling and explicit mutation refreshes keep this state current.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recording?.id, isInFlightRecording]);
-
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth < 1024);
-    // Initial check
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, [setActivePanel]);
 
   useEffect(() => {
     if (!isMobile) {

--- a/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
@@ -98,6 +98,18 @@ export default function RecordingPage({ params }: PageProps) {
     return null;
   }
 
+  // Renaming a speaker propagates into the generated notes (shared by the
+  // desktop side panel and the mobile Speakers tab).
+  const handleSpeakerRenamed = async (oldName: string, newName: string) => {
+    if (recording?.transcript?.notes) {
+      await handleGlobalFindAndReplace(
+        oldName,
+        getAutoSpeakerReplacementName(newName),
+        { caseSensitive: true },
+      );
+    }
+  };
+
   const mainContent = (
     <RecordingMainContent
       recording={recording}
@@ -129,6 +141,9 @@ export default function RecordingPage({ params }: PageProps) {
       onPause={handlePause}
       onResume={handleResume}
       onRenameSpeaker={handleRenameSpeaker}
+      onColorChange={handleColorChange}
+      onRefresh={refreshRecordingView}
+      onSpeakerRenamed={handleSpeakerRenamed}
       onUpdateSegmentSpeaker={handleUpdateSegmentSpeaker}
       onUpdateSegmentText={handleUpdateSegmentText}
       onFindAndReplace={handleGlobalFindAndReplace}
@@ -137,8 +152,7 @@ export default function RecordingPage({ params }: PageProps) {
       onActiveEditUtteranceChange={setActiveTranscriptEditId}
       onExport={() => setShowExportModal(true)}
       isGeneratingNotes={
-        isGeneratingNotes ||
-        recording.transcript?.notes_status === "generating"
+        isGeneratingNotes || recording.transcript?.notes_status === "generating"
       }
       notesCanUndo={notesHistory.length > 0}
       notesCanRedo={notesFuture.length > 0}
@@ -159,7 +173,9 @@ export default function RecordingPage({ params }: PageProps) {
               onSaveProcessingNotes={handleProcessingNotesChange}
               onSaveMeetingEdgeFocus={handleMeetingEdgeFocusChange}
               meetingEdgeContextLevel={meetingEdgeContextLevel}
-              onSaveMeetingEdgeContextLevel={handleMeetingEdgeContextLevelChange}
+              onSaveMeetingEdgeContextLevel={
+                handleMeetingEdgeContextLevelChange
+              }
               showMeetingEdge={meetingEdgeEnabled}
               onBack={navigateToRecordings}
               onDiscarded={navigateToRecordings}
@@ -168,9 +184,7 @@ export default function RecordingPage({ params }: PageProps) {
           </div>
         ) : isMobile ? (
           <div className="flex h-full flex-1 min-w-0 flex-col bg-white dark:bg-gray-900">
-            <div className="min-h-0 flex-1">
-              {mainContent}
-            </div>
+            <div className="min-h-0 flex-1">{mainContent}</div>
 
             {!isMobileChatOpen && (
               <div className="pointer-events-none fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] right-4 z-40">
@@ -193,12 +207,12 @@ export default function RecordingPage({ params }: PageProps) {
                     <MessageSquare className="w-5 h-5 text-orange-500" />
                     Meeting Chat
                   </h2>
-                <button
-                  onClick={() => setIsMobileChatOpen(false)}
-                  className="inline-flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
-                  title="Back to meeting"
-                  aria-label="Back to meeting"
-                >
+                  <button
+                    onClick={() => setIsMobileChatOpen(false)}
+                    className="inline-flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
+                    title="Back to meeting"
+                    aria-label="Back to meeting"
+                  >
                     <ArrowLeft className="h-5 w-5" />
                     <span>Back</span>
                   </button>
@@ -250,15 +264,7 @@ export default function RecordingPage({ params }: PageProps) {
                     onResume={handleResume}
                     onRefresh={refreshRecordingView}
                     globalSpeakers={globalSpeakers}
-                    onSpeakerRenamed={async (oldName, newName) => {
-                      if (recording?.transcript?.notes) {
-                          await handleGlobalFindAndReplace(
-                            oldName,
-                            getAutoSpeakerReplacementName(newName),
-                            { caseSensitive: true },
-                          );
-                      }
-                    }}
+                    onSpeakerRenamed={handleSpeakerRenamed}
                   />
                 </Panel>
 
@@ -285,8 +291,6 @@ export default function RecordingPage({ params }: PageProps) {
         onExport={handleExport}
         hasNotes={!!recording?.transcript?.notes}
       />
-
-
     </div>
   );
 }

--- a/frontend/src/components/ConfirmationModal.tsx
+++ b/frontend/src/components/ConfirmationModal.tsx
@@ -35,8 +35,8 @@ export default function ConfirmationModal({
   if (!isOpen || !mounted) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md border border-gray-300 dark:border-gray-800 p-6 relative animate-in fade-in zoom-in-95 duration-200">
+    <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md max-h-[calc(100dvh-2rem)] overflow-y-auto border border-gray-300 dark:border-gray-800 p-6 relative animate-in fade-in zoom-in-95 duration-200">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-bold text-gray-900 dark:text-white">
             {title}

--- a/frontend/src/components/DictionaryModal.tsx
+++ b/frontend/src/components/DictionaryModal.tsx
@@ -90,8 +90,8 @@ export default function DictionaryModal({ isOpen, onClose }: DictionaryModalProp
   if (!isOpen || !mounted) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg flex flex-col border border-gray-300 dark:border-gray-800 max-h-[80vh]">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg flex flex-col border border-gray-300 dark:border-gray-800 max-h-[calc(100dvh-2rem)]">
         {/* Header */}
         <div className="p-4 border-b border-gray-200 dark:border-gray-800 flex justify-between items-center shrink-0">
           <h2 className="text-lg font-bold text-gray-900 dark:text-white flex items-center gap-2">

--- a/frontend/src/components/DocumentsView.tsx
+++ b/frontend/src/components/DocumentsView.tsx
@@ -182,7 +182,7 @@ export default function DocumentsView({ recordingId }: DocumentsViewProps) {
                   >
                     {doc.status}
                   </div>
-                  <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex gap-1 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100">
                     <button
                       onClick={() => setDocumentToDelete(doc)}
                       className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"

--- a/frontend/src/components/ImportAudioModal.tsx
+++ b/frontend/src/components/ImportAudioModal.tsx
@@ -174,8 +174,8 @@ export default function ImportAudioModal({ isOpen, onClose, onSuccess }: ImportA
   if (!isOpen || !mounted) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg flex flex-col border border-gray-300 dark:border-gray-800">
+    <div className="fixed inset-0 z-100 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto flex flex-col border border-gray-300 dark:border-gray-800">
         {/* Header */}
         <div className="p-6 border-b border-gray-200 dark:border-gray-800 flex justify-between items-center">
           <h2 className="text-xl font-bold text-gray-900 dark:text-white">Import Audio</h2>

--- a/frontend/src/components/LiveAudioWaveform.tsx
+++ b/frontend/src/components/LiveAudioWaveform.tsx
@@ -47,7 +47,7 @@ function WaveformTrack({
   const range = dynamicMax - dynamicMin;
   return (
     <div className="rounded-3xl border border-white/60 bg-white/75 p-4 shadow-lg shadow-orange-950/10 backdrop-blur dark:border-white/10 dark:bg-gray-950/60 dark:shadow-black/20">
-      <div className="flex h-24 items-end gap-1 overflow-hidden rounded-2xl bg-gradient-to-b from-orange-100/80 via-white to-white px-2 py-3 dark:from-orange-500/10 dark:via-gray-950 dark:to-gray-950">
+      <div className="flex h-24 items-end gap-px sm:gap-1 overflow-hidden rounded-2xl bg-gradient-to-b from-orange-100/80 via-white to-white px-2 py-3 dark:from-orange-500/10 dark:via-gray-950 dark:to-gray-950">
         {history.map((sample, index) => {
           const scaled = range > 0 ? Math.max(0, Math.min(100, ((sample - dynamicMin) / range) * 100)) : 0;
           return (

--- a/frontend/src/components/MainNav.tsx
+++ b/frontend/src/components/MainNav.tsx
@@ -390,7 +390,7 @@ export default function MainNav() {
         >
           <div
             ref={setRootNodeRef}
-            className={`flex-1 overflow-y-auto p-2 border-2 border-transparent rounded-lg transition-all ${isOverRoot ? "border-orange-300 bg-orange-50/50 dark:border-orange-700 dark:bg-orange-900/10" : ""}`}
+            className={`min-h-0 flex-1 overflow-y-auto p-2 border-2 border-transparent rounded-lg transition-all ${isOverRoot ? "border-orange-300 bg-orange-50/50 dark:border-orange-700 dark:bg-orange-900/10" : ""}`}
           >
             {!collapsed && (
               <div className="flex items-center justify-between px-3 py-2">

--- a/frontend/src/components/MainNav.tsx
+++ b/frontend/src/components/MainNav.tsx
@@ -51,7 +51,7 @@ export default function MainNav() {
   const router = useRouter();
   const pathname = usePathname();
   const { pausedRecording, runtimeActive } = useCapture();
-  const { isCompact } = useViewportDensity();
+  const { isCompact, isDesktop } = useViewportDensity();
   const {
     currentView,
     setCurrentView,
@@ -105,7 +105,6 @@ export default function MainNav() {
   } = useMainNavTags();
 
   const [mounted, setMounted] = useState(false);
-  const [isDesktop, setIsDesktop] = useState(false);
 
   // Modal states
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
@@ -118,17 +117,6 @@ export default function MainNav() {
 
   useEffect(() => {
     setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    const syncViewport = () => {
-      setIsDesktop(window.innerWidth >= DESKTOP_BREAKPOINT);
-    };
-
-    syncViewport();
-    window.addEventListener("resize", syncViewport);
-
-    return () => window.removeEventListener("resize", syncViewport);
   }, []);
 
   // Handle resize

--- a/frontend/src/components/NotesView.tsx
+++ b/frontend/src/components/NotesView.tsx
@@ -62,7 +62,9 @@ export default function NotesView({
   const displayNotes = notes
     ? notes.replace(/^#+\s*Meeting Notes\s*/i, "").trim()
     : null;
-  const generateNotesLabel = displayNotes ? "Regenerate Notes" : "Generate Notes";
+  const generateNotesLabel = displayNotes
+    ? "Regenerate Notes"
+    : "Generate Notes";
 
   // Editing State
   const [localNotes, setLocalNotes] = useState(displayNotes || "");
@@ -131,7 +133,9 @@ export default function NotesView({
         const locale = settings.spellcheck_language || "en-GB";
         spellCheckService.initialise(locale);
       })
-      .catch((err) => console.error("[NotesView] Failed to load spell check settings:", err));
+      .catch((err) =>
+        console.error("[NotesView] Failed to load spell check settings:", err),
+      );
   }, []);
 
   // Handle right-click on misspelt words
@@ -162,7 +166,8 @@ export default function NotesView({
 
     const editorDom = editor.view.dom;
     editorDom.addEventListener("contextmenu", handleContextMenu);
-    return () => editorDom.removeEventListener("contextmenu", handleContextMenu);
+    return () =>
+      editorDom.removeEventListener("contextmenu", handleContextMenu);
   }, [editor]);
 
   // Calculate matches when findText or editor content changes
@@ -382,9 +387,9 @@ export default function NotesView({
       {/* Toolbar */}
       <div className="bg-gray-300 dark:bg-gray-900/95 border-b-2 border-gray-400 dark:border-gray-700 shadow-md z-10 flex flex-col">
         {/* Row 1: Header & Global Actions */}
-        <div className="px-6 py-3 flex items-center justify-between gap-2">
+        <div className="px-3 md:px-6 py-3 flex flex-wrap items-center justify-between gap-2">
           {/* Formatting Toolbar */}
-          <div className="flex items-center gap-1">
+          <div className="flex flex-wrap items-center gap-1">
             {editor && (
               <>
                 <button
@@ -448,7 +453,7 @@ export default function NotesView({
             )}
           </div>
 
-          <div className="flex items-center gap-1">
+          <div className="flex flex-wrap items-center gap-1">
             <button
               onClick={onGenerateNotes}
               disabled={isGenerating}
@@ -518,8 +523,8 @@ export default function NotesView({
 
         {/* Row 2: Search & Replace Controls */}
         {(showSearch || showReplace) && (
-          <div className="px-6 pb-3 flex items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-200 border-t border-gray-400/30 dark:border-gray-700/50 pt-3">
-            <div className="relative flex-1 min-w-0">
+          <div className="px-3 md:px-6 pb-3 flex flex-wrap items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-200 border-t border-gray-400/30 dark:border-gray-700/50 pt-3">
+            <div className="relative min-w-40 flex-[1_1_11rem]">
               <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
               <input
                 placeholder="Find..."
@@ -555,7 +560,7 @@ export default function NotesView({
               )}
             </div>
             {showReplace && (
-              <div className="relative flex-1 min-w-0">
+              <div className="relative min-w-40 flex-[1_1_11rem]">
                 <ArrowRightLeft className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
                 <input
                   placeholder="Replace..."
@@ -566,7 +571,7 @@ export default function NotesView({
               </div>
             )}
             {showReplace && (
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 {/* Settings Toggle */}
                 <div className="relative">
                   <button

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -633,7 +633,7 @@ export default function Sidebar() {
   return (
     <aside
       id="sidebar-recordings-list"
-      className={`shrink-0 border-r border-orange-100 dark:border-gray-800/80 bg-[radial-gradient(circle_at_top_right,_rgba(249,115,22,0.16),_transparent_45%),linear-gradient(180deg,_#fffaf0_0%,_#fff7ed_100%)] dark:bg-[radial-gradient(circle_at_top_right,_rgba(251,146,60,0.10),_transparent_40%),linear-gradient(180deg,_#0a0f1c_0%,_#0b1220_100%)] flex flex-col h-100dvh relative transition-opacity ${
+      className={`shrink-0 border-r border-orange-100 dark:border-gray-800/80 bg-[radial-gradient(circle_at_top_right,_rgba(249,115,22,0.16),_transparent_45%),linear-gradient(180deg,_#fffaf0_0%,_#fff7ed_100%)] dark:bg-[radial-gradient(circle_at_top_right,_rgba(251,146,60,0.10),_transparent_40%),linear-gradient(180deg,_#0a0f1c_0%,_#0b1220_100%)] flex flex-col h-full relative transition-opacity ${
         isRecordingView ? "hidden lg:flex" : "w-full lg:flex"
       }`}
       style={mounted && isDesktopLayout ? { width: `${resolvedSidebarWidth}px` } : {}}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -109,7 +109,7 @@ export default function Sidebar() {
   const router = useRouter();
   const { addNotification } = useNotificationStore();
   const actions = useRecordingActions();
-  const { isCompact } = useViewportDensity();
+  const { isCompact, isDesktop: isDesktopLayout } = useViewportDensity();
   const {
     currentView,
     selectedTagIds,
@@ -125,8 +125,8 @@ export default function Sidebar() {
   } = useNavigationStore();
 
   const [mounted, setMounted] = useState(false);
+  // `isDesktopLayout` now comes from the shared viewport provider (aliased above).
   const [recordings, setRecordings] = useState<Recording[]>([]);
-  const [isDesktopLayout, setIsDesktopLayout] = useState(false);
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(
     null,
   );
@@ -346,17 +346,6 @@ export default function Sidebar() {
   useEffect(() => {
     setMounted(true);
     getGlobalSpeakers().then(setGlobalSpeakers).catch(console.error);
-  }, []);
-
-  useEffect(() => {
-    const syncViewport = () => {
-      setIsDesktopLayout(window.innerWidth >= 1024);
-    };
-
-    syncViewport();
-    window.addEventListener("resize", syncViewport);
-
-    return () => window.removeEventListener("resize", syncViewport);
   }, []);
 
   // Listen for recording-updated events

--- a/frontend/src/components/TasksWorkspace.tsx
+++ b/frontend/src/components/TasksWorkspace.tsx
@@ -743,7 +743,7 @@ export default function TasksWorkspace() {
                         type="button"
                         onClick={() => beginEdit(task)}
                         disabled={isBusy}
-                        className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:border-orange-200 hover:text-orange-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-orange-500/30 dark:hover:text-orange-300"
+                        className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2.5 text-sm font-semibold text-gray-700 hover:border-orange-200 hover:text-orange-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-orange-500/30 dark:hover:text-orange-300"
                       >
                         <Pencil className="h-4 w-4" />
                         Edit
@@ -761,7 +761,7 @@ export default function TasksWorkspace() {
                             )
                           }
                           disabled={isBusy}
-                          className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:border-emerald-200 hover:text-emerald-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-emerald-500/30 dark:hover:text-emerald-300"
+                          className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2.5 text-sm font-semibold text-gray-700 hover:border-emerald-200 hover:text-emerald-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-emerald-500/30 dark:hover:text-emerald-300"
                         >
                           {task.completed_at ? (
                             <RotateCcw className="h-4 w-4" />
@@ -783,7 +783,7 @@ export default function TasksWorkspace() {
                           )
                         }
                         disabled={isBusy}
-                        className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:border-amber-200 hover:text-amber-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-amber-500/30 dark:hover:text-amber-300"
+                        className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2.5 text-sm font-semibold text-gray-700 hover:border-amber-200 hover:text-amber-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-amber-500/30 dark:hover:text-amber-300"
                       >
                         {task.archived_at ? (
                           <ArchiveRestore className="h-4 w-4" />
@@ -796,7 +796,7 @@ export default function TasksWorkspace() {
                         type="button"
                         onClick={() => void handleDeleteTask(task)}
                         disabled={isBusy}
-                        className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:border-rose-200 hover:text-rose-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-rose-500/30 dark:hover:text-rose-300"
+                        className="inline-flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-2.5 text-sm font-semibold text-gray-700 hover:border-rose-200 hover:text-rose-700 disabled:opacity-60 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-rose-500/30 dark:hover:text-rose-300"
                       >
                         {isBusy ? (
                           <Loader2 className="h-4 w-4 animate-spin" />

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Menu } from "lucide-react";
+import Image from "next/image";
 import { useNavigationStore } from "@/lib/store";
 import { usePathname } from "next/navigation";
 
@@ -8,24 +9,34 @@ export default function TopBar() {
   const { toggleMobileNav } = useNavigationStore();
   const pathname = usePathname();
 
-  const isRecordingView = pathname?.startsWith("/recordings/");
-  const buttonClassName = "pointer-events-auto inline-flex h-12 w-12 items-center justify-center rounded-2xl border border-gray-200 bg-white/90 text-gray-700 shadow-lg shadow-black/10 backdrop-blur-sm transition-colors hover:bg-white dark:border-gray-700 dark:bg-gray-800/90 dark:text-gray-300 dark:hover:bg-gray-800 dark:shadow-black/30";
-
-  if (isRecordingView) {
+  // The recording detail view renders its own full-width header/controls, so it
+  // supplies its own menu affordance and the shared bar would be redundant.
+  if (pathname?.startsWith("/recordings/")) {
     return null;
   }
 
   return (
-    <div className="pointer-events-none fixed left-4 top-[calc(env(safe-area-inset-top)+0.75rem)] z-40 lg:hidden">
-      <div className="flex items-center">
-        <button
-          onClick={toggleMobileNav}
-          className={buttonClassName}
-          title="Open Menu"
-        >
-          <Menu className="w-5 h-5" />
-        </button>
+    <header className="lg:hidden shrink-0 z-30 flex items-center gap-3 border-b border-gray-200/70 bg-white/85 px-3 pt-[calc(env(safe-area-inset-top)+0.5rem)] pb-2 backdrop-blur-md dark:border-gray-800/80 dark:bg-[#0a0f1c]/90">
+      <button
+        onClick={toggleMobileNav}
+        className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-gray-200 bg-white/90 text-gray-700 shadow-sm transition-colors hover:bg-white dark:border-gray-700 dark:bg-gray-800/90 dark:text-gray-200 dark:hover:bg-gray-800"
+        title="Open Menu"
+        aria-label="Open navigation menu"
+      >
+        <Menu className="h-5 w-5" />
+      </button>
+      <div className="flex min-w-0 items-center gap-2">
+        <Image
+          src="/assets/NojoinLogo.png"
+          alt=""
+          width={28}
+          height={28}
+          className="h-7 w-7 shrink-0 object-contain"
+        />
+        <span className="truncate text-lg font-semibold text-orange-600">
+          Nojoin
+        </span>
       </div>
-    </div>
+    </header>
   );
 }

--- a/frontend/src/components/ViewportDensityProvider.tsx
+++ b/frontend/src/components/ViewportDensityProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import {
+  DESKTOP_BREAKPOINT,
   resolveViewportDensity,
   type ViewportDensity,
 } from "@/lib/viewportDensity";
@@ -17,6 +18,10 @@ import {
 interface ViewportDensityContextValue {
   density: ViewportDensity;
   isCompact: boolean;
+  /** True below the desktop breakpoint (1024px) — the app-wide mobile boundary. */
+  isMobile: boolean;
+  /** True at or above the desktop breakpoint (1024px). */
+  isDesktop: boolean;
   viewportHeight: number;
   viewportWidth: number;
 }
@@ -71,15 +76,18 @@ export function ViewportDensityProvider({
     };
   }, [density]);
 
-  const value = useMemo(
-    () => ({
+  const value = useMemo(() => {
+    const isDesktop = width >= DESKTOP_BREAKPOINT;
+
+    return {
       density,
       isCompact: density === "compact",
+      isMobile: !isDesktop,
+      isDesktop,
       viewportHeight: height,
       viewportWidth: width,
-    }),
-    [density, height, width],
-  );
+    };
+  }, [density, height, width]);
 
   return (
     <ViewportDensityContext.Provider value={value}>

--- a/frontend/src/components/VoiceprintModal.tsx
+++ b/frontend/src/components/VoiceprintModal.tsx
@@ -387,8 +387,8 @@ export default function VoiceprintModal({
   if (!isOpen || !mounted) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center gap-3">

--- a/frontend/src/components/dashboardTasks/TaskRow.tsx
+++ b/frontend/src/components/dashboardTasks/TaskRow.tsx
@@ -149,7 +149,7 @@ export default function TaskRow(props: TaskRowProps) {
     const timeRemainingState = getTimeRemainingState(task, now);
 
     return (
-      <div className="density-surface-subtle group grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-4 border border-gray-200 bg-gradient-to-br from-white via-white to-orange-50/50 px-4 py-4 shadow-sm shadow-orange-950/5 transition-all hover:-translate-y-0.5 hover:shadow-lg dark:border-gray-700/70 dark:from-gray-900/80 dark:via-gray-900/70 dark:to-orange-500/10">
+      <div className="density-surface-subtle group grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-4 gap-y-3 border border-gray-200 bg-gradient-to-br from-white via-white to-orange-50/50 px-4 py-4 shadow-sm shadow-orange-950/5 transition-all hover:-translate-y-0.5 hover:shadow-lg sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-4 dark:border-gray-700/70 dark:from-gray-900/80 dark:via-gray-900/70 dark:to-orange-500/10">
         <button
           type="button"
           onClick={() => void handleToggleTask(task)}
@@ -225,14 +225,14 @@ export default function TaskRow(props: TaskRowProps) {
           isBusy={isBusy}
           handleArchiveTask={handleArchiveTask}
           handleDeleteTask={handleDeleteTask}
-          wrapperClassName="density-surface-panel flex shrink-0 self-center border border-transparent bg-white/80 dark:bg-white/5"
+          wrapperClassName="density-surface-panel col-span-2 justify-self-end flex shrink-0 self-center border border-transparent bg-white/80 sm:col-span-1 dark:bg-white/5"
         />
       </div>
     );
   }
 
   return (
-    <div className="density-surface-subtle grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-4 border border-gray-200 bg-white/80 px-4 py-4 dark:border-gray-700 dark:bg-gray-900/60">
+    <div className="density-surface-subtle grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-4 gap-y-3 border border-gray-200 bg-white/80 px-4 py-4 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-4 dark:border-gray-700 dark:bg-gray-900/60">
       <button
         type="button"
         onClick={() => void handleToggleTask(task)}
@@ -297,7 +297,7 @@ export default function TaskRow(props: TaskRowProps) {
         isBusy={isBusy}
         handleArchiveTask={handleArchiveTask}
         handleDeleteTask={handleDeleteTask}
-        wrapperClassName="flex shrink-0 self-center rounded-2xl border border-transparent bg-white/80 dark:bg-white/5"
+        wrapperClassName="col-span-2 justify-self-end flex shrink-0 self-center rounded-2xl border border-transparent bg-white/80 sm:col-span-1 dark:bg-white/5"
       />
     </div>
   );

--- a/frontend/src/components/people/PeopleTable.tsx
+++ b/frontend/src/components/people/PeopleTable.tsx
@@ -49,6 +49,16 @@ export function PeopleTable({
     });
   };
 
+  // Anchors the action menu to the trigger button's rectangle; ContextMenu
+  // shifts itself away from the viewport edge. Shared by the table row and the
+  // mobile card so both open the same menu.
+  const openMenuFromButton = (e: React.MouseEvent, person: GlobalSpeaker) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    setContextMenu({ x: rect.right, y: rect.bottom, person });
+  };
+
   if (isLoading) {
     return (
       <div className="w-full flex justify-center p-12">
@@ -75,192 +85,299 @@ export function PeopleTable({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
-      <div className="overflow-x-auto">
-        <table className="w-full text-left border-collapse">
-          <thead>
-            <tr className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
-              <th className="px-6 py-4 w-12">
-                <input
-                  type="checkbox"
-                  className="rounded border-gray-300 text-orange-600 focus:ring-orange-500 w-4 h-4 cursor-pointer"
-                  checked={allSelected}
-                  ref={(input) => {
-                    if (input) input.indeterminate = someSelected;
-                  }}
-                  onChange={(e) => onSelectAll(e.target.checked)}
-                />
-              </th>
-              <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/4">
-                Name
-              </th>
-              <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/4">
-                Contact
-              </th>
-              <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/6">
-                Company / Role
-              </th>
-              <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/12 text-center">
-                Meetings
-              </th>
-              <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/6">
-                Tags
-              </th>
-              <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-20 text-right">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-            {people.map((person) => (
-              <tr
-                key={person.id}
-                className={`group hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-context-menu ${selectedIds.has(person.id) ? "bg-orange-50 dark:bg-orange-900/10" : ""}`}
-                onContextMenu={(e) => handleContextMenu(e, person)}
-              >
-                {/* Checkbox */}
-                <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
+    <>
+      {/* Desktop / wide viewports: the full data table. */}
+      <div className="hidden lg:block bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+                <th className="px-6 py-4 w-12">
                   <input
                     type="checkbox"
                     className="rounded border-gray-300 text-orange-600 focus:ring-orange-500 w-4 h-4 cursor-pointer"
-                    checked={selectedIds.has(person.id)}
-                    onChange={() => onToggleSelection(person.id)}
-                  />
-                </td>
-
-                {/* Name & Avatar */}
-                <td className="px-6 py-4">
-                  <div className="flex items-center gap-3">
-                    <div
-                      className={`w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-bold shadow-sm ring-2 ring-white dark:ring-gray-800 ${person.color?.startsWith("#") ? "" : getColorByKey(person.color).dot}`}
-                      style={
-                        person.color?.startsWith("#")
-                          ? { backgroundColor: person.color }
-                          : {}
-                      }
-                    >
-                      {person.name.charAt(0).toUpperCase()}
-                    </div>
-                    <div>
-                      <div className="font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1.5">
-                        {person.name}
-                        {person.is_voiceprint_locked && (
-                          <div className="group/lock relative">
-                            <Lock className="w-3.5 h-3.5 text-green-500" />
-                            <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 px-2 py-1 text-xs text-white bg-gray-900 rounded opacity-0 group-hover/lock:opacity-100 transition-opacity whitespace-nowrap pointer-events-none">
-                              Voiceprint Locked
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </td>
-
-                {/* Contact */}
-                <td className="px-6 py-4">
-                  <div className="space-y-1">
-                    {person.email && (
-                      <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
-                        <Mail className="w-3.5 h-3.5 text-gray-400" />
-                        <a
-                          href={`mailto:${person.email}`}
-                          className="hover:text-orange-500 hover:underline"
-                        >
-                          {person.email}
-                        </a>
-                      </div>
-                    )}
-                    {person.phone_number && (
-                      <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
-                        <Phone className="w-3.5 h-3.5 text-gray-400" />
-                        <span>{person.phone_number}</span>
-                      </div>
-                    )}
-                    {!person.email && !person.phone_number && (
-                      <span className="text-sm text-gray-400 italic">
-                        No contact info
-                      </span>
-                    )}
-                  </div>
-                </td>
-
-                {/* Company / Role */}
-                <td className="px-6 py-4">
-                  <div className="space-y-0.5">
-                    {person.title && (
-                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                        {person.title}
-                      </div>
-                    )}
-                    {person.company && (
-                      <div className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400">
-                        {person.company}
-                      </div>
-                    )}
-                    {!person.title && !person.company && (
-                      <span className="text-sm text-gray-400 italic">--</span>
-                    )}
-                  </div>
-                </td>
-
-                {/* Meetings */}
-                <td className="px-6 py-4 text-center">
-                  <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                    {person.recording_count || 0}
-                  </span>
-                </td>
-
-                {/* Tags */}
-                <td className="px-6 py-4">
-                  <div className="flex flex-wrap gap-1.5">
-                    {person.tags && person.tags.length > 0 ? (
-                      person.tags.map((tag) => {
-                        const color = getColorByKey(tag.color || "gray");
-                        return (
-                          <span
-                            key={tag.id}
-                            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-200"
-                          >
-                            <span
-                              className={`w-1.5 h-1.5 rounded-full mr-1.5 ${color.dot}`}
-                            />
-                            {tag.name}
-                          </span>
-                        );
-                      })
-                    ) : (
-                      <span className="text-xs text-gray-400 italic">
-                        No tags
-                      </span>
-                    )}
-                  </div>
-                </td>
-
-                {/* Actions */}
-                <td className="px-6 py-4 text-right relative">
-                  <button
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      // Anchors the context menu to the button's bounding rectangle; the
-                      // ContextMenu component handles viewport-edge shifting internally.
-                      const rect = e.currentTarget.getBoundingClientRect();
-                      setContextMenu({
-                        x: rect.right, // ContextMenu handles shifting.
-                        y: rect.bottom,
-                        person,
-                      });
+                    checked={allSelected}
+                    ref={(input) => {
+                      if (input) input.indeterminate = someSelected;
                     }}
-                    className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                  >
-                    <MoreVertical className="w-5 h-5" />
-                  </button>
-                </td>
+                    onChange={(e) => onSelectAll(e.target.checked)}
+                  />
+                </th>
+                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/4">
+                  Name
+                </th>
+                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/4">
+                  Contact
+                </th>
+                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/6">
+                  Company / Role
+                </th>
+                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/12 text-center">
+                  Meetings
+                </th>
+                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-1/6">
+                  Tags
+                </th>
+                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider w-20 text-right">
+                  Actions
+                </th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+              {people.map((person) => (
+                <tr
+                  key={person.id}
+                  className={`group hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-context-menu ${selectedIds.has(person.id) ? "bg-orange-50 dark:bg-orange-900/10" : ""}`}
+                  onContextMenu={(e) => handleContextMenu(e, person)}
+                >
+                  {/* Checkbox */}
+                  <td
+                    className="px-6 py-4"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <input
+                      type="checkbox"
+                      className="rounded border-gray-300 text-orange-600 focus:ring-orange-500 w-4 h-4 cursor-pointer"
+                      checked={selectedIds.has(person.id)}
+                      onChange={() => onToggleSelection(person.id)}
+                    />
+                  </td>
+
+                  {/* Name & Avatar */}
+                  <td className="px-6 py-4">
+                    <div className="flex items-center gap-3">
+                      <div
+                        className={`w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-bold shadow-sm ring-2 ring-white dark:ring-gray-800 ${person.color?.startsWith("#") ? "" : getColorByKey(person.color).dot}`}
+                        style={
+                          person.color?.startsWith("#")
+                            ? { backgroundColor: person.color }
+                            : {}
+                        }
+                      >
+                        {person.name.charAt(0).toUpperCase()}
+                      </div>
+                      <div>
+                        <div className="font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1.5">
+                          {person.name}
+                          {person.is_voiceprint_locked && (
+                            <div className="group/lock relative">
+                              <Lock className="w-3.5 h-3.5 text-green-500" />
+                              <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 px-2 py-1 text-xs text-white bg-gray-900 rounded opacity-0 group-hover/lock:opacity-100 transition-opacity whitespace-nowrap pointer-events-none">
+                                Voiceprint Locked
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+
+                  {/* Contact */}
+                  <td className="px-6 py-4">
+                    <div className="space-y-1">
+                      {person.email && (
+                        <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                          <Mail className="w-3.5 h-3.5 text-gray-400" />
+                          <a
+                            href={`mailto:${person.email}`}
+                            className="hover:text-orange-500 hover:underline"
+                          >
+                            {person.email}
+                          </a>
+                        </div>
+                      )}
+                      {person.phone_number && (
+                        <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                          <Phone className="w-3.5 h-3.5 text-gray-400" />
+                          <span>{person.phone_number}</span>
+                        </div>
+                      )}
+                      {!person.email && !person.phone_number && (
+                        <span className="text-sm text-gray-400 italic">
+                          No contact info
+                        </span>
+                      )}
+                    </div>
+                  </td>
+
+                  {/* Company / Role */}
+                  <td className="px-6 py-4">
+                    <div className="space-y-0.5">
+                      {person.title && (
+                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                          {person.title}
+                        </div>
+                      )}
+                      {person.company && (
+                        <div className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400">
+                          {person.company}
+                        </div>
+                      )}
+                      {!person.title && !person.company && (
+                        <span className="text-sm text-gray-400 italic">--</span>
+                      )}
+                    </div>
+                  </td>
+
+                  {/* Meetings */}
+                  <td className="px-6 py-4 text-center">
+                    <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                      {person.recording_count || 0}
+                    </span>
+                  </td>
+
+                  {/* Tags */}
+                  <td className="px-6 py-4">
+                    <div className="flex flex-wrap gap-1.5">
+                      {person.tags && person.tags.length > 0 ? (
+                        person.tags.map((tag) => {
+                          const color = getColorByKey(tag.color || "gray");
+                          return (
+                            <span
+                              key={tag.id}
+                              className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-200"
+                            >
+                              <span
+                                className={`w-1.5 h-1.5 rounded-full mr-1.5 ${color.dot}`}
+                              />
+                              {tag.name}
+                            </span>
+                          );
+                        })
+                      ) : (
+                        <span className="text-xs text-gray-400 italic">
+                          No tags
+                        </span>
+                      )}
+                    </div>
+                  </td>
+
+                  {/* Actions */}
+                  <td className="px-6 py-4 text-right relative">
+                    <button
+                      onClick={(e) => openMenuFromButton(e, person)}
+                      className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                    >
+                      <MoreVertical className="w-5 h-5" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Narrow viewports: stacked cards so nothing needs horizontal scrolling. */}
+      <div className="lg:hidden space-y-3">
+        <label className="flex cursor-pointer items-center gap-2 px-1 text-sm text-gray-600 dark:text-gray-400">
+          <input
+            type="checkbox"
+            className="h-4 w-4 cursor-pointer rounded border-gray-300 text-orange-600 focus:ring-orange-500"
+            checked={allSelected}
+            ref={(input) => {
+              if (input) input.indeterminate = someSelected;
+            }}
+            onChange={(e) => onSelectAll(e.target.checked)}
+          />
+          Select all ({people.length})
+        </label>
+
+        {people.map((person) => (
+          <div
+            key={person.id}
+            onContextMenu={(e) => handleContextMenu(e, person)}
+            className={`rounded-xl border p-4 shadow-sm transition-colors ${
+              selectedIds.has(person.id)
+                ? "border-orange-300 bg-orange-50 dark:border-orange-500/40 dark:bg-orange-900/10"
+                : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+            }`}
+          >
+            <div className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 shrink-0 cursor-pointer rounded border-gray-300 text-orange-600 focus:ring-orange-500"
+                checked={selectedIds.has(person.id)}
+                onChange={() => onToggleSelection(person.id)}
+              />
+              <div
+                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white shadow-sm ring-2 ring-white dark:ring-gray-800 ${person.color?.startsWith("#") ? "" : getColorByKey(person.color).dot}`}
+                style={
+                  person.color?.startsWith("#")
+                    ? { backgroundColor: person.color }
+                    : {}
+                }
+              >
+                {person.name.charAt(0).toUpperCase()}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5 font-medium text-gray-900 dark:text-gray-100">
+                  <span className="truncate">{person.name}</span>
+                  {person.is_voiceprint_locked && (
+                    <Lock
+                      className="h-3.5 w-3.5 shrink-0 text-green-500"
+                      aria-label="Voiceprint locked"
+                    />
+                  )}
+                </div>
+                {(person.title || person.company) && (
+                  <div className="truncate text-sm text-gray-500 dark:text-gray-400">
+                    {[person.title, person.company].filter(Boolean).join(" · ")}
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={(e) => openMenuFromButton(e, person)}
+                className="-mr-1 -mt-1 shrink-0 rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+                aria-label={`Actions for ${person.name}`}
+              >
+                <MoreVertical className="h-5 w-5" />
+              </button>
+            </div>
+
+            {(person.email || person.phone_number) && (
+              <div className="mt-3 space-y-1 pl-7">
+                {person.email && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                    <Mail className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                    <a
+                      href={`mailto:${person.email}`}
+                      className="truncate hover:text-orange-500 hover:underline"
+                    >
+                      {person.email}
+                    </a>
+                  </div>
+                )}
+                {person.phone_number && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                    <Phone className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                    <span>{person.phone_number}</span>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="mt-3 flex flex-wrap items-center gap-1.5 pl-7">
+              <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700/60 dark:text-gray-300">
+                {person.recording_count || 0} meetings
+              </span>
+              {person.tags?.map((tag) => {
+                const color = getColorByKey(tag.color || "gray");
+                return (
+                  <span
+                    key={tag.id}
+                    className="inline-flex items-center rounded-full border border-gray-300 bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                  >
+                    <span
+                      className={`mr-1.5 h-1.5 w-1.5 rounded-full ${color.dot}`}
+                    />
+                    {tag.name}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </div>
 
       {contextMenu && (
@@ -293,6 +410,6 @@ export function PeopleTable({
           ]}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/people/PeopleTagSidebar.tsx
+++ b/frontend/src/components/people/PeopleTagSidebar.tsx
@@ -6,6 +6,7 @@ import {
   ChevronsDown,
   ChevronsUp,
   Plus,
+  Pencil,
   ChevronDown,
   ChevronRight,
   Search,
@@ -69,8 +70,7 @@ export function PeopleTagSidebar({
       const data = await getPeopleTags();
       setTags(data);
       onTagsUpdated?.(data);
-
-        } catch (error: unknown) {
+    } catch (error: unknown) {
       console.error("Failed to fetch tags:", error);
     } finally {
       setIsLoading(false);
@@ -127,8 +127,7 @@ export function PeopleTagSidebar({
       if (parentId) {
         setExpandedTagIds((prev) => new Set(prev).add(parentId));
       }
-
-        } catch (error: unknown) {
+    } catch (error: unknown) {
       console.error("Failed to add tag:", error);
     }
   };
@@ -139,8 +138,7 @@ export function PeopleTagSidebar({
       await updatePeopleTag(id, { name: name.trim() });
       await fetchTags();
       setEditingTagId(null);
-
-        } catch (error: unknown) {
+    } catch (error: unknown) {
       console.error("Failed to update tag:", error);
     }
   };
@@ -150,8 +148,7 @@ export function PeopleTagSidebar({
       await deletePeopleTag(id);
       await fetchTags();
       setConfirmDelete(null);
-
-        } catch (error: unknown) {
+    } catch (error: unknown) {
       console.error("Failed to delete tag:", error);
     }
   };
@@ -160,8 +157,7 @@ export function PeopleTagSidebar({
     try {
       await updatePeopleTag(id, { color });
       setTags((prev) => prev.map((t) => (t.id === id ? { ...t, color } : t)));
-
-        } catch (error: unknown) {
+    } catch (error: unknown) {
       console.error("Failed to update tag color:", error);
     }
   };
@@ -198,7 +194,9 @@ export function PeopleTagSidebar({
             onClick={onMobileClose}
           />
         )}
-        <div className={`${SIDEBAR_SHELL} ${mobileTransform} items-center justify-center`}>
+        <div
+          className={`${SIDEBAR_SHELL} ${mobileTransform} items-center justify-center`}
+        >
           <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-orange-500"></div>
         </div>
       </>
@@ -214,136 +212,136 @@ export function PeopleTagSidebar({
         />
       )}
       <div className={`${SIDEBAR_SHELL} ${mobileTransform}`}>
-      <div className="p-4 border-b border-gray-200 dark:border-gray-800 space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-[11px] font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider flex items-center gap-2">
-            <TagIcon className="w-3.5 h-3.5" />
-            People Tags
-          </h2>
-          <div className="flex items-center gap-1">
-            <button
-              onClick={onMobileClose}
-              className="lg:hidden p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-              title="Close"
-              aria-label="Close tag filters"
-            >
-              <X className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => {
-                const allIds = tags.map((t) => t.id);
-                setExpandedTagIds(new Set(allIds));
-              }}
-              className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-              title="Expand All"
-            >
-              <ChevronsDown className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={() => setExpandedTagIds(new Set())}
-              className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-              title="Collapse All"
-            >
-              <ChevronsUp className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={() => setIsAddingRoot(true)}
-              className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-orange-500 dark:hover:text-orange-400"
-              title="Add Tag"
-            >
-              <Plus className="w-3.5 h-3.5" />
-            </button>
+        <div className="p-4 border-b border-gray-200 dark:border-gray-800 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-[11px] font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider flex items-center gap-2">
+              <TagIcon className="w-3.5 h-3.5" />
+              People Tags
+            </h2>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={onMobileClose}
+                className="lg:hidden p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+                title="Close"
+                aria-label="Close tag filters"
+              >
+                <X className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => {
+                  const allIds = tags.map((t) => t.id);
+                  setExpandedTagIds(new Set(allIds));
+                }}
+                className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+                title="Expand All"
+              >
+                <ChevronsDown className="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={() => setExpandedTagIds(new Set())}
+                className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+                title="Collapse All"
+              >
+                <ChevronsUp className="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={() => setIsAddingRoot(true)}
+                className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-orange-500 dark:hover:text-orange-400"
+                title="Add Tag"
+              >
+                <Plus className="w-3.5 h-3.5" />
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-400" />
-          <input
-            type="text"
-            placeholder="Search tags..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 text-sm bg-gray-50 dark:bg-gray-800 border-none rounded-lg focus:ring-2 focus:ring-orange-500 outline-none transition-all"
-          />
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-y-auto custom-scrollbar p-2">
-        {isAddingRoot && (
-          <div className="mb-2 px-2 flex items-center gap-1">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-400" />
             <input
-              autoFocus
-              className="flex-1 px-2 py-1 text-sm bg-white dark:bg-gray-800 border border-orange-500 rounded outline-none"
-              placeholder="Root tag name..."
-              value={newTagName}
-              onChange={(e) => setNewTagName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleAddTag(newTagName);
-                else if (e.key === "Escape") setIsAddingRoot(false);
-              }}
+              type="text"
+              placeholder="Search tags..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-9 pr-3 py-2 text-sm bg-gray-50 dark:bg-gray-800 border-none rounded-lg focus:ring-2 focus:ring-orange-500 outline-none transition-all"
             />
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto custom-scrollbar p-2">
+          {isAddingRoot && (
+            <div className="mb-2 px-2 flex items-center gap-1">
+              <input
+                autoFocus
+                className="flex-1 px-2 py-1 text-sm bg-white dark:bg-gray-800 border border-orange-500 rounded outline-none"
+                placeholder="Root tag name..."
+                value={newTagName}
+                onChange={(e) => setNewTagName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleAddTag(newTagName);
+                  else if (e.key === "Escape") setIsAddingRoot(false);
+                }}
+              />
+              <button
+                onClick={() => handleAddTag(newTagName)}
+                className="p-1.5 text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/30 rounded"
+              >
+                <Check className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+
+          {filteredTree.map((tag) => (
+            <TagNode
+              key={tag.id}
+              tag={tag}
+              level={0}
+              expandedIds={expandedTagIds}
+              toggleExpand={toggleExpand}
+              selectedTagIds={selectedTagIds}
+              onToggleTag={onToggleTag}
+              editingTagId={editingTagId}
+              onEditStart={(id) => {
+                setEditingTagId(id);
+              }}
+              onEditCancel={() => setEditingTagId(null)}
+              onEditSave={handleUpdateTagName}
+              addingSubTagTo={addingSubTagTo}
+              onAddSubStart={setAddingSubTagTo}
+              onAddSubSave={handleAddTag}
+              onDelete={setConfirmDelete}
+              onColorChange={handleColorChange}
+            />
+          ))}
+
+          {filteredTree.length === 0 && !isAddingRoot && (
+            <div className="text-center py-8">
+              <TagIcon className="w-8 h-8 text-gray-300 dark:text-gray-700 mx-auto mb-2" />
+              <p className="text-xs text-gray-500 dark:text-gray-500">
+                No tags found
+              </p>
+            </div>
+          )}
+        </div>
+
+        {selectedTagIds.length > 0 && (
+          <div className="p-2 border-t border-gray-200 dark:border-gray-800">
             <button
-              onClick={() => handleAddTag(newTagName)}
-              className="p-1.5 text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/30 rounded"
+              onClick={onClearFilters}
+              className="w-full px-3 py-1.5 text-xs font-medium text-orange-600 dark:text-orange-400 hover:bg-orange-50 dark:hover:bg-orange-950/30 rounded-lg flex items-center justify-center gap-2 border border-orange-200 dark:border-orange-900/50 transition-colors"
             >
-              <Check className="w-4 h-4" />
+              <X className="w-3.5 h-3.5" /> Clear active filters (
+              {selectedTagIds.length})
             </button>
           </div>
         )}
 
-        {filteredTree.map((tag) => (
-          <TagNode
-            key={tag.id}
-            tag={tag}
-            level={0}
-            expandedIds={expandedTagIds}
-            toggleExpand={toggleExpand}
-            selectedTagIds={selectedTagIds}
-            onToggleTag={onToggleTag}
-            editingTagId={editingTagId}
-            onEditStart={(id) => {
-              setEditingTagId(id);
-            }}
-            onEditCancel={() => setEditingTagId(null)}
-            onEditSave={handleUpdateTagName}
-            addingSubTagTo={addingSubTagTo}
-            onAddSubStart={setAddingSubTagTo}
-            onAddSubSave={handleAddTag}
-            onDelete={setConfirmDelete}
-            onColorChange={handleColorChange}
-          />
-        ))}
-
-        {filteredTree.length === 0 && !isAddingRoot && (
-          <div className="text-center py-8">
-            <TagIcon className="w-8 h-8 text-gray-300 dark:text-gray-700 mx-auto mb-2" />
-            <p className="text-xs text-gray-500 dark:text-gray-500">
-              No tags found
-            </p>
-          </div>
-        )}
-      </div>
-
-      {selectedTagIds.length > 0 && (
-        <div className="p-2 border-t border-gray-200 dark:border-gray-800">
-          <button
-            onClick={onClearFilters}
-            className="w-full px-3 py-1.5 text-xs font-medium text-orange-600 dark:text-orange-400 hover:bg-orange-50 dark:hover:bg-orange-950/30 rounded-lg flex items-center justify-center gap-2 border border-orange-200 dark:border-orange-900/50 transition-colors"
-          >
-            <X className="w-3.5 h-3.5" /> Clear active filters (
-            {selectedTagIds.length})
-          </button>
-        </div>
-      )}
-
-      <ConfirmationModal
-        isOpen={!!confirmDelete}
-        onClose={() => setConfirmDelete(null)}
-        onConfirm={() => confirmDelete && handleDelete(confirmDelete.id)}
-        title="Delete People Tag"
-        message={`Are you sure you want to delete "${confirmDelete?.name}"? This will remove it from all people.`}
-        isDangerous
-      />
+        <ConfirmationModal
+          isOpen={!!confirmDelete}
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={() => confirmDelete && handleDelete(confirmDelete.id)}
+          title="Delete People Tag"
+          message={`Are you sure you want to delete "${confirmDelete?.name}"? This will remove it from all people.`}
+          isDangerous
+        />
       </div>
     </>
   );
@@ -441,16 +439,31 @@ function TagNode({
         </div>
 
         {!isEditing && (
-          <div className="flex items-center opacity-0 group-hover:opacity-100 transition-opacity">
+          // Controls stay visible on touch (no hover) but keep the clean
+          // hover-reveal on desktop where a pointer is available.
+          <div className="flex items-center gap-0.5 opacity-100 transition-opacity lg:opacity-0 lg:group-hover:opacity-100">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEditStart(tag.id, tag.name);
+              }}
+              className="p-1.5 hover:text-orange-500 transition-all"
+              title="Rename"
+              aria-label={`Rename ${tag.name}`}
+            >
+              <Pencil className="w-3.5 h-3.5" />
+            </button>
+
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 onAddSubStart(tag.id);
               }}
-              className="p-1 hover:text-orange-500 transition-all"
+              className="p-1.5 hover:text-orange-500 transition-all"
               title="Add sub-tag"
+              aria-label={`Add sub-tag to ${tag.name}`}
             >
-              <Plus className="w-3 h-3" />
+              <Plus className="w-3.5 h-3.5" />
             </button>
 
             {hasChildren && (
@@ -459,13 +472,16 @@ function TagNode({
                   e.stopPropagation();
                   toggleExpand(tag.id);
                 }}
-                className="p-1 hover:text-gray-600 dark:hover:text-gray-300 transition-all"
+                className="p-1.5 hover:text-gray-600 dark:hover:text-gray-300 transition-all"
                 title={isExpanded ? "Collapse" : "Expand"}
+                aria-label={
+                  isExpanded ? `Collapse ${tag.name}` : `Expand ${tag.name}`
+                }
               >
                 {isExpanded ? (
-                  <ChevronDown className="w-3 h-3" />
+                  <ChevronDown className="w-3.5 h-3.5" />
                 ) : (
-                  <ChevronRight className="w-3 h-3" />
+                  <ChevronRight className="w-3.5 h-3.5" />
                 )}
               </button>
             )}
@@ -475,10 +491,11 @@ function TagNode({
                 e.stopPropagation();
                 onDelete(tag);
               }}
-              className="p-1 hover:text-red-500 transition-all"
+              className="p-1.5 hover:text-red-500 transition-all"
               title="Delete"
+              aria-label={`Delete ${tag.name}`}
             >
-              <X className="w-3 h-3" />
+              <X className="w-3.5 h-3.5" />
             </button>
           </div>
         )}

--- a/frontend/src/components/people/PeopleTagSidebar.tsx
+++ b/frontend/src/components/people/PeopleTagSidebar.tsx
@@ -32,13 +32,23 @@ interface PeopleTagSidebarProps {
   onToggleTag: (tagId: number) => void;
   onClearFilters: () => void;
   onTagsUpdated?: (tags: PeopleTag[]) => void;
+  /** Mobile drawer state. On desktop the pane is always inline. */
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 }
+
+// Inline pane on desktop; off-canvas drawer on mobile so the People table gets
+// the full width of a phone screen.
+const SIDEBAR_SHELL =
+  "fixed inset-y-0 left-0 z-50 flex h-full w-[min(20rem,85vw)] shrink-0 flex-col overflow-hidden border-r border-gray-200 bg-white transition-transform duration-300 dark:border-gray-800 dark:bg-gray-900 lg:static lg:z-auto lg:w-64 lg:translate-x-0 lg:shadow-none";
 
 export function PeopleTagSidebar({
   selectedTagIds,
   onToggleTag,
   onClearFilters,
   onTagsUpdated,
+  mobileOpen = false,
+  onMobileClose,
 }: PeopleTagSidebarProps) {
   const [tags, setTags] = useState<PeopleTag[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -175,16 +185,35 @@ export function PeopleTagSidebar({
     return filter(tagTree);
   }, [tagTree, searchQuery]);
 
+  const mobileTransform = mobileOpen
+    ? "translate-x-0 shadow-2xl lg:shadow-none"
+    : "-translate-x-full";
+
   if (isLoading) {
     return (
-      <div className="w-64 shrink-0 border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-orange-500"></div>
-      </div>
+      <>
+        {mobileOpen && (
+          <div
+            className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+            onClick={onMobileClose}
+          />
+        )}
+        <div className={`${SIDEBAR_SHELL} ${mobileTransform} items-center justify-center`}>
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-orange-500"></div>
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="w-64 shrink-0 border-r border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 flex flex-col h-full overflow-hidden">
+    <>
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+          onClick={onMobileClose}
+        />
+      )}
+      <div className={`${SIDEBAR_SHELL} ${mobileTransform}`}>
       <div className="p-4 border-b border-gray-200 dark:border-gray-800 space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-[11px] font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider flex items-center gap-2">
@@ -192,6 +221,14 @@ export function PeopleTagSidebar({
             People Tags
           </h2>
           <div className="flex items-center gap-1">
+            <button
+              onClick={onMobileClose}
+              className="lg:hidden p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              title="Close"
+              aria-label="Close tag filters"
+            >
+              <X className="w-4 h-4" />
+            </button>
             <button
               onClick={() => {
                 const allIds = tags.map((t) => t.id);
@@ -307,7 +344,8 @@ export function PeopleTagSidebar({
         message={`Are you sure you want to delete "${confirmDelete?.name}"? This will remove it from all people.`}
         isDangerous
       />
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/components/settings/AiHuggingFaceSection.tsx
+++ b/frontend/src/components/settings/AiHuggingFaceSection.tsx
@@ -1,6 +1,7 @@
 import { Settings } from "@/types";
 import SettingsPanel from "./SettingsPanel";
 import SettingsSection from "./SettingsSection";
+import SettingsStatusBadge from "./SettingsStatusBadge";
 
 interface AiHuggingFaceSectionProps {
   settings: Settings;
@@ -19,7 +20,7 @@ export default function AiHuggingFaceSection({
       width="regular"
     >
       <SettingsPanel className="mx-auto max-w-3xl space-y-4">
-        <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl">
           <div>
             <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
               Hugging Face Integration
@@ -35,19 +36,19 @@ export default function AiHuggingFaceSection({
           </div>
           <div>
             {settings.hf_token ? (
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-400">
+              <SettingsStatusBadge tone="success">
                 Configured via Server (.env)
-              </span>
+              </SettingsStatusBadge>
             ) : (
-              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-400">
+              <SettingsStatusBadge tone="warning">
                 Missing Config
-              </span>
+              </SettingsStatusBadge>
             )}
           </div>
         </div>
         <p className="text-xs contrast-helper">
-          Required for Pyannote speaker diarization. Ensure you have accepted the
-          user agreement for{" "}
+          Required for Pyannote speaker diarization. Ensure you have accepted
+          the user agreement for{" "}
           <code>pyannote/speaker-diarization-community-1</code> on Hugging Face.
         </p>
       </SettingsPanel>

--- a/frontend/src/components/settings/AiModelDependenciesSection.tsx
+++ b/frontend/src/components/settings/AiModelDependenciesSection.tsx
@@ -3,6 +3,7 @@ import { Check, Loader2, Trash2, X } from "lucide-react";
 import { SystemModelStatus } from "@/types";
 import SettingsPanel from "./SettingsPanel";
 import SettingsSection from "./SettingsSection";
+import SettingsStatusBadge from "./SettingsStatusBadge";
 
 interface AiModelDependenciesSectionProps {
   modelStatus: SystemModelStatus | null;
@@ -75,13 +76,13 @@ export default function AiModelDependenciesSection({
                 <div className="flex items-center gap-3">
                   {modelStatus?.[model.id]?.downloaded ? (
                     <>
-                      <span className="text-xs bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400 px-2.5 py-1 rounded-full flex items-center gap-1 font-medium">
+                      <SettingsStatusBadge tone="success" className="gap-1">
                         <Check className="w-3 h-3" /> Ready
-                      </span>
+                      </SettingsStatusBadge>
                       {modelStatus?.[model.id]?.source === "bundled" && (
-                        <span className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400 px-2.5 py-1 rounded-full font-medium">
+                        <SettingsStatusBadge tone="info">
                           Bundled
-                        </span>
+                        </SettingsStatusBadge>
                       )}
                       <button
                         onClick={() => handleDeleteModel(model.id)}
@@ -106,9 +107,9 @@ export default function AiModelDependenciesSection({
                     </>
                   ) : (
                     <div className="flex flex-col items-end">
-                      <span className="text-xs bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400 px-2.5 py-1 rounded-full flex items-center gap-1 font-medium">
+                      <SettingsStatusBadge tone="error" className="gap-1">
                         <X className="w-3 h-3" /> Missing
-                      </span>
+                      </SettingsStatusBadge>
                       {modelStatus?.[model.id]?.checked_paths &&
                         modelStatus[model.id].checked_paths.length > 0 && (
                           <span

--- a/frontend/src/components/settings/AiRoutingSection.tsx
+++ b/frontend/src/components/settings/AiRoutingSection.tsx
@@ -13,7 +13,7 @@ import { checkLlmConfigured } from "./aiSettingsModels";
 import { cliModelOptions, type CliModelOption } from "./cliModels";
 
 const SELECT_CLASS =
-  "w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all";
+  "w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all disabled:opacity-50";
 
 const PROVIDER_LABEL: Record<CliProvider, string> = {
   claude_code: "Claude",

--- a/frontend/src/components/settings/AiTranscriptionSection.tsx
+++ b/frontend/src/components/settings/AiTranscriptionSection.tsx
@@ -116,18 +116,25 @@ export default function AiTranscriptionSection({
           <div>
             <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">
               Whisper Model Size
-              <div className="group relative">
+              <button
+                type="button"
+                className="group relative inline-flex"
+                aria-label="Show available Whisper models"
+              >
                 <HelpCircle className="w-4 h-4 text-gray-500 dark:text-gray-400 cursor-help" />
-                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block w-80 p-4 bg-gray-900 text-white text-xs rounded-lg shadow-xl z-50 pointer-events-none">
+                <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden max-w-[calc(100vw-2rem)] w-80 p-4 bg-gray-900 text-white text-xs rounded-lg shadow-xl z-50 pointer-events-none group-hover:block group-focus:block">
                   <div className="font-bold mb-2 text-sm">Available Models</div>
-                  <div className="grid grid-cols-5 gap-2 border-b border-gray-700 pb-2 mb-2 font-semibold">
-                    <div className="col-span-1">Size</div>
-                    <div className="col-span-1">Params</div>
-                    <div className="col-span-1">VRAM</div>
-                    <div className="col-span-1">Speed</div>
+                  <div className="grid grid-cols-4 gap-2 border-b border-gray-700 pb-2 mb-2 font-semibold text-left">
+                    <div>Size</div>
+                    <div>Params</div>
+                    <div>VRAM</div>
+                    <div>Speed</div>
                   </div>
                   {WHISPER_MODELS.map((m) => (
-                    <div key={m.id} className="grid grid-cols-5 gap-2 mb-1">
+                    <div
+                      key={m.id}
+                      className="grid grid-cols-4 gap-2 mb-1 text-left"
+                    >
                       <div className="col-span-1 font-medium text-orange-400">
                         {m.label}
                       </div>
@@ -141,7 +148,7 @@ export default function AiTranscriptionSection({
                     and accuracy.
                   </div>
                 </div>
-              </div>
+              </button>
             </label>
 
             <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
@@ -156,7 +163,8 @@ export default function AiTranscriptionSection({
                     (
                     {
                       WHISPER_MODELS.find(
-                        (m) => m.id === (settings.whisper_model_size || "turbo"),
+                        (m) =>
+                          m.id === (settings.whisper_model_size || "turbo"),
                       )?.vram
                     }{" "}
                     VRAM)

--- a/frontend/src/components/settings/BackupOptionsModal.tsx
+++ b/frontend/src/components/settings/BackupOptionsModal.tsx
@@ -51,9 +51,9 @@ export default function BackupOptionsModal({
   };
 
   return createPortal(
-    <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+    <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
       <div
-        className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg border border-gray-300 dark:border-gray-800 p-6 relative animate-in fade-in zoom-in-95 duration-200"
+        className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto border border-gray-300 dark:border-gray-800 p-6 relative animate-in fade-in zoom-in-95 duration-200"
         role="dialog"
         aria-modal="true"
         onClick={(e) => e.stopPropagation()}
@@ -66,8 +66,8 @@ export default function BackupOptionsModal({
         </button>
 
         <div className="flex items-center gap-3 mb-6">
-          <div className="p-3 bg-blue-100 dark:bg-blue-900/30 rounded-lg">
-            <Download className="w-6 h-6 text-blue-600 dark:text-blue-400" />
+          <div className="p-3 bg-orange-100 dark:bg-orange-900/30 rounded-lg">
+            <Download className="w-6 h-6 text-orange-600 dark:text-orange-400" />
           </div>
           <div>
             <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
@@ -103,7 +103,7 @@ export default function BackupOptionsModal({
                     checked={includeAudio}
                     onChange={(e) => setIncludeAudio(e.target.checked)}
                   />
-                  <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
+                  <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-orange-300 dark:peer-focus:ring-orange-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-orange-600"></div>
                 </div>
               </div>
               <p className="text-sm contrast-helper">
@@ -143,7 +143,7 @@ export default function BackupOptionsModal({
             <button
               onClick={handleExport}
               disabled={isProcessing}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow-sm transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-sm font-medium text-white bg-orange-600 hover:bg-orange-700 rounded-lg shadow-sm transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isProcessing ? (
                 <>

--- a/frontend/src/components/settings/BackupRestore.tsx
+++ b/frontend/src/components/settings/BackupRestore.tsx
@@ -147,11 +147,9 @@ export default function BackupRestore() {
       setTimeout(() => {
         window.location.reload();
       }, 2000);
-
-        } catch (error: unknown) {
+    } catch (error: unknown) {
       console.error("Import failed:", error);
-      const errorMsg =
-        getErrorMessage(error, "Failed to restore backup.");
+      const errorMsg = getErrorMessage(error, "Failed to restore backup.");
       setMessage({ type: "error", text: errorMsg });
     } finally {
       setImporting(false);
@@ -162,52 +160,53 @@ export default function BackupRestore() {
 
   return (
     <div className="space-y-6">
-      <div className="rounded-[28px] border border-gray-200/80 bg-white/95 p-6 shadow-sm dark:border-gray-800 dark:bg-gray-950/60 space-y-6">
-          {/* Export Section */}
-          <div className="pb-6 border-b border-gray-200 dark:border-gray-700">
-            <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
-              Export Backup
-            </h4>
-            <p className="text-sm contrast-helper mb-4">
-              Download a zip file containing your database, recordings, and
-              settings, tasks from the Task List, people voiceprints, and
-              calendar data.
-              <br />
-              <span className="text-xs text-orange-600 dark:text-orange-400 font-medium">
-                AI and Hugging Face keys stay redacted. Calendar provider
-                credentials and connected calendar tokens are included so
-                calendar integrations restore correctly. Treat backup files as
-                sensitive.
-              </span>
-            </p>
-            <button
-              onClick={handleExportClick}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 transition-colors"
-            >
-              <Download className="w-4 h-4 mr-2" />
-              Download Backup
-            </button>
-          </div>
+      {/* Card chrome is supplied by the enclosing SettingsSection in
+          AdminSettings; this wrapper only groups the export/restore content. */}
+      <div className="space-y-6">
+        {/* Export Section */}
+        <div className="pb-6 border-b border-gray-200 dark:border-gray-700">
+          <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+            Export Backup
+          </h4>
+          <p className="text-sm contrast-helper mb-4">
+            Download a zip file containing your database, recordings, and
+            settings, tasks from the Task List, people voiceprints, and calendar
+            data.
+            <br />
+            <span className="text-xs text-orange-600 dark:text-orange-400 font-medium">
+              AI and Hugging Face keys stay redacted. Calendar provider
+              credentials and connected calendar tokens are included so calendar
+              integrations restore correctly. Treat backup files as sensitive.
+            </span>
+          </p>
+          <button
+            onClick={handleExportClick}
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 transition-colors"
+          >
+            <Download className="w-4 h-4 mr-2" />
+            Download Backup
+          </button>
+        </div>
 
-          {/* Import Section */}
-          <div>
-            <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
-              Import Backup
-            </h4>
-            <p className="text-sm contrast-helper mb-4">
-              Restore data from a previously exported backup file.
-            </p>
+        {/* Import Section */}
+        <div>
+          <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+            Import Backup
+          </h4>
+          <p className="text-sm contrast-helper mb-4">
+            Restore data from a previously exported backup file.
+          </p>
 
-            <div className="space-y-4">
-              {/* Drag & Drop Zone */}
-              <div
-                ref={dropZoneRef}
-                onClick={() => !importing && fileInputRef.current?.click()}
-                onDragEnter={handleDragEnter}
-                onDragLeave={handleDragLeave}
-                onDragOver={handleDragOver}
-                onDrop={handleDrop}
-                className={`
+          <div className="space-y-4">
+            {/* Drag & Drop Zone */}
+            <div
+              ref={dropZoneRef}
+              onClick={() => !importing && fileInputRef.current?.click()}
+              onDragEnter={handleDragEnter}
+              onDragLeave={handleDragLeave}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+              className={`
                   relative border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors
                   ${
                     isDragging
@@ -218,115 +217,115 @@ export default function BackupRestore() {
                   }
                   ${importing ? "pointer-events-none opacity-75" : ""}
                 `}
-              >
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".zip"
-                  onChange={(e) => {
-                    const f = e.target.files?.[0];
-                    if (f) handleFileSelect(f);
-                  }}
-                  className="hidden"
-                />
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".zip"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) handleFileSelect(f);
+                }}
+                className="hidden"
+              />
 
-                {selectedFile ? (
-                  <div className="space-y-2">
-                    <FileArchive className="w-12 h-12 mx-auto text-green-500" />
-                    <p className="font-medium text-gray-900 dark:text-white truncate max-w-xs mx-auto">
-                      {selectedFile.name}
-                    </p>
-                    <p className="text-sm text-gray-500">
-                      {formatFileSize(selectedFile.size)}
-                    </p>
-                    {!importing && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleRemoveFile();
-                        }}
-                        className="text-sm text-red-500 hover:text-red-600 underline flex items-center justify-center gap-1 mx-auto"
-                      >
-                        <Trash2 className="w-3 h-3" /> Remove
-                      </button>
-                    )}
-                  </div>
-                ) : (
-                  <div className="space-y-2">
-                    <Upload className="w-12 h-12 mx-auto text-gray-500 dark:text-gray-400" />
-                    <p className="text-gray-700 dark:text-gray-300">
-                      <span className="font-medium text-orange-500">
-                        Click to browse
-                      </span>{" "}
-                      or drag and drop
-                    </p>
-                    <p className="text-xs contrast-helper">ZIP files only</p>
-                  </div>
-                )}
-              </div>
-
-              {/* Upload Progress */}
-              {importing && (
+              {selectedFile ? (
                 <div className="space-y-2">
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="text-gray-700 dark:text-gray-300">
-                      {uploadProgress < 100
-                        ? "Uploading..."
-                        : "Processing on server (Do not close)..."}
-                    </span>
-                    <span className="text-gray-900 dark:text-white font-medium">
-                      {uploadProgress}%
-                    </span>
-                  </div>
-                  <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                    <div
-                      className={`h-2 rounded-full transition-all duration-300 ${uploadProgress === 100 ? "bg-green-500 animate-pulse" : "bg-orange-500"}`}
-                      style={{ width: `${uploadProgress}%` }}
-                    />
-                  </div>
-                  {processingStatus && (
-                    <p className="mt-1 text-center text-xs italic contrast-helper">
-                      {processingStatus}
-                    </p>
+                  <FileArchive className="w-12 h-12 mx-auto text-green-500" />
+                  <p className="font-medium text-gray-900 dark:text-white truncate max-w-xs mx-auto">
+                    {selectedFile.name}
+                  </p>
+                  <p className="text-sm text-gray-500">
+                    {formatFileSize(selectedFile.size)}
+                  </p>
+                  {!importing && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRemoveFile();
+                      }}
+                      className="text-sm text-red-500 hover:text-red-600 underline flex items-center justify-center gap-1 mx-auto"
+                    >
+                      <Trash2 className="w-3 h-3" /> Remove
+                    </button>
                   )}
                 </div>
+              ) : (
+                <div className="space-y-2">
+                  <Upload className="w-12 h-12 mx-auto text-gray-500 dark:text-gray-400" />
+                  <p className="text-gray-700 dark:text-gray-300">
+                    <span className="font-medium text-orange-500">
+                      Click to browse
+                    </span>{" "}
+                    or drag and drop
+                  </p>
+                  <p className="text-xs contrast-helper">ZIP files only</p>
+                </div>
               )}
+            </div>
 
-              <button
-                onClick={handleRestoreClick}
-                disabled={!isValidZip || importing}
-                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 transition-colors"
-              >
-                {importing ? (
-                  <>
-                    <Loader2 className="animate-spin -ml-1 mr-2 h-4 w-4" />
-                    Restoring...
-                  </>
-                ) : (
-                  <>
-                    <Upload className="-ml-1 mr-2 h-4 w-4" />
-                    Restore Backup
-                  </>
+            {/* Upload Progress */}
+            {importing && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-gray-700 dark:text-gray-300">
+                    {uploadProgress < 100
+                      ? "Uploading..."
+                      : "Processing on server (Do not close)..."}
+                  </span>
+                  <span className="text-gray-900 dark:text-white font-medium">
+                    {uploadProgress}%
+                  </span>
+                </div>
+                <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                  <div
+                    className={`h-2 rounded-full transition-all duration-300 ${uploadProgress === 100 ? "bg-green-500 animate-pulse" : "bg-orange-500"}`}
+                    style={{ width: `${uploadProgress}%` }}
+                  />
+                </div>
+                {processingStatus && (
+                  <p className="mt-1 text-center text-xs italic contrast-helper">
+                    {processingStatus}
+                  </p>
                 )}
-              </button>
+              </div>
+            )}
+
+            <button
+              onClick={handleRestoreClick}
+              disabled={!isValidZip || importing}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 transition-colors"
+            >
+              {importing ? (
+                <>
+                  <Loader2 className="animate-spin -ml-1 mr-2 h-4 w-4" />
+                  Restoring...
+                </>
+              ) : (
+                <>
+                  <Upload className="-ml-1 mr-2 h-4 w-4" />
+                  Restore Backup
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {message && (
+          <div
+            className={`p-4 rounded-md ${message.type === "success" ? "bg-green-50 text-green-800 dark:bg-green-900/20 dark:text-green-300" : "bg-red-50 text-red-800 dark:bg-red-900/20 dark:text-red-300"}`}
+          >
+            <div className="flex">
+              {message.type === "success" ? (
+                <CheckCircle className="h-5 w-5 mr-2" />
+              ) : (
+                <AlertTriangle className="h-5 w-5 mr-2" />
+              )}
+              <p className="text-sm font-medium">{message.text}</p>
             </div>
           </div>
-
-          {message && (
-            <div
-              className={`p-4 rounded-md ${message.type === "success" ? "bg-green-50 text-green-800 dark:bg-green-900/20 dark:text-green-300" : "bg-red-50 text-red-800 dark:bg-red-900/20 dark:text-red-300"}`}
-            >
-              <div className="flex">
-                {message.type === "success" ? (
-                  <CheckCircle className="h-5 w-5 mr-2" />
-                ) : (
-                  <AlertTriangle className="h-5 w-5 mr-2" />
-                )}
-                <p className="text-sm font-medium">{message.text}</p>
-              </div>
-            </div>
-          )}
-        </div>
+        )}
+      </div>
       <RestoreOptionsModal
         isOpen={showRestoreOptions}
         onClose={() => setShowRestoreOptions(false)}

--- a/frontend/src/components/settings/CalendarConnectionsSettings.tsx
+++ b/frontend/src/components/settings/CalendarConnectionsSettings.tsx
@@ -448,7 +448,7 @@ export default function CalendarConnectionsSettings() {
                               : "border-gray-200 bg-white/80 hover:border-orange-200 hover:bg-orange-50/70 dark:border-gray-700 dark:bg-gray-800/80 dark:hover:border-orange-500/20 dark:hover:bg-gray-800"
                           }`}
                         >
-                          <div className="flex items-start justify-between gap-3">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2 text-gray-900 dark:text-white">
                                 <span className="truncate text-sm font-semibold">
@@ -468,7 +468,7 @@ export default function CalendarConnectionsSettings() {
                               )}
                             </div>
 
-                            <div className="flex shrink-0 items-center gap-2">
+                            <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
                               {busyKey === `colour:${calendar.id}` ? (
                                 <div className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
                                   <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/frontend/src/components/settings/InvitesTab.tsx
+++ b/frontend/src/components/settings/InvitesTab.tsx
@@ -268,8 +268,8 @@ export default function InvitesTab() {
 
       {/* Create Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-md p-6 border border-gray-200 dark:border-gray-700">
+        <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-md max-h-[calc(100dvh-2rem)] overflow-y-auto p-6 border border-gray-200 dark:border-gray-700">
             <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
               Create Invitation
             </h3>

--- a/frontend/src/components/settings/RestoreOptionsModal.tsx
+++ b/frontend/src/components/settings/RestoreOptionsModal.tsx
@@ -38,8 +38,8 @@ export default function RestoreOptionsModal({
     if (!isOpen || !mounted) return null;
 
     return createPortal(
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 backdrop-blur-sm">
-            <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg border border-gray-300 dark:border-gray-800 p-6 relative animate-in fade-in zoom-in-95 duration-200">
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+            <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto border border-gray-300 dark:border-gray-800 p-6 relative animate-in fade-in zoom-in-95 duration-200">
                 <div className="flex justify-between items-center mb-6">
                     <div className="flex items-center gap-3">
                         <div className="p-2 bg-orange-100 dark:bg-orange-900/20 rounded-lg">

--- a/frontend/src/components/settings/SecondaryProviderSection.tsx
+++ b/frontend/src/components/settings/SecondaryProviderSection.tsx
@@ -104,7 +104,7 @@ export default function SecondaryProviderSection({
     >
       <div className="mx-auto max-w-3xl space-y-4">
         <SettingsPanel className="space-y-6">
-          <div className="p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center justify-between gap-3">
+          <div className="p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                 Secondary AI provider:{" "}

--- a/frontend/src/components/settings/ServerProviderSection.tsx
+++ b/frontend/src/components/settings/ServerProviderSection.tsx
@@ -69,7 +69,7 @@ export default function ServerProviderSection({
     >
       <div className="mx-auto max-w-3xl space-y-4">
         <SettingsPanel className="space-y-6">
-          <div className="p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center justify-between gap-3">
+          <div className="p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <div className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
                 Active AI provider:{" "}

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -21,7 +21,7 @@ export default function SettingsLayout({
 }: SettingsLayoutProps) {
   return (
     <div className="flex h-full flex-col bg-gray-50 dark:bg-gray-900">
-      <div className="flex shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4 py-4 pl-14 md:px-6 md:py-5 dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4 py-4 md:px-6 md:py-5 dark:border-gray-700 dark:bg-gray-800">
         <div>
           <h1 className="density-heading-section text-2xl font-bold text-gray-900 dark:text-white">
             {title}
@@ -31,8 +31,8 @@ export default function SettingsLayout({
         {headerAccessory}
       </div>
 
-      <div className="flex flex-1 flex-col overflow-hidden md:flex-row">
-        <aside className="flex w-full shrink-0 flex-col border-b border-r-0 bg-gray-100 md:w-[15rem] lg:w-64 md:border-r md:border-b-0 dark:bg-gray-900/80 contrast-border">
+      <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
+        <aside className="flex w-full shrink-0 flex-col border-b border-r-0 bg-gray-100 lg:w-64 lg:border-r lg:border-b-0 dark:bg-gray-900/80 contrast-border">
           {sidebarHeader && <div className="border-b p-4 contrast-border">{sidebarHeader}</div>}
           {navigation}
           {sidebarFooter && <div className="border-t p-4 contrast-border">{sidebarFooter}</div>}

--- a/frontend/src/components/settings/SettingsNav.tsx
+++ b/frontend/src/components/settings/SettingsNav.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/cn";
 
 import type {
@@ -18,40 +21,56 @@ export default function SettingsNav({
   onSelect,
   matchScores,
 }: SettingsNavProps) {
-  return (
-    <nav className="hide-scrollbar flex overflow-x-auto p-2 md:flex-col md:space-y-1 md:overflow-y-auto md:p-4">
-      {items.map((item) => {
-        const Icon = item.icon;
-        const isActive = activeItemId === item.id;
-        const matchScore = matchScores?.[item.id];
-        const hasMatch = typeof matchScore === "number" && matchScore < 0.6;
+  const activeRef = useRef<HTMLButtonElement | null>(null);
 
-        return (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => onSelect(item.id)}
-            className={cn(
-              "flex shrink-0 items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors md:mb-0",
-              isActive
-                ? "settings-tab-active shadow-sm"
-                : "border-transparent settings-tab-inactive",
-            )}
-            title={item.description}
-          >
-            <span className="flex items-center gap-3">
-              <Icon
-                className={cn(
-                  "h-4 w-4",
-                  isActive ? "text-orange-800 dark:text-orange-200" : "contrast-icon-muted",
-                )}
-              />
-              {item.label}
-            </span>
-            {hasMatch && <span className="h-2 w-2 rounded-full bg-orange-500" />}
-          </button>
-        );
-      })}
-    </nav>
+  // Keep the selected tab visible in the horizontal mobile strip so a tab that
+  // sits past the right edge (e.g. Admin) is never left clipped and unreachable.
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({
+      inline: "nearest",
+      block: "nearest",
+    });
+  }, [activeItemId]);
+
+  return (
+    // The right-edge fade (mobile only) signals the strip scrolls horizontally.
+    <div className="relative md:contents">
+      <nav className="hide-scrollbar flex gap-2 overflow-x-auto p-2 pr-6 md:flex-col md:gap-0 md:space-y-1 md:overflow-y-auto md:p-4 md:pr-4">
+        {items.map((item) => {
+          const Icon = item.icon;
+          const isActive = activeItemId === item.id;
+          const matchScore = matchScores?.[item.id];
+          const hasMatch = typeof matchScore === "number" && matchScore < 0.6;
+
+          return (
+            <button
+              key={item.id}
+              ref={isActive ? activeRef : undefined}
+              type="button"
+              onClick={() => onSelect(item.id)}
+              className={cn(
+                "flex shrink-0 items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors md:mb-0",
+                isActive
+                  ? "settings-tab-active shadow-sm"
+                  : "border-transparent settings-tab-inactive",
+              )}
+              title={item.description}
+            >
+              <span className="flex items-center gap-3">
+                <Icon
+                  className={cn(
+                    "h-4 w-4",
+                    isActive ? "text-orange-800 dark:text-orange-200" : "contrast-icon-muted",
+                  )}
+                />
+                {item.label}
+              </span>
+              {hasMatch && <span className="h-2 w-2 rounded-full bg-orange-500" />}
+            </button>
+          );
+        })}
+      </nav>
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[var(--background)] to-transparent md:hidden" />
+    </div>
   );
 }

--- a/frontend/src/components/settings/SettingsNav.tsx
+++ b/frontend/src/components/settings/SettingsNav.tsx
@@ -34,8 +34,8 @@ export default function SettingsNav({
 
   return (
     // The right-edge fade (mobile only) signals the strip scrolls horizontally.
-    <div className="relative md:contents">
-      <nav className="hide-scrollbar flex gap-2 overflow-x-auto p-2 pr-6 md:flex-col md:gap-0 md:space-y-1 md:overflow-y-auto md:p-4 md:pr-4">
+    <div className="relative lg:contents">
+      <nav className="hide-scrollbar flex gap-2 overflow-x-auto p-2 pr-6 lg:flex-col lg:gap-0 lg:space-y-1 lg:overflow-y-auto lg:p-4 lg:pr-4">
         {items.map((item) => {
           const Icon = item.icon;
           const isActive = activeItemId === item.id;
@@ -49,7 +49,7 @@ export default function SettingsNav({
               type="button"
               onClick={() => onSelect(item.id)}
               className={cn(
-                "flex shrink-0 items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors md:mb-0",
+                "flex shrink-0 items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors lg:mb-0",
                 isActive
                   ? "settings-tab-active shadow-sm"
                   : "border-transparent settings-tab-inactive",
@@ -70,7 +70,7 @@ export default function SettingsNav({
           );
         })}
       </nav>
-      <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[var(--background)] to-transparent md:hidden" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[var(--background)] to-transparent lg:hidden" />
     </div>
   );
 }

--- a/frontend/src/components/settings/UsersTab.tsx
+++ b/frontend/src/components/settings/UsersTab.tsx
@@ -105,8 +105,7 @@ export default function UsersTab() {
       setIsCreating(false);
       setNewUser({ ...EMPTY_NEW_USER });
       await fetchUsers();
-
-        } catch (err: unknown) {
+    } catch (err: unknown) {
       addNotification({
         message: getErrorMessage(err, "Failed to create user"),
         type: "error",
@@ -128,15 +127,17 @@ export default function UsersTab() {
         type: "success",
       });
       const nextTotal = Math.max(0, total - 1);
-      const nextPage = Math.min(page, Math.max(1, Math.ceil(nextTotal / limit)));
+      const nextPage = Math.min(
+        page,
+        Math.max(1, Math.ceil(nextTotal / limit)),
+      );
 
       if (nextPage !== page) {
         setPage(nextPage);
       } else {
         await fetchUsers();
       }
-
-        } catch (err: unknown) {
+    } catch (err: unknown) {
       addNotification({
         message: getErrorMessage(err, "Failed to delete user"),
         type: "error",
@@ -177,8 +178,7 @@ export default function UsersTab() {
       setEditModalOpen(false);
       setEditingUser(null);
       await fetchUsers();
-
-        } catch (err: unknown) {
+    } catch (err: unknown) {
       addNotification({
         message: getErrorMessage(err, "Failed to update user"),
         type: "error",
@@ -190,16 +190,16 @@ export default function UsersTab() {
     <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="relative w-full sm:max-w-xs">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400" />
-            <input
-              value={search}
-              onChange={(e) => {
-                setSearch(e.target.value);
-                setPage(1);
-              }}
-              placeholder="Search users..."
-              className="w-full pl-9 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-            />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 dark:text-gray-400" />
+          <input
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            placeholder="Search users..."
+            className="w-full pl-9 pr-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+          />
         </div>
         <button
           onClick={toggleCreateForm}
@@ -285,76 +285,85 @@ export default function UsersTab() {
       <SettingsPanel className="overflow-hidden p-0">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm text-gray-800 dark:text-gray-200 whitespace-nowrap">
-          <thead className="bg-gray-100 dark:bg-gray-900/80 text-gray-800 dark:text-gray-100 uppercase font-medium">
-            <tr>
-              <th className="px-4 py-3">ID</th>
-              <th className="px-4 py-3">Username</th>
-              <th className="px-4 py-3">Role</th>
-              <th className="px-4 py-3">Status</th>
-              <th className="px-4 py-3 text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-300 dark:divide-gray-600">
-            {loading ? (
+            <thead className="bg-gray-100 dark:bg-gray-900/80 text-gray-800 dark:text-gray-100 uppercase font-medium">
               <tr>
-                <td colSpan={5} className="p-4 text-center">
-                  <Loader2 className="w-5 h-5 animate-spin mx-auto" />
-                </td>
+                <th className="px-4 py-3">ID</th>
+                <th className="px-4 py-3">Username</th>
+                <th className="px-4 py-3">Role</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3 text-right">Actions</th>
               </tr>
-            ) : (
-              users.map((user) => (
-                <tr
-                  key={user.id}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-700/40"
-                >
-                  <td className="px-4 py-3">{user.id}</td>
-
-                  {/* Username */}
-                  <td className="px-4 py-3">{user.username}</td>
-
-                  {/* Role */}
-                  <td className="px-4 py-3">
-                    <span
-                      className={`px-2 py-0.5 rounded text-xs ${
-                        user.role === "owner"
-                          ? "bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-300"
-                          : user.role === "admin"
-                            ? "bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-300"
-                            : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300"
-                      }`}
-                    >
-                      {user.role.charAt(0).toUpperCase() + user.role.slice(1)}
-                    </span>
-                  </td>
-
-                  {/* Status */}
-                  <td className="px-4 py-3">
-                    <span
-                      className={`px-2 py-0.5 rounded text-xs ${user.is_active ? "bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300" : "bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300"}`}
-                    >
-                      {user.is_active ? "Active" : "Inactive"}
-                    </span>
-                  </td>
-
-                  {/* Actions */}
-                  <td className="px-4 py-3 text-right flex justify-end gap-2">
-                    <button
-                      onClick={() => startEdit(user)}
-                      className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-                    >
-                      <Edit2 className="w-4 h-4" />
-                    </button>
-                    <button
-                      onClick={() => handleDeleteUser(user.id)}
-                      className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+            </thead>
+            <tbody className="divide-y divide-gray-300 dark:divide-gray-600">
+              {loading ? (
+                <tr>
+                  <td colSpan={5} className="p-4 text-center">
+                    <Loader2 className="w-5 h-5 animate-spin mx-auto" />
                   </td>
                 </tr>
-              ))
-            )}
-          </tbody>
+              ) : users.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="p-8 text-center text-sm text-gray-500 dark:text-gray-400"
+                  >
+                    No users found.
+                  </td>
+                </tr>
+              ) : (
+                users.map((user) => (
+                  <tr
+                    key={user.id}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-700/40"
+                  >
+                    <td className="px-4 py-3">{user.id}</td>
+
+                    {/* Username */}
+                    <td className="px-4 py-3">{user.username}</td>
+
+                    {/* Role */}
+                    <td className="px-4 py-3">
+                      <span
+                        className={`px-2 py-0.5 rounded text-xs ${
+                          user.role === "owner"
+                            ? "bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-300"
+                            : user.role === "admin"
+                              ? "bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-300"
+                              : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300"
+                        }`}
+                      >
+                        {user.role.charAt(0).toUpperCase() + user.role.slice(1)}
+                      </span>
+                    </td>
+
+                    {/* Status */}
+                    <td className="px-4 py-3">
+                      <span
+                        className={`px-2 py-0.5 rounded text-xs ${user.is_active ? "bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300" : "bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300"}`}
+                      >
+                        {user.is_active ? "Active" : "Inactive"}
+                      </span>
+                    </td>
+
+                    {/* Actions */}
+                    <td className="px-4 py-3 text-right flex justify-end gap-2">
+                      <button
+                        onClick={() => startEdit(user)}
+                        className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                      >
+                        <Edit2 className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => handleDeleteUser(user.id)}
+                        className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
           </table>
         </div>
         <div className="flex items-center justify-between border-t border-gray-200 dark:border-gray-700 px-4 py-3">
@@ -416,7 +425,10 @@ export default function UsersTab() {
                   type="password"
                   value={editForm.password || ""}
                   onChange={(e) =>
-                    setEditForm((prev) => ({ ...prev, password: e.target.value }))
+                    setEditForm((prev) => ({
+                      ...prev,
+                      password: e.target.value,
+                    }))
                   }
                   placeholder="Enter new password"
                   autoComplete="new-password"
@@ -432,7 +444,10 @@ export default function UsersTab() {
                 <select
                   value={editForm.role || "user"}
                   onChange={(e) =>
-                    setEditForm({ ...editForm, role: e.target.value as UserRole })
+                    setEditForm({
+                      ...editForm,
+                      role: e.target.value as UserRole,
+                    })
                   }
                   className="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-3 py-2 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-transparent"
                 >
@@ -450,7 +465,7 @@ export default function UsersTab() {
                   onChange={(e) =>
                     setEditForm({ ...editForm, is_active: e.target.checked })
                   }
-                  className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                  className="rounded border-gray-300 text-orange-600 focus:ring-orange-500"
                 />
                 <label
                   htmlFor="is_active"

--- a/frontend/src/components/settings/UsersTab.tsx
+++ b/frontend/src/components/settings/UsersTab.tsx
@@ -385,8 +385,8 @@ export default function UsersTab() {
 
       {/* Edit User Modal */}
       {editModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-md p-6 border border-gray-200 dark:border-gray-700">
+        <div className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-md max-h-[calc(100dvh-2rem)] overflow-y-auto p-6 border border-gray-200 dark:border-gray-700">
             <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
               Edit User
             </h3>

--- a/frontend/src/components/ui/MultiSelect.tsx
+++ b/frontend/src/components/ui/MultiSelect.tsx
@@ -69,10 +69,11 @@ export default function MultiSelect({
                             {option.label}
                             <button
                                 type="button"
-                                className="ml-1 rounded-full hover:bg-white/20"
+                                aria-label={`Remove ${option.label}`}
+                                className="ml-0.5 rounded-full p-0.5 hover:bg-white/20"
                                 onClick={(e) => removeSelect(e, option.value)}
                             >
-                                <X className="h-3 w-3" />
+                                <X className="h-3.5 w-3.5" />
                             </button>
                         </span>
                     ))

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -3,7 +3,7 @@ import { persist } from "zustand/middleware";
 import type { RecordingId } from "@/types";
 
 export type ViewType = "recordings" | "archived" | "deleted";
-export type ActivePanel = "transcript" | "notes" | "documents";
+export type ActivePanel = "transcript" | "notes" | "documents" | "speakers";
 
 interface NavigationState {
   // View State


### PR DESCRIPTION
## Description

Fixes a set of mobile-layout problems that made the app hard to use on a phone. All changes are layout/CSS and component-structure only — no data flow, capture logic, or API behaviour changed.

- **App shell uses `h-dvh` instead of `h-screen` (`100vh`).** `100vh` is frozen at the tallest viewport, so the bottom of every scroll view sat behind the mobile browser toolbar. `100dvh` tracks the visible area, so content is reachable. Fixes the Capture page (and all scroll views) being cut off at the bottom.
- **Navigation: a real in-flow sticky top app bar.** The hamburger was a `position: fixed` floating button that overlapped every page title. It is now a proper bar (hamburger + Nojoin brand) lifted into an outer shell column, so it reserves the top row and titles render below it. The nav↔main row moves into an inner `flex-1 min-h-0` row so full-height pages (People, Recordings) still fill exactly "viewport minus bar" with no overflow. Desktop is unchanged (the bar is `lg:hidden`, so the column collapses to today's layout).
- **People: the tag pane is desktop-inline / mobile-drawer.** It was a fixed `w-64` pane that left ~137px for the table on a phone. On mobile it is now an off-canvas drawer opened by a new "Tags" button (with an active-filter count); the table gets the full width.
- **Settings calendar rows stack on mobile.** The name + colour + Auto + toggle row forced the toggle off-screen; it now stacks (name on top, controls wrap below).
- **Settings tab strip scrolls the active tab into view**, with inter-tab gaps and a right-edge fade so it reads as scrollable (previously "Admin" was clipped and looked broken).
- **Dashboard/Tasks task rows go to a 2-column grid on mobile** (checkbox + full-width title), with archive/delete dropping to a right-aligned second row, so long titles no longer wrap to four lines. Applies to both the dashboard tasks panel and the `/tasks` page.

Fixes # (n/a)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [ ] Backend tests — not run: no backend changes in this PR
- [ ] Python quality — not run: no backend changes in this PR
- [x] Frontend lint: `cd frontend && npm run lint` — clean
- [x] Frontend unit tests: `cd frontend && npm run test` — 181 passed
- [x] Frontend build: `cd frontend && npm run build` — succeeds (TypeScript clean)
- [ ] Docs validation — not run: no docs changes
- [ ] Alembic validation — not run: no migration changes

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required (layout/CSS only; no user-facing workflow or setup change).

## Security impact

- [x] No security-sensitive change.

## Manual verification

Automated checks pass. Device smoke testing recommended before merge (Chromium on Android/iOS):

- Titles on Settings / People / Tasks / Dashboard sit fully below the top bar (no occlusion).
- Capture page and Settings scroll all the way to the bottom control (nothing behind the browser toolbar).
- People: table is full-width; the "Tags" button opens the filter drawer; backdrop/✕ closes it.
- Settings → Calendar: toggles fully visible (stacked); tab strip scrolls and centres the active tab.
- Tasks/Dashboard: long titles read on 1–2 lines with actions on their own row.

No capture *logic* changed (only the shared app-shell height), but since the Capture page inherits it, its bottom-scroll and controls are worth a quick device check. No recording context-menu changes (`RecordingCard.tsx` / `Sidebar.tsx` untouched).
