### PR TITLE
fix(security): validate chunk_index at the upload chunk sink to close CodeQL py/path-injection alert (#35)

### DIFF
--- a/backend/api/v1/endpoints/backup.py
+++ b/backend/api/v1/endpoints/backup.py
@@ -274,11 +274,13 @@ async def upload_chunk(upload_id: str, chunk_index: int, file: UploadFile = File
     Upload a single chunk.
     """
     path_manager = PathManager()
+    # get_chunk_path validates both request-derived components (upload_id via
+    # UUID round-trip, chunk_index via int coercion) before returning a path
+    # that is guaranteed to sit inside the upload dir.
     try:
-        upload_dir = path_manager.get_upload_temp_dir(upload_id)
+        chunk_path = path_manager.get_chunk_path(upload_id, chunk_index)
     except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid upload_id.")
-    chunk_path = upload_dir / f"{chunk_index}.part"
+        raise HTTPException(status_code=400, detail="Invalid upload_id or chunk_index.")
 
     try:
         with open(chunk_path, "wb") as f:

--- a/backend/tests/test_path_manager.py
+++ b/backend/tests/test_path_manager.py
@@ -57,6 +57,30 @@ def test_get_upload_temp_dir_rejects_non_uuid_and_traversal_ids(tmp_path):
     _reset_path_manager_singleton()
 
 
+def test_get_chunk_path_contains_chunk_and_rejects_bad_index(tmp_path):
+    manager = _manager_rooted_at(tmp_path)
+    upload_id = str(uuid.uuid4())
+    upload_dir = tmp_path / "temp_uploads" / upload_id
+
+    # A valid index resolves to a .part file inside the upload dir.
+    chunk_path = manager.get_chunk_path(upload_id, 0)
+    assert chunk_path == upload_dir / "0.part"
+    assert chunk_path.resolve().is_relative_to(upload_dir.resolve())
+
+    # int coercion is the taint barrier: string-like ints are accepted and
+    # normalised, non-numeric and negative values are refused outright.
+    assert manager.get_chunk_path(upload_id, "12") == upload_dir / "12.part"
+    for bad in (-1, "..", "0/../../etc/passwd", "1.part", "x"):
+        with pytest.raises(ValueError):
+            manager.get_chunk_path(upload_id, bad)
+
+    # A hostile upload_id is still rejected via get_upload_temp_dir.
+    with pytest.raises(ValueError):
+        manager.get_chunk_path("../../etc/passwd", 0)
+
+    _reset_path_manager_singleton()
+
+
 def test_containerized_runtime_uses_persisted_project_data_dir(monkeypatch, tmp_path):
     project_root = tmp_path / "project"
     (project_root / "data").mkdir(parents=True)

--- a/backend/utils/path_manager.py
+++ b/backend/utils/path_manager.py
@@ -461,6 +461,37 @@ class PathManager:
         path.mkdir(parents=True, exist_ok=True)
         return path
 
+    def get_chunk_path(self, upload_id: str, chunk_index: int) -> Path:
+        """
+        Resolve the on-disk path for a single multipart-upload chunk.
+
+        Both request-derived components are neutralised before they reach a
+        filesystem sink. ``upload_id`` is validated and canonicalised by
+        :meth:`get_upload_temp_dir`; ``chunk_index`` is re-coerced through
+        :class:`int`, which is a path-injection barrier because the result can
+        only ever be digits (optionally a leading ``-``) and therefore cannot
+        carry a separator or ``..`` segment. Negative ordinals are rejected as
+        they have no valid meaning as a chunk index.
+        """
+        upload_dir = self.get_upload_temp_dir(upload_id)
+
+        try:
+            safe_index = int(chunk_index)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"Invalid chunk_index: {chunk_index!r}") from exc
+        if safe_index < 0:
+            raise ValueError(f"Invalid chunk_index: {chunk_index!r}")
+
+        chunk_path = upload_dir / f"{safe_index}.part"
+
+        # Defence in depth: confirm the path stays within the upload dir before
+        # any filesystem access, keeping the containment invariant explicit and
+        # local to the sink (mirrors get_upload_temp_dir).
+        if not chunk_path.resolve().is_relative_to(upload_dir.resolve()):
+            raise ValueError(f"Invalid chunk_index: {chunk_index!r}")
+
+        return chunk_path
+
     def assemble_upload(self, upload_id: str, dest_path: Path) -> bool:
         """
         Assemble chunks from temp directory into final file.


### PR DESCRIPTION
## Description

Closes CodeQL code scanning alert [#35](https://github.com/Valtora/Nojoin/security/code-scanning/35) (`py/path-injection`, High, CWE-22/23/36/73/99).

The alert flags the `open(chunk_path, "wb")` sink in `upload_chunk`. Commit 583f750 hardened the `upload_id` arm of this flow (UUID round-trip plus containment guard in `get_upload_temp_dir`), but the handler builds the chunk path from two request-derived values, and the second one was never sanitised:

```python
upload_dir = path_manager.get_upload_temp_dir(upload_id)   # sanitised
chunk_path = upload_dir / f"{chunk_index}.part"            # chunk_index still tainted
```

CodeQL reports per-source rather than per-sink, so the alert stayed open on the `chunk_index` taint path even after the `upload_id` fix landed.

In practice this is not exploitable. FastAPI coerces `chunk_index` to a real `int` before the handler runs, so the formatted segment can only ever be digits followed by `.part`, and no traversal is reachable. CodeQL does not model the framework's declared-type coercion as a barrier, so the flow needs an explicit runtime barrier to clear, and the sink deserves a guard that does not rely on an unenforced annotation.

This adds `PathManager.get_chunk_path(upload_id, chunk_index)`, which owns validation of both components in one place, matching how `get_upload_temp_dir` and `assemble_upload` already centralise upload path logic:

- `upload_id` is validated and canonicalised via the existing `get_upload_temp_dir` UUID round-trip.
- `chunk_index` is re-coerced through `int()`, which is the actual taint barrier (a numeric conversion cannot carry a separator or `..`). Negative ordinals are rejected.
- A `resolve()` plus `is_relative_to` containment check is kept as defence in depth, mirroring the explicit-invariant style of the `upload_id` fix.

`upload_chunk` now routes through the helper and maps a rejected value to a `400` rather than a `500`. No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (857 passed)
- [x] Python quality: `python scripts/check.py` (OK: lint, format, whitespace, filesize, typecheck, docs, alembic, tests)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Frontend checks were not run because this change touches no paths under `frontend/`.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

The documented security boundaries are unchanged. This hardens an existing internal validation rather than altering a rule described in `docs/SECURITY.md`.

## Security impact

- [ ] No security-sensitive change.
- [x] Touches auth, tokens, encryption, capture ownership, or exposure. `docs/SECURITY.md` boundaries preserved and updated where behaviour changed.

Security-relevant as a path-injection hardening on an admin-only upload sink. No `docs/SECURITY.md` behaviour changed, so no update was needed. The endpoint remains gated behind `get_current_active_superuser`.

## Manual verification

No browser or capture surface is involved, so no manual smoke testing applies. Verification was via the automated suite plus targeted unit coverage added in `backend/tests/test_path_manager.py`, which asserts the barrier directly rather than only the happy path:

- a valid index resolves to a `.part` file contained within the upload dir
- string-like integers are normalised through the `int()` coercion
- hostile values (`".."`, `"0/../../etc/passwd"`, `"1.part"`, `"x"`) and negative indices are rejected with `ValueError`
- a hostile `upload_id` is still rejected via `get_upload_temp_dir`

Pending confirmation after merge: CodeQL must re-run on `main` for alert #35 to transition to fixed.
