### PR TITLE
feat(notes): consolidate note generation on a shared spec and improve structure

### DIFF
--- a/backend/processing/llm_backends/anthropic.py
+++ b/backend/processing/llm_backends/anthropic.py
@@ -151,9 +151,11 @@ class AnthropicLLMBackend(LLMBackend):
                 "No Anthropic model configured. Please select a model in Settings."
             )
         try:
+            # Match the unified meeting-intelligence path's ceiling so the shared
+            # "be comprehensive" notes spec is not silently truncated on long meetings.
             response = self.client.messages.create(
                 model=self.model,
-                max_tokens=2048,
+                max_tokens=4096,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.2,
             )

--- a/backend/processing/llm_backends/base.py
+++ b/backend/processing/llm_backends/base.py
@@ -25,6 +25,7 @@ from backend.utils.meeting_intelligence import (
     AutomaticMeetingIntelligenceRequest,
     AutomaticMeetingIntelligenceResult,
     MeetingIntelligenceContractError,
+    build_title_preference_instruction,
     get_default_automatic_meeting_intelligence_prompt_template,
 )
 from backend.utils.meeting_intelligence import (
@@ -37,10 +38,12 @@ from backend.utils.meeting_intelligence import (
     parse_automatic_meeting_intelligence_response as parse_automatic_meeting_intelligence_payload,
 )
 from backend.utils.meeting_notes import (
+    NOTES_BODY_SPEC,
     MeetingEventContext,
     append_user_notes_section,
     build_meeting_context_prompt_section,
     build_user_notes_prompt_section,
+    strip_leading_title_heading,
 )
 from backend.utils.speaker_name_suggestions import (
     SpeakerInferenceResult,
@@ -238,11 +241,6 @@ class LLMBackend:
         return build_chat_prompt(user_question, meeting_notes, diarized_transcript)
 
     @staticmethod
-    def get_default_speaker_prompt_template():
-        return """
-You are an expert meeting assistant. Analyze the diarized meeting transcript below, where speakers are labeled generically (e.g., 'Speaker 1', 'SPEAKER_00').\n\nFirst, infer the most likely real names or roles for each speaker, based on context, introductions, or references in the transcript. Use the user-authored notes as supplemental context when they mention attendee names, roles, or who said what. If a real name is not clear, suggest a likely role (e.g., 'Project Manager', 'Client', 'Engineer') or keep the generic label. Be conservative: only use a real name or role if it is clearly stated or strongly implied. If the user notes conflict with the transcript, prefer the transcript.\n\nOutput a Markdown table mapping each diarization label to the inferred name or role. Only output the table and nothing else.\n\n# User Notes Context\n{user_notes_section}\n\n# Meeting Context\n{meeting_context_section}\n\nBelow is the diarized transcript:\n\n{transcript}\n"""
-
-    @staticmethod
     def get_default_speaker_suggestion_prompt_template():
         return """
 You are an expert meeting assistant. Analyze the diarized meeting transcript below and return only evidence-backed speaker name suggestions for unresolved diarization labels.
@@ -292,17 +290,12 @@ You are an expert meeting assistant. Analyze the diarized meeting transcript bel
 
     @staticmethod
     def get_default_notes_prompt_template():
-        return """You are an expert meeting intelligence assistant. Your task is to generate comprehensive, high-quality meeting notes from the provided transcript. Use the speaker mapping to refer to participants by their inferred names/roles instead of generic labels.
-
-# CRITICAL FORMATTING REQUIREMENTS
-You MUST follow these formatting rules EXACTLY. Do not deviate:
-1. Use ONLY the section structure specified below, with headings translated into the requested output language
-2. Use Markdown formatting throughout
-3. Be thorough and detailed - notes may be as lengthy as required to capture all important content
-4. Do NOT add any introductory text, concluding remarks, or sections not specified below
-5. Start your response with one top-level Markdown heading (`# ...`) in the requested output language - nothing before it
-6. Incorporate relevant user-authored notes into the appropriate sections when they add useful context or action items
-7. Do NOT add a separate appendix or label LLM-generated content as such; the application will surface the user-authored notes separately
+        # Body structure and fidelity rules live in the shared NOTES_BODY_SPEC so
+        # this standalone (regeneration) prompt and the unified meeting-intelligence
+        # prompt cannot drift. Only the delivery wrapper (raw Markdown, speaker
+        # mapping, transcript) is specific to this path.
+        return (
+            """You are an expert meeting-notes assistant. Generate meeting notes from the transcript below. Use the speaker mapping to refer to participants by their inferred names or roles instead of generic labels.
 
 # Speaker Mapping
 {mapping_table}
@@ -315,74 +308,29 @@ You MUST follow these formatting rules EXACTLY. Do not deviate:
 
 {output_language_section}
 
-# OUTPUT FORMAT - Follow this EXACT structure:
+# Notes Format
+"""
+            + NOTES_BODY_SPEC
+            + """
 
-# [Localized meeting-notes heading]
-
-## [Localized Topics Discussed heading]
-List each major topic or theme discussed in the meeting as a bullet point. Be specific and descriptive.
-- Topic 1: Brief description
-- Topic 2: Brief description
-(continue for all topics)
-
-## [Localized Summary heading]
-Provide a comprehensive summary of the meeting covering:
-- The main purpose and context of the meeting
-- Key points raised by participants
-- Important information shared
-- Overall conclusions or outcomes reached
-
-## [Localized Detailed Notes heading]
-
-### [Topic Name 1]
-Provide detailed notes on this topic including:
-- **Key Points**: Main arguments, information, or ideas presented
-- **Discussion**: What was debated or discussed, including different perspectives
-- **Decisions**: Any decisions made regarding this topic (if applicable)
-- **Rationale**: The reasoning behind decisions or recommendations (if discussed)
-- **Open Questions**: Any unresolved questions or points requiring follow-up
-
-### [Topic Name 2]
-(Follow the same structure for each major topic)
-
-(Continue for all topics discussed)
-
-## [Localized Action Items / Tasks heading]
-List all tasks, action items, or follow-ups mentioned, formatted as:
-- [ ] Task description - Assigned to: [Person] - Due: [Date if mentioned, otherwise "TBD"]
-(If no tasks were discussed, write: "No specific action items were identified in this meeting.")
-
-## [Localized Miscellaneous heading]
-Capture any additional important information that doesn't fit the above categories:
-- Side discussions or tangential points of interest
-- Announcements or FYIs mentioned
-- References to external documents, resources, or prior meetings
-- Any other noteworthy content
-(If nothing applicable, write: "No additional items.")
-
----
-
-# Transcript to Analyze:
-
+# Transcript to Analyze
 {transcript}
 
----
-
-Now generate the meeting notes following the exact structure specified above, replacing bracketed heading descriptions with headings in the requested output language. Be comprehensive and capture all important details."""
-
-    @staticmethod
-    def get_default_title_prompt_template():
-        return (
-            "You are an expert meeting assistant. Given the full meeting transcript below, "
-            "provide a concise, descriptive title that summarises the main topic or purpose of the meeting. "
-            "Limit the title to at most 12 words. Output ONLY the title with no additional commentary, punctuation, or formatting.\n\n"
-            "{output_language_section}\n\n"
-            "# Transcript\n\n{transcript}\n"
+Return only the meeting notes described above, starting directly with the Summary section and with no preamble or closing commentary."""
         )
 
     @staticmethod
-    def get_speaker_prompt_template() -> str:
-        return LLMBackend.get_default_speaker_prompt_template()
+    def get_default_title_prompt_template():
+        # Reuse the shared title-style instruction (short titles by default) so the
+        # standalone title path matches the unified meeting-intelligence path.
+        return (
+            "You are an expert meeting-notes assistant. Given the full meeting transcript below, "
+            "provide a title that summarises the main topic or purpose of the meeting. "
+            + build_title_preference_instruction(True)
+            + " Output ONLY the title with no additional commentary, punctuation, or formatting.\n\n"
+            "{output_language_section}\n\n"
+            "# Transcript\n\n{transcript}\n"
+        )
 
     @staticmethod
     def get_notes_prompt_template() -> str:
@@ -403,25 +351,6 @@ Now generate the meeting notes following the exact structure specified above, re
     @staticmethod
     def get_meeting_edge_prompt_template() -> str:
         return get_default_meeting_edge_prompt_template()
-
-    @staticmethod
-    def parse_mapping_table(response_text: str) -> Dict[str, str]:
-        lines = [line.strip() for line in response_text.splitlines() if line.strip()]
-        mapping = {}
-        in_table = False
-        for line in lines:
-            if line.startswith("|") and "|" in line[1:]:
-                in_table = True
-                parts = [p.strip() for p in line.strip("|").split("|")]
-                if (
-                    len(parts) == 2
-                    and parts[0] != "Diarization Label"
-                    and not parts[0].startswith("-")
-                ):
-                    mapping[parts[0]] = parts[1]
-            elif in_table and (not line.startswith("|")):
-                break
-        return mapping
 
     @staticmethod
     def parse_notes(response_text: str) -> str:
@@ -485,21 +414,6 @@ Now generate the meeting notes following the exact structure specified above, re
         )
 
     @staticmethod
-    def build_speaker_prompt(
-        prompt_template: str,
-        transcript: str,
-        user_notes: Optional[str] = None,
-        meeting_context: Optional[MeetingEventContext] = None,
-    ) -> str:
-        return prompt_template.format(
-            transcript=transcript,
-            user_notes_section=build_user_notes_prompt_section(user_notes),
-            meeting_context_section=build_meeting_context_prompt_section(
-                meeting_context
-            ),
-        )
-
-    @staticmethod
     def build_speaker_suggestion_prompt(
         prompt_template: str,
         transcript: str,
@@ -544,7 +458,7 @@ Now generate the meeting notes following the exact structure specified above, re
 
     @staticmethod
     def finalise_meeting_notes(notes: str, user_notes: Optional[str] = None) -> str:
-        return append_user_notes_section(notes, user_notes)
+        return append_user_notes_section(strip_leading_title_heading(notes), user_notes)
 
     @staticmethod
     def parse_automatic_meeting_intelligence_result(

--- a/backend/tests/test_automatic_meeting_intelligence_worker.py
+++ b/backend/tests/test_automatic_meeting_intelligence_worker.py
@@ -364,7 +364,7 @@ def test_run_automatic_meeting_intelligence_stage_persists_suggestions_title_and
         assert transcript.error_message is None
         assert (
             transcript.notes
-            == "# Meeting Notes\n\n## Summary\nGenerated notes.\n\n## User Notes\n- [User] Confirm the rollout date"
+            == "## Summary\nGenerated notes.\n\n## User Notes\n- [User] Confirm the rollout date"
         )
         assert captured["request"].unresolved_speakers == ("SPEAKER_00",)
         assert captured["request"].user_notes == "Confirm the rollout date"
@@ -512,7 +512,7 @@ def test_auto_apply_links_exact_global_match_and_respects_voiceprint_lock(
             return AutomaticMeetingIntelligenceResult(
                 speaker_mapping={"SPEAKER_00": "Dana"},
                 title="Launch Readiness Review",
-                notes_markdown="# Meeting Notes\n\nGenerated notes.",
+                notes_markdown="## Summary\nGenerated notes.",
             )
 
     monkeypatch.setattr(

--- a/backend/tests/test_llm_services_unified.py
+++ b/backend/tests/test_llm_services_unified.py
@@ -166,7 +166,7 @@ def test_anthropic_generate_meeting_intelligence_uses_shared_contract() -> None:
     assert "## User Notes" in result.notes_markdown
     assert capture["max_tokens"] == 4096
     assert capture["messages"][0]["content"].startswith(
-        "You are an expert meeting intelligence assistant."
+        "You are an expert meeting-notes assistant."
     )
 
 

--- a/backend/tests/test_meeting_intelligence.py
+++ b/backend/tests/test_meeting_intelligence.py
@@ -1,7 +1,9 @@
 import json
 from types import SimpleNamespace
 
+from backend.processing.llm_backends.base import LLMBackend
 from backend.utils.meeting_intelligence import (
+    DEFAULT_AUTOMATIC_MEETING_INTELLIGENCE_PROMPT_TEMPLATE,
     AutomaticMeetingIntelligenceRequest,
     AutomaticMeetingIntelligenceResult,
     MeetingIntelligenceContractError,
@@ -12,6 +14,7 @@ from backend.utils.meeting_intelligence import (
     parse_automatic_meeting_intelligence_response,
 )
 from backend.utils.meeting_notes import (
+    NOTES_BODY_SPEC,
     is_placeholder_speaker_name,
     resolve_recording_speaker_name,
 )
@@ -30,7 +33,9 @@ def test_parse_automatic_meeting_intelligence_response_from_json() -> None:
 
     assert result.speaker_mapping == {"SPEAKER_00": "Alex"}
     assert result.title == "Launch Readiness Review"
-    assert result.notes_markdown.startswith("# Meeting Notes")
+    # A redundant title heading is stripped; notes begin at the Summary section.
+    assert result.notes_markdown.startswith("## Summary")
+    assert "# Meeting Notes" not in result.notes_markdown
 
 
 def test_parse_automatic_meeting_intelligence_response_from_fenced_json() -> None:
@@ -115,19 +120,64 @@ def test_automatic_meeting_intelligence_request_rejects_duplicate_labels() -> No
         raise AssertionError("Expected MeetingIntelligenceContractError")
 
 
-def test_automatic_meeting_intelligence_result_requires_top_level_markdown_heading() -> (
-    None
-):
+def test_automatic_meeting_intelligence_result_requires_a_section_heading() -> None:
     try:
         AutomaticMeetingIntelligenceResult(
             speaker_mapping={"SPEAKER_00": "Alex"},
             title="Launch Readiness Review",
-            notes_markdown="## Summary\nAll teams are ready.",
+            notes_markdown="All teams are ready.",
         )
     except MeetingIntelligenceContractError as exc:
-        assert "top-level Markdown heading" in str(exc)
+        assert "section heading" in str(exc)
     else:
         raise AssertionError("Expected MeetingIntelligenceContractError")
+
+
+def test_automatic_meeting_intelligence_result_accepts_summary_first_notes() -> None:
+    result = AutomaticMeetingIntelligenceResult(
+        speaker_mapping={"SPEAKER_00": "Alex"},
+        title="Launch Readiness Review",
+        notes_markdown="## Summary\nAll teams are ready.",
+    )
+
+    assert result.notes_markdown.startswith("## Summary")
+
+
+def test_both_notes_prompts_embed_the_shared_notes_body_spec() -> None:
+    # Drift guard: the unified meeting-intelligence prompt and the standalone
+    # regeneration prompt must both embed NOTES_BODY_SPEC verbatim so their note
+    # structure and fidelity rules can never diverge again.
+    assert NOTES_BODY_SPEC in DEFAULT_AUTOMATIC_MEETING_INTELLIGENCE_PROMPT_TEMPLATE
+    assert NOTES_BODY_SPEC in LLMBackend.get_default_notes_prompt_template()
+
+
+def test_notes_body_spec_uses_the_best_practice_section_order() -> None:
+    # Structure follows the approved best-practice layout: summary first, then
+    # decisions and action items surfaced ahead of the per-topic detail.
+    positions = [
+        NOTES_BODY_SPEC.index(marker)
+        for marker in (
+            "## Summary",
+            "## Key Decisions",
+            "## Action Items / Tasks",
+            "## Detailed Notes",
+            "## Miscellaneous",
+        )
+    ]
+    assert positions == sorted(positions)
+    assert "Never invent facts" in NOTES_BODY_SPEC
+    # Notes must begin at Summary; the app shows the meeting title separately.
+    assert "do not add a title heading" in NOTES_BODY_SPEC.lower()
+
+
+def test_rendered_unified_prompt_carries_the_new_structure() -> None:
+    request = AutomaticMeetingIntelligenceRequest(
+        resolved_transcript="[00:00 - 00:05] Alex: We will ship on Friday.",
+        unresolved_speakers=(),
+    )
+    prompt = build_automatic_meeting_intelligence_prompt(request)
+    assert "## Key Decisions" in prompt
+    assert "## Summary" in prompt
 
 
 def test_build_automatic_meeting_intelligence_prompt_includes_shared_sections() -> None:
@@ -153,14 +203,16 @@ def test_build_automatic_meeting_intelligence_prompt_includes_shared_sections() 
     assert "Keep any JSON keys exactly as specified" in prompt
 
 
-def test_automatic_meeting_intelligence_accepts_localized_top_level_heading() -> None:
+def test_automatic_meeting_intelligence_strips_localized_title_heading() -> None:
     result = AutomaticMeetingIntelligenceResult(
         speaker_mapping={},
         title="Préparation du lancement",
         notes_markdown="# Notes de réunion\n\n## Résumé\nToutes les équipes sont prêtes.",
     )
 
-    assert result.notes_markdown.startswith("# Notes de réunion")
+    # The localized title heading is stripped; notes begin at the localized Summary.
+    assert result.notes_markdown.startswith("## Résumé")
+    assert "Notes de réunion" not in result.notes_markdown
 
 
 def test_get_speakers_eligible_for_llm_renaming_excludes_trusted_speakers() -> None:

--- a/backend/utils/meeting_intelligence.py
+++ b/backend/utils/meeting_intelligence.py
@@ -8,17 +8,20 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from backend.utils.languages import build_output_language_prompt_section
 from backend.utils.meeting_notes import (
+    NOTES_BODY_SPEC,
     MeetingEventContext,
     append_user_notes_section,
     build_meeting_context_prompt_section,
     build_user_notes_prompt_section,
     is_placeholder_speaker_name,
     resolve_recording_speaker_name,
+    strip_leading_title_heading,
 )
 
 JSON_FENCE_PATTERN = re.compile(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", re.IGNORECASE)
 
-DEFAULT_AUTOMATIC_MEETING_INTELLIGENCE_PROMPT_TEMPLATE = """You are an expert meeting intelligence assistant.
+DEFAULT_AUTOMATIC_MEETING_INTELLIGENCE_PROMPT_TEMPLATE = (
+    """You are an expert meeting-notes assistant.
 
 Your task is to produce one valid JSON object that combines:
 1. speaker suggestions for unresolved diarization labels only
@@ -54,24 +57,18 @@ Your task is to produce one valid JSON object that combines:
         "SPEAKER_00": "Person name or role"
     }},
     "title": "Meeting title",
-    "notes_markdown": "# Localized meeting-notes heading\\n\\n## Localized section heading\\n..."
+    "notes_markdown": "## Localized summary heading\\n\\n...\\n\\n## Localized section heading\\n..."
 }}
 
 # Notes Markdown Requirements
-- Use Markdown.
-- Start with exactly one top-level Markdown heading (`# ...`) in the requested output language.
-- Use localized equivalents of this section order:
-    1. Topics Discussed
-    2. Summary
-    3. Detailed Notes
-    4. Action Items / Tasks
-    5. Miscellaneous
-- Incorporate relevant user-authored notes into the body where they materially improve accuracy.
-- Do not add a separate appendix for user notes.
+"""
+    + NOTES_BODY_SPEC
+    + """
 
 # Transcript
 {transcript}
 """
+)
 
 
 class MeetingIntelligenceContractError(ValueError):
@@ -158,7 +155,11 @@ class AutomaticMeetingIntelligenceResult:
             if str(label).strip() and str(name).strip()
         }
         title = re.sub(r"\s+", " ", self.title.strip())
-        notes_markdown = self.notes_markdown.replace("\r\n", "\n").strip()
+        # Notes must begin at the Summary section; the application shows the meeting
+        # title separately. Strip a redundant title heading if the model emits one.
+        notes_markdown = strip_leading_title_heading(
+            self.notes_markdown.replace("\r\n", "\n").strip()
+        )
 
         if not title:
             raise MeetingIntelligenceContractError("title must be a non-empty string")
@@ -168,9 +169,9 @@ class AutomaticMeetingIntelligenceResult:
                 "notes_markdown must be a non-empty string"
             )
 
-        if not re.match(r"^#\s+\S", notes_markdown):
+        if not re.match(r"^##\s+\S", notes_markdown):
             raise MeetingIntelligenceContractError(
-                "notes_markdown must start with a top-level Markdown heading"
+                "notes_markdown must start with a section heading (## ...)"
             )
 
         object.__setattr__(self, "speaker_mapping", normalized_mapping)

--- a/backend/utils/meeting_notes.py
+++ b/backend/utils/meeting_notes.py
@@ -7,6 +7,64 @@ PLACEHOLDER_SPEAKER_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Single source of truth for the meeting-notes body: the section structure and
+# fidelity rules the model must follow. Both note-generation paths embed this
+# verbatim -- the unified meeting-intelligence prompt (inside its JSON
+# ``notes_markdown`` field) and the standalone regeneration prompt (as raw
+# Markdown) -- so the two can never drift in structure or quality again. A test
+# asserts both templates contain it.
+#
+# The layout follows external best practice: lead with a scannable summary,
+# surface decisions and action items where they drive follow-through, then the
+# per-topic detail. Keep this string free of ``{``/``}`` so it survives the
+# ``str.format`` call each embedding template still runs.
+NOTES_BODY_SPEC = """Structure the notes for fast follow-through, not verbatim transcription. Write Markdown and begin directly with the Summary section below. Do not add a title heading of your own; the application already displays the meeting title above the notes. Translate every heading below into the requested output language, keeping this order and structure.
+
+## Summary
+Two to four sentences the reader can scan first: why the meeting happened and what came out of it. Lead with outcomes, not chronology.
+
+## Key Decisions
+Each decision the meeting actually reached, one per line, paired with the reasoning behind it so it is not re-litigated later:
+- The decision - the reasoning or trade-off behind it.
+Omit this entire section if no decisions were reached. Never record a decision that was not made.
+
+## Action Items / Tasks
+Every task, commitment, or follow-up that was actually raised, one per line:
+- [ ] Task description - Owner: single named person, or Unassigned - Due: a date, or TBD
+Give each item exactly one owner; never assign a task to the team as a whole. If none were raised, write a single line stating that no action items were identified.
+
+## Detailed Notes
+One ### subsection per major topic, in the order discussed, with the subheading naming the topic. Under each, include only what applies:
+- Key Points: the substantive information, arguments, or figures, attributed to the participant who raised them where that matters.
+- Discussion: what was debated, including differing perspectives, summarised rather than transcribed.
+- Open Questions: anything left unresolved or needing follow-up.
+
+## Miscellaneous
+Anything material that fits nowhere above: announcements, FYIs, or references to external documents and prior meetings. If nothing applies, write a single line saying so.
+
+Apply these fidelity rules throughout:
+- Be comprehensive about what was said, but favour signal over volume: capture every decision, commitment, and material point, and leave out greetings, small talk, and filler.
+- Never invent facts, decisions, action items, figures, or attributions. If it was not said, do not record it.
+- Attribute claims and commitments to the participant who made them, using their mapped name or role rather than a generic label.
+- Weave any user-authored notes into the relevant sections where they improve accuracy. The application preserves the raw user notes separately, so do not add your own appendix for them and do not label content as AI-generated or user-generated."""
+
+
+_LEADING_TITLE_HEADING_PATTERN = re.compile(r"^\s*#\s+[^\n]*(?:\n+|\Z)")
+
+
+def strip_leading_title_heading(notes_markdown: str) -> str:
+    """Remove a single leading level-1 (``# ...``) title line from notes.
+
+    Generated notes must begin at the Summary section: the application renders the
+    meeting title separately, so a title heading inside the notes is redundant and
+    can even contradict it. The prompt instructs the model accordingly; this
+    defensively strips a title heading if a model still emits one. Level-2+
+    headings (``## ...``) are left untouched.
+    """
+    if not notes_markdown:
+        return notes_markdown
+    return _LEADING_TITLE_HEADING_PATTERN.sub("", notes_markdown, count=1).strip()
+
 
 def resolve_recording_speaker_name(speaker: Any) -> Optional[str]:
     resolved_name = (


### PR DESCRIPTION
## Description

A pass over Nojoin's note-generation prompts to improve the consistency and quality of generated meeting notes.

The core problem: the automatic first pass (the unified meeting-intelligence prompt) and the "Regenerate Notes" button (the standalone notes prompt) used two separate, drifted prompt bodies, so regenerating notes could produce a different structure from the original. This change makes both paths share a single source of truth and adopts an evidence-based note structure.

What changed:

- Added `NOTES_BODY_SPEC` in `backend/utils/meeting_notes.py` as the single source of truth for note structure and fidelity rules. Both note-generation prompts (unified `meeting_intelligence.py` and standalone `base.py`) embed it verbatim, so they can no longer drift. A drift-guard test asserts both contain it.
- Restructured notes to a best-practice, follow-through-oriented layout: `Summary` first, a dedicated scannable `Key Decisions` section (with rationale), prominent `Action Items` (single named owner plus due date), then per-topic `Detailed Notes`, then `Miscellaneous`. This replaces the previous topic-list-first layout that buried decisions.
- Added anti-hallucination fidelity rules to the notes body (never invent facts, decisions, figures, or attributions; attribute claims to the speaker who made them; favour signal over volume). The primary path previously had none.
- Notes now begin at the `Summary` section and no longer emit their own top-level title heading, which duplicated and sometimes contradicted the meeting title the app already displays. Enforced by the prompt instruction, the JSON schema example, a defensive `strip_leading_title_heading()` helper applied in both paths, and an updated result contract (notes must start with a `## ` section heading).
- Unified the persona to "expert meeting-notes assistant" across the notes and title prompts, and routed the standalone title prompt through the shared short-title instruction so both title paths behave consistently.
- Raised the Anthropic standalone-notes `max_tokens` from 2048 to 4096 to match the unified path so comprehensive notes are not silently truncated.
- Removed the dead legacy speaker-table prompt and its helpers (`get_default_speaker_prompt_template`, `get_speaker_prompt_template`, `build_speaker_prompt`, `parse_mapping_table`); the evidence-JSON speaker-suggestion path fully supersedes them and they had no production or test callers.

No new dependencies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (864 passed)
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint` (not run: no frontend paths changed)
- [ ] Frontend unit tests: `cd frontend && npm run test` (not run: no frontend paths changed)
- [ ] Frontend build: `cd frontend && npm run build` (not run: no frontend paths changed)
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required. Confirmed no guide specifies the note section layout; `docs/USAGE.md` describes only what the notes-language setting controls (still accurate) and `docs/ARCHITECTURE.md` covers prompt caching (unaffected).

## Security impact

- [x] No security-sensitive change.

## Manual verification

Automated coverage only in this PR (864 backend tests pass, including new drift-guard and title-strip tests). Recommended live smoke check before or after merge: process a recording and use "Regenerate Notes", confirming the notes open at the Summary heading, carry a scannable Key Decisions section, and contain no duplicate title line. No capture, context-menu, auth, or migration paths are touched.
