### PR TITLE
fix(security): validate upload_id as UUID to close CodeQL py/path-injection alerts (#35-#38)

### DIFF
--- a/backend/api/v1/endpoints/backup.py
+++ b/backend/api/v1/endpoints/backup.py
@@ -274,7 +274,10 @@ async def upload_chunk(upload_id: str, chunk_index: int, file: UploadFile = File
     Upload a single chunk.
     """
     path_manager = PathManager()
-    upload_dir = path_manager.get_upload_temp_dir(upload_id)
+    try:
+        upload_dir = path_manager.get_upload_temp_dir(upload_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid upload_id.")
     chunk_path = upload_dir / f"{chunk_index}.part"
 
     try:
@@ -315,8 +318,14 @@ async def complete_upload(
     final_path = restore_temp_dir / f"{job_id}_restored.zip"
 
     try:
-        # Assemble file
-        path_manager.assemble_upload(upload_id, final_path)
+        # Assemble file. A malformed upload_id (rejected by get_upload_temp_dir)
+        # or a batch with no uploaded parts is a client error, not a 500.
+        try:
+            path_manager.assemble_upload(upload_id, final_path)
+        except ValueError:
+            if final_path.exists():
+                os.remove(final_path)
+            raise HTTPException(status_code=400, detail="Invalid or empty upload.")
 
         # Initialize job
         BackupManager.restore_jobs[job_id] = {
@@ -338,6 +347,10 @@ async def complete_upload(
             status_code=202, content={"job_id": job_id, "message": "Restore started"}
         )
 
+    except HTTPException:
+        # A deliberate client-error response (e.g. 400) must not be re-wrapped
+        # into a generic 500 by the catch-all below.
+        raise
     except Exception as e:  # noqa: BLE001
         if final_path.exists():
             os.remove(final_path)

--- a/backend/tests/test_path_manager.py
+++ b/backend/tests/test_path_manager.py
@@ -1,3 +1,7 @@
+import uuid
+
+import pytest
+
 from backend.core.security import _migrate_legacy_secret_file
 from backend.utils.path_manager import PathManager
 
@@ -13,31 +17,42 @@ def _manager_rooted_at(tmp_path) -> PathManager:
     return manager
 
 
-def test_get_upload_temp_dir_sanitizes_and_contains_upload_id(tmp_path):
+def test_get_upload_temp_dir_accepts_valid_uuid_and_contains_it(tmp_path):
     manager = _manager_rooted_at(tmp_path)
     base = tmp_path / "temp_uploads"
 
-    # Legitimate id round-trips unchanged and lands inside the uploads root.
-    good = manager.get_upload_temp_dir("upload-123_abc")
-    assert good == base / "upload-123_abc"
+    # A canonical server-minted UUID round-trips to a directory inside the root.
+    upload_id = str(uuid.uuid4())
+    good = manager.get_upload_temp_dir(upload_id)
+    assert good == base / upload_id
     assert good.is_relative_to(base)
 
-    # Traversal payloads are stripped to safe segments that stay contained.
-    for hostile in ["../../etc/passwd", "a/../../b", "..%2f..", "....//x"]:
-        result = manager.get_upload_temp_dir(hostile)
-        assert result.is_relative_to(base)
+    # The id is normalized through uuid.UUID, so casing/formatting variants map
+    # to the same canonical directory rather than the raw request string.
+    canonical = str(uuid.UUID(upload_id))
+    assert manager.get_upload_temp_dir(upload_id.upper()) == base / canonical
 
     _reset_path_manager_singleton()
 
 
-def test_get_upload_temp_dir_falls_back_when_id_is_empty(tmp_path):
+def test_get_upload_temp_dir_rejects_non_uuid_and_traversal_ids(tmp_path):
     manager = _manager_rooted_at(tmp_path)
-    base = tmp_path / "temp_uploads"
 
-    # An id that sanitizes to nothing must not resolve to the base itself.
-    result = manager.get_upload_temp_dir("../..")
-    assert result == base / "default_upload"
-    assert result.is_relative_to(base)
+    # Anything that is not a canonical UUID is refused outright: there is no
+    # silent fallback bucket that two malformed uploads could collide inside,
+    # and no request-derived string ever reaches the filesystem.
+    hostile = [
+        "../../etc/passwd",
+        "a/../../b",
+        "..%2f..",
+        "....//x",
+        "upload-123_abc",
+        "../..",
+        "",
+    ]
+    for bad in hostile:
+        with pytest.raises(ValueError):
+            manager.get_upload_temp_dir(bad)
 
     _reset_path_manager_singleton()
 

--- a/backend/utils/path_manager.py
+++ b/backend/utils/path_manager.py
@@ -432,18 +432,29 @@ class PathManager:
     def get_upload_temp_dir(self, upload_id: str) -> Path:
         """
         Get the temporary directory for a specific multipart upload.
+
+        Upload ids are always server-minted UUID4 strings (see the backup
+        upload endpoints, which issue them via ``uuid.uuid4()``). The id is
+        therefore validated by round-tripping it through :class:`uuid.UUID`:
+        this rejects anything that is not a canonical UUID and, crucially,
+        rebuilds ``safe_id`` from the parsed value rather than the raw request
+        string. No attacker-controlled separator or ``..`` segment can survive
+        the round-trip, so nothing derived from the request reaches the
+        filesystem sinks below.
         """
-        # Sanitize upload_id to prevent path traversal: allow only alphanumerics,
-        # hyphen and underscore, which strips any separators or dot segments.
-        safe_id = "".join([c for c in upload_id if c.isalnum() or c in "-_"])
-        if not safe_id:
-            safe_id = "default_upload"
+        import uuid
+
+        try:
+            safe_id = str(uuid.UUID(str(upload_id)))
+        except (ValueError, AttributeError, TypeError) as exc:
+            raise ValueError(f"Invalid upload_id: {upload_id!r}") from exc
 
         base = self._user_data_directory / "temp_uploads"
         path = base / safe_id
 
-        # Defence in depth: confirm the path stays within the uploads root before
-        # any filesystem access, so no crafted upload_id can escape the base.
+        # Defence in depth: confirm the path stays within the uploads root
+        # before any filesystem access. A canonical UUID cannot escape, but the
+        # guard keeps the invariant explicit and local to the sink.
         if not path.is_relative_to(base):
             raise ValueError(f"Invalid upload_id: {upload_id!r}")
 


### PR DESCRIPTION
## Description

Closes the four open CodeQL `py/path-injection` alerts (#35-#38) and clears the remaining Dependabot backlog.

The multipart backup-upload flow already sanitised `upload_id` (character allowlist + `is_relative_to` guard, added in #98), but CodeQL does not model either construct as a taint barrier, so `upload_id` stayed tainted all the way to the `mkdir` / `glob` / `rmtree` / `open` sinks. All four alerts descend from `PathManager.get_upload_temp_dir`.

Fix: validate `upload_id` by round-tripping it through `uuid.UUID` and rebuilding `safe_id` from the parsed value. Every `upload_id` is a server-minted `uuid4` (issued in `init_upload`), so this is strictly correct, and it breaks the dataflow CodeQL follows (there is no flow step through the `UUID` constructor). It is also more correct than the old behaviour: a malformed id now raises `ValueError` instead of silently collapsing into a shared `default_upload` bucket where two bad uploads could collide. The endpoints translate that `ValueError` into a clean `400`, and `complete_upload` no longer re-wraps a deliberate `HTTPException` into a generic `500`. The `is_relative_to` guard is kept as defence in depth.

Regression tests updated to assert canonical-UUID acceptance/normalisation and outright rejection of traversal / non-UUID ids.

No new dependencies (`uuid` is stdlib).

### Dependabot (handled outside this diff)

The two open `torch` alerts (`GHSA-rrmf-rvhw-rf47`, `torch.jit.script` memory corruption) were re-reviewed and dismissed as `tolerable_risk`, matching the earlier #114 dismissal: GitHub reports no fixed release for the `<= 2.12.0` range, torchaudio publishes no 2.12.x so 2.11.0 is the matched-stack ceiling, and `torch.jit.script` is never called in first-party code (torch only loads trusted model weights). Dependabot is now at zero open alerts.

Fixes #35
Fixes #36
Fixes #37
Fixes #38

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 856 passed
- [x] Python quality: `python scripts/check.py` — OK: lint, format, whitespace, filesize, typecheck, docs, alembic, tests
- [ ] Frontend lint — not run (no frontend files changed)
- [ ] Frontend unit tests — not run (no frontend files changed)
- [ ] Frontend build — not run (no frontend files changed)
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required. `docs/SECURITY.md` documents no upload-path internals and no user-facing security guarantee changed; this is an internal hardening.

## Security impact

- [x] Touches exposure (path traversal on a superuser-only multipart upload endpoint). `docs/SECURITY.md` boundaries preserved; no boundary behaviour changed, so no update required.

## Manual verification

CodeQL rescan on this branch is the authoritative check that alerts #35-#38 are cleared; the fix is designed to remove the taint path CodeQL follows. Behaviour verified via the updated `backend/tests/test_path_manager.py` (valid UUID accepted and normalised, traversal / non-UUID ids rejected) and the full backend suite.
