### PR TITLE
fix(frontend): stop false Server Unreachable alerts while the tab is hidden

### DIFF
--- a/frontend/src/lib/serviceStatusStore.test.ts
+++ b/frontend/src/lib/serviceStatusStore.test.ts
@@ -82,6 +82,36 @@ describe("serviceStatusStore backend health", () => {
     });
   });
 
+  it("does not probe or accrue failures while the tab is hidden", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+
+    try {
+      const { useServiceStatusStore } = await import("./serviceStatusStore");
+
+      await useServiceStatusStore.getState().checkBackend();
+
+      // A backgrounded tab is throttled by the browser, so a timed-out probe
+      // would be a false negative. We must not fetch, and must leave the
+      // previously-known-good status untouched.
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(useServiceStatusStore.getState()).toMatchObject({
+        backend: true,
+        backendFailCount: 0,
+      });
+    } finally {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+    }
+  });
+
   it("preserves deployment warnings when falling back to the public health probe", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/frontend/src/lib/serviceStatusStore.ts
+++ b/frontend/src/lib/serviceStatusStore.ts
@@ -77,6 +77,22 @@ export const useServiceStatusStore = create<ServiceStatusState>((set, get) => {
     backendFailCount: 0,
 
     checkBackend: async () => {
+      // A hidden/backgrounded tab has its timers throttled and network
+      // requests deprioritised by the browser, so the health probe can time
+      // out even while the backend is perfectly healthy (active recording
+      // uploads keep succeeding throughout). Skip probing while hidden so we
+      // never accrue failures — and never raise a false "Server Unreachable"
+      // alert — during a call the user is watching in another window. The
+      // visibilitychange handler in ServiceStatusAlerts re-checks immediately
+      // on return to the foreground.
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        scheduleNextBackend();
+        return;
+      }
+
       const apiBaseUrl = (process.env.NEXT_PUBLIC_API_URL || "/api").replace(
         /\/$/,
         "",


### PR DESCRIPTION
## Description

During a live meeting, the app raised two "Server Unreachable: Cannot connect to Nojoin Backend API." error toasts even though the backend was healthy the whole time and the recording completed with zero data loss.

Root cause is entirely client-side. The backend health poller in `serviceStatusStore.ts` runs on a `setTimeout` loop independent of tab visibility. When the Nojoin tab is backgrounded (as it is during a call the user is watching in another window), the browser throttles its timers and deprioritises its network requests, so the health probe's 5s `AbortController` times out even while the backend is fine. Three consecutive timeouts (`backendFailCount > 2`) trip the persistent "Server Unreachable" alert in `ServiceStatusAlerts.tsx`. Meanwhile the high-priority MediaRecorder segment uploads kept succeeding without a single sequence gap, so the poller was declaring the backend unreachable at the exact moments it was demonstrably reachable.

Log evidence from the incident: `nojoin-api` returned 200 across both windows, `nojoin-nginx` logged no errors/timeouts, segment sequences were gap-free for the affected recording, and the recording finalized 200 OK.

Fix: skip the probe (without accruing failures) when `document.visibilityState === "hidden"`, guarded by `typeof document !== "undefined"` for SSR safety. The existing focus/`visibilitychange` handler in `ServiceStatusAlerts.tsx` already forces an immediate re-check on return to the foreground, so a genuine outage is still surfaced the moment the user looks at the tab.

No new dependencies.

Fixes # (n/a — reported from production logs)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [ ] Backend tests: `source .venv/bin/activate && pytest` (not run locally; frontend-only change, covered by CI "Backend tests")
- [ ] Python quality: `python scripts/check.py` (not run; no Python touched)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (37 files, 182 tests passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required.

## Security impact

- [x] No security-sensitive change.

## Manual verification

Added a unit test asserting `checkBackend()` does not fetch and does not increment `backendFailCount` while `document.visibilityState` is "hidden", and that previously-known-good status is preserved. Existing tests (which run under jsdom's default "visible" state) are unchanged and still pass.

Recommended manual smoke before merge: start a recording, switch to another window/tab for a couple of minutes so the Nojoin tab is backgrounded, confirm no "Server Unreachable" toast appears, return to the tab and confirm status stays healthy; separately, stop the backend while the tab is foregrounded and confirm the alert still fires as before.
