### PR TITLE
fix(frontend): clear high-severity brace-expansion and js-yaml advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -648,9 +648,9 @@
       "dev": true
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -723,9 +723,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4102,16 +4102,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4959,11 +4958,10 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5266,9 +5264,9 @@
       "dev": true
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6478,9 +6476,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,7 @@
   },
   "overrides": {
     "eslint-plugin-react-hooks": "7.0.1",
-    "brace-expansion@<1.1.13": "1.1.13",
+    "brace-expansion@1": "^1.1.16",
     "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
     "follow-redirects": "1.16.0",
     "picomatch": "4.0.4",


### PR DESCRIPTION
## Description

Clears the two open High-severity Dependabot alerts on `frontend/package-lock.json` (brace-expansion DoS via exponential-time `{}` expansion, GHSA-3jxr-9vmj-r5cp, alerts 120 and 121), plus a third High advisory (`js-yaml` quadratic-CPU DoS via merge-key chains, GHSA-52cp-r559-cp3m) that local `npm audit` surfaced but the last Dependabot scan had not yet listed.

**Root cause.** The `overrides` block already carried `"brace-expansion@<1.1.13": "1.1.13"` from a previous round of the same advisory. An upper-bound override key (`@<X`) only matches hard-pinned edges, not the floating `^1.1.7` edge that `minimatch@3` (pulled by the eslint toolchain) requests, so it was effectively inert; the lockfile simply froze the four nested copies at `1.1.13`. When the advisory's affected range later widened to `<1.1.16`, `1.1.13` itself became vulnerable and neither `npm audit fix` nor `npm update` would re-resolve the deeply-nested transitive.

**Fix.** Replace the stale override with a major-scoped key, `"brace-expansion@1": "^1.1.16"`, which matches the `^1.1.7` edge by subset and forces all four nested copies to `1.1.16`, while leaving the separate `^5.x` edge untouched. `npm audit fix` additionally bumped the top-level `brace-expansion 5.0.6 -> 5.0.8` and `js-yaml 4.2.0 -> 4.3.0` in the lockfile. `npm audit` now reports 0 vulnerabilities.

All three packages are dev-only transitive dependencies of the lint/build toolchain (`eslint` / `eslint-config-next` / `minimatch`); none ship in the production bundle, so exposure was confined to the build/CI environment. `brace-expansion 5.0.8` drops Node 18 engine support (`20 || >=22`), a non-issue as `next@16` already requires Node 20+.

New dependencies: none added; transitive version bumps only.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (864 passed)
- [ ] Python quality: `python scripts/check.py` (not run; no Python changed)
- [x] Frontend lint: `cd frontend && npm run lint` (clean)
- [x] Frontend unit tests: `cd frontend && npm run test` (182 passed)
- [x] Frontend build: `cd frontend && npm run build` (passed)
- [x] Docs validation: `python3 scripts/validate_docs.py` (25 files)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (single head `b3d7e2f14a05`)

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] No documentation change required.

## Security impact

- [x] No security-sensitive change.

This PR clears dev-only High-severity supply-chain advisories in the lint/build toolchain. It does not touch auth, tokens, encryption, capture ownership, or exposure surfaces, so `docs/SECURITY.md` boundaries are unaffected.

## Manual verification

- `npm audit` in `frontend/` reports 0 vulnerabilities after the change (down from 2 High).
- Confirmed the four nested `brace-expansion` copies resolve to `1.1.16`, the top-level copy to `5.0.8`, and `js-yaml` to `4.3.0` in `package-lock.json`.
- `git diff` scope confined to `frontend/package.json` (one line) and `frontend/package-lock.json`.

No browser capture, recording context-menu, or auth flows were touched.
