### PR TITLE
fix: repair multi-select batch actions and clarify sidebar selection cues

### DIFF
--- a/backend/api/v1/endpoints/recordings/__init__.py
+++ b/backend/api/v1/endpoints/recordings/__init__.py
@@ -114,5 +114,17 @@ from .helpers import (
 from .router import router
 from .routes_batch_init import BatchRecordingIds
 
+# Route-matching order guard. Starlette matches routes in registration order and
+# does NOT prefer a literal path segment over a path parameter. The route
+# submodules above register on one shared ``router`` in import order, and Ruff's
+# isort keeps that import list alphabetical, so ``routes_actions`` registers
+# ``/{recording_id}/soft-delete`` before ``routes_batch_init`` registers
+# ``/batch/soft-delete``. Without this sort, ``POST /batch/soft-delete`` (and
+# ``/batch/archive`` and ``/batch/restore``) match the single-recording handler
+# with ``recording_id="batch"`` and 404. Stable-sort so literal-path routes
+# precede parameterised ones; this runs before ``api.py`` copies the routes via
+# ``include_router``, and the stable sort preserves order within each group.
+router.routes.sort(key=lambda route: "{" in getattr(route, "path", ""))
+
 # Dynamically construct __all__ to include all names from this package's namespace
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/backend/tests/test_endpoint_route_contracts.py
+++ b/backend/tests/test_endpoint_route_contracts.py
@@ -6,7 +6,9 @@ the affected routers as ``(path, methods, name, response_model_name)`` so that
 any change to a path, HTTP method, handler name, or response model is caught.
 """
 
-from backend.api.v1.endpoints import speakers, transcripts
+from starlette.routing import Match
+
+from backend.api.v1.endpoints import recordings, speakers, transcripts
 
 
 def _route_contract(router):
@@ -171,3 +173,33 @@ def test_transcripts_router_is_reexported_from_package():
     # ``backend/api/v1/api.py`` can mount ``transcripts.router`` unchanged.
     assert hasattr(transcripts, "router")
     assert hasattr(speakers, "router")
+
+
+def _first_matching_route(router, method, path):
+    """Return the route Starlette would dispatch to (registration order wins)."""
+    scope = {"type": "http", "method": method, "path": path}
+    for route in router.routes:
+        match, _ = route.matches(scope)
+        if match == Match.FULL:
+            return route
+    return None
+
+
+def test_batch_recording_routes_are_not_shadowed_by_id_routes():
+    """Regression (recordings package split): batch routes must win over id routes.
+
+    The recordings package registers ``/batch/<action>`` (routes_batch_init) and
+    ``/{recording_id}/<action>`` (routes_actions) on one shared router. Starlette
+    matches in registration order and does not prefer a literal segment over a
+    path parameter, so ``POST /batch/soft-delete`` must be registered before
+    ``POST /{recording_id}/soft-delete``; otherwise it matches the single-record
+    handler with ``recording_id="batch"`` and 404s (the "Failed to delete
+    recordings" bug). Batch archive/restore/soft-delete share this hazard.
+    """
+    for action in ("archive", "restore", "soft-delete"):
+        route = _first_matching_route(recordings.router, "POST", f"/batch/{action}")
+        assert route is not None, f"POST /batch/{action} matched no route"
+        assert route.path == f"/batch/{action}", (
+            f"POST /batch/{action} is shadowed by {route.path} "
+            f"(handler {route.name}); a parameterised route matched first"
+        )

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -903,19 +903,23 @@ export default function Sidebar() {
                     }
                     onClick={(e) => handleRecordingClick(e, recording, index)}
                     onContextMenu={(e) => handleContextMenu(e, recording)}
-                    className={`block p-3 rounded-lg border transition-all shadow-sm ${
+                    className={`block p-3 rounded-lg border transition-all ${
                       isActive && !selectionMode
                         ? "bg-orange-100 dark:bg-orange-900/20 border-orange-500 dark:border-orange-500"
                         : isSelected
-                          ? "bg-orange-100 dark:bg-orange-900/10 border-orange-400 dark:border-orange-600"
+                          ? "bg-orange-50 dark:bg-orange-950/40 border-orange-400 dark:border-orange-500"
                           : "bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-800 hover:border-orange-500 hover:bg-orange-100 dark:hover:border-orange-700 dark:hover:bg-gray-800"
+                    } ${
+                      isSelected
+                        ? "ring-2 ring-orange-500 ring-offset-2 ring-offset-[#fff7ed] dark:ring-offset-[#0b1220] shadow-md"
+                        : "shadow-sm"
                     }`}
                   >
                     <div className="flex justify-between items-start mb-1">
                       <div className="flex items-center gap-2 min-w-0">
-                        {selectionMode && (
+                        {(selectionMode || isSelected) && (
                           <div
-                            className={`shrink-0 ${isSelected ? "text-orange-600" : "text-gray-300"}`}
+                            className={`shrink-0 ${isSelected ? "text-orange-600 dark:text-orange-400" : "text-gray-300 dark:text-gray-600"}`}
                           >
                             {isSelected ? (
                               <CheckSquare className="w-4 h-4" />
@@ -940,7 +944,7 @@ export default function Sidebar() {
                     </div>
 
                     <div
-                      className={`flex items-center text-xs text-gray-500 dark:text-gray-400 gap-2 ${selectionMode ? "pl-6" : ""}`}
+                      className={`flex items-center text-xs text-gray-500 dark:text-gray-400 gap-2 ${selectionMode || isSelected ? "pl-6" : ""}`}
                     >
                       <span>{formatDate(recording.created_at)}</span>
                       <span className="text-gray-300 dark:text-gray-700">


### PR DESCRIPTION
## Description

Two multi-select fixes for the recordings sidebar.

**1. Backend: batch action routes were shadowed and returned 404.** The `#100` refactor split `recordings.py` into a package where every route submodule registers on one shared `router`, imported alphabetically. Ruff's isort keeps that import order, so `routes_actions` (`/{recording_id}/...`) registered before `routes_batch_init` (`/batch/...`). Starlette matches in registration order and does not prefer a literal segment over a path parameter, so `POST /batch/soft-delete` matched `POST /{recording_id}/soft-delete` with `recording_id="batch"` and 404'd — surfacing in the UI as "Failed to delete recordings". Batch archive, restore, and soft-delete were all broken; batch permanent-delete survived only because its collision partner is a `DELETE`, not a `POST`.

The fix is a stable sort of `router.routes` at the end of the package `__init__` that puts literal-path routes ahead of parameterised ones. It is deliberately independent of import order (a plain reorder would be reverted by isort) and runs before `api.py` copies the routes via `include_router`. A behavioural regression test asserts, via Starlette's own `route.matches()`, that `POST /batch/{archive,restore,soft-delete}` dispatch to the batch handlers. The existing route-contract snapshot could not catch this because it sorts routes before comparing.

**2. Frontend: multi-select cards had no clear selection cue.** The `isSelected` style nearly duplicated the "active/open" style — in light mode both used `bg-orange-100`; borders differed by a single shade — so selecting a second meeting produced almost no visible change. Selection was also a mutually-exclusive branch, so a card that was both the open meeting and selected lost its selection cue entirely.

Selection is now an additive overlay composed on top of the base state: a floating `ring-2 ring-orange-500` with an offset matched to the sidebar background, `shadow-md` elevation, a lighter `orange-50`/`orange-950` fill, and a check tick shown on any selected card (not only in checkbox selection mode). Only `frontend/src/components/Sidebar.tsx` is touched; the grid `RecordingCard.tsx` has no multi-select state, and the recording context menu is unchanged, so no cross-file sync was required.

Fixes # (no tracked issue)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 856 passed
- [x] Python quality: `python scripts/check.py` — OK (lint, format, whitespace, filesize, typecheck, docs, alembic, tests)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` — 181 passed
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required. The backend fix restores previously intended behaviour; the frontend change is a cosmetic selection-state improvement. No user-facing guide documents the batch-select visuals.

## Security impact

- [x] No security-sensitive change.

## Manual verification

- Backend: confirmed the live `POST /api/v1/recordings/batch/soft-delete -> 404` in the `nojoin-api` container logs, reproduced the shadowed route registration order in the running container, and confirmed the new order (literal `/batch/*` before `/{recording_id}/*`). The regression test fails on the pre-fix code and passes after.
- Frontend: `npm run build` and `Sidebar.test.tsx` pass; produced a faithful static before/after preview of the selection states in light and dark.
- Not a capture change and not a context-menu change, so the capture browser-smoke matrix and the `RecordingCard.tsx`/`Sidebar.tsx` sync do not apply.

Pending: live in-app confirmation of the new selection styling after the `frontend` (and `api`) containers are rebuilt and redeployed.
