### PR TITLE
fix(deps): patch postcss and make the held torch pin self-policing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@
 # - Docker base images are pinned by digest in the Dockerfiles. Dependabot
 #   bumps the digest (and tag comment) when a new image is published.
 # - Updates are grouped where practical to keep pull-request volume reviewable.
+# - The `ignore:` blocks below suppress *version-update pull requests* only.
+#   They do NOT suppress Dependabot *security alerts*: those are a separate
+#   channel with no YAML equivalent, so a held pin under an open advisory keeps
+#   raising alerts that no upgrade can fix. See "Held Pins and Unfixable
+#   Advisories" in docs/DEVELOPMENT.md for how those are handled, and
+#   scripts/check_held_pins.py for the checked-in record of each hold.
 version: 2
 
 updates:
@@ -37,7 +43,10 @@ updates:
           - "*"
     # Held pins (see PR #43). Remove an entry when its blocker clears.
     ignore:
-      # torchaudio publishes no 2.12.x; 2.11.0 is the matched-stack ceiling.
+      # torchaudio has published nothing above 2.11.0, and its wheels are
+      # compiled against a matching torch minor, so 2.11.0 is the matched-stack
+      # ceiling. Held under GHSA-rrmf-rvhw-rf47, which is not fixed until torch
+      # 2.13.0; held-pin-watch.yml opens an issue when torchaudio catches up.
       - dependency-name: "torch"
         versions: [">=2.12.0"]
       # torchcodec stays matched to torch 2.11 (the 0.11.x line).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,26 @@ jobs:
       - name: Check trailing whitespace
         run: python scripts/check_whitespace.py
 
+  held-pins:
+    # Always run: the matched torch/torchaudio stack is declared across several
+    # requirements files and the worker base image, and nothing else fails a
+    # bump applied to only some of them. Offline and pure stdlib, so it is
+    # cheap; the networked half runs from held-pin-watch.yml on a schedule.
+    name: Held pin drift check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Check held pins agree across the matched stack
+        run: python scripts/check_held_pins.py --offline
+
   dependency-scan:
     name: Dependency vulnerability scan
     runs-on: ubuntu-latest
@@ -380,6 +400,7 @@ jobs:
       - docs-validation
       - alembic-validation
       - whitespace
+      - held-pins
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/held-pin-watch.yml
+++ b/.github/workflows/held-pin-watch.yml
@@ -1,0 +1,117 @@
+name: Held Pin Watch
+
+# Watches the deliberately held dependency pins recorded in
+# scripts/check_held_pins.py and opens an issue when one can finally move.
+#
+# A held pin (currently the torch/torchaudio stack) keeps attracting Dependabot
+# security alerts that no upgrade can fix, because the fixed version is not
+# installable while a companion package lags. Those alerts are auto-dismissed by
+# a Dependabot auto-triage rule, which means nothing would otherwise tell us the
+# day the hold can be lifted. This job is that signal: it asks PyPI directly
+# rather than waiting for an alert we have deliberately silenced.
+#
+# It mirrors repo-audit-reminder.yml: the runner's built-in gh CLI rather than a
+# third-party action, so there is no extra pinned SHA to maintain, and it is
+# idempotent, so it never stacks a second open issue.
+
+on:
+  schedule:
+    # 10:00 UTC on the first day of each month.
+    - cron: "0 10 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch-held-pins:
+    name: Check whether a held pin can move
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Check held pins against PyPI
+        id: check
+        run: |
+          set -uo pipefail
+
+          # The script is pure stdlib, so there is nothing to install. Exit 1
+          # means "action available", which is the signal this job exists to
+          # catch, not a failure -- capture it rather than letting it abort.
+          report="$(python scripts/check_held_pins.py --json)"
+          status=$?
+
+          echo "${report}"
+          {
+            echo "report<<REPORT_EOF"
+            echo "${report}"
+            echo "REPORT_EOF"
+            echo "status=${status}"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [[ "${status}" -eq 2 ]]; then
+            echo "::warning::A held-pin release check could not be completed (likely a PyPI lookup failure). No issue was opened."
+          fi
+
+      - name: Open or skip the held-pin issue
+        if: steps.check.outputs.status == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          REPORT: ${{ steps.check.outputs.report }}
+        run: |
+          set -euo pipefail
+
+          gh label create held-pin \
+            --color b60205 \
+            --description "A deliberately held dependency pin can now move" \
+            --force
+
+          # Idempotency: if an open held-pin issue already exists, do nothing.
+          existing="$(gh issue list --label held-pin --state open --json number --jq 'length')"
+          if [[ "${existing}" -gt 0 ]]; then
+            echo "An open held-pin issue already exists; nothing to do."
+            exit 0
+          fi
+
+          stamp="$(date -u +'%Y-%m')"
+          body_file="$(mktemp)"
+          {
+            cat <<'EOF'
+          A dependency pin held below its latest release can now move, or the
+          held pins have drifted apart. The hold policy is documented under
+          "Held Pins and Unfixable Advisories" in docs/DEVELOPMENT.md.
+
+          Report from `scripts/check_held_pins.py --json`:
+
+          ```json
+          EOF
+            printf '%s\n' "${REPORT}"
+            cat <<'EOF'
+          ```
+
+          If a hold has cleared:
+
+          - [ ] Move every pin in the matched stack together (requirements files and the worker base image digest).
+          - [ ] Update `HOLDS` in `scripts/check_held_pins.py` to the new version, or delete the entry if the hold is gone for good.
+          - [ ] Remove the matching `ignore:` entry from `.github/dependabot.yml`.
+          - [ ] Remove the Dependabot auto-triage rule for the package, so real advisories surface again.
+          - [ ] Confirm the previously-dismissed alerts close as fixed.
+
+          If the report shows drift instead, the stack was bumped inconsistently:
+          reconcile the pins before doing anything else.
+          EOF
+          } > "${body_file}"
+
+          gh issue create \
+            --title "Held dependency pin can move (${stamp})" \
+            --label held-pin \
+            --body-file "${body_file}"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -543,6 +543,44 @@ Each ecosystem is capped at five open pull requests so the queue stays reviewabl
 
 **Security prioritisation.** Dependabot security alerts and any update that resolves a known CVE take priority over routine version bumps and should be merged promptly once CI is green. Because the release pipeline fails on fixable CRITICAL/HIGH image findings (REL-008), a security update is often the unblocking fix for a release: merge the relevant base-image or dependency update, then re-cut the tag. For a finding with no upstream fix, record a dated, justified entry in [.trivyignore](../.trivyignore) rather than blocking indefinitely.
 
+### Held Pins and Unfixable Advisories
+
+A few dependencies are pinned below their latest release because a companion package has not shipped a matching build, not because we chose to lag. The live example is the PyTorch stack: `pyannote.audio` and `torch-audiomentations` both require `torchaudio`, whose wheels are compiled against a matching `torch` minor, and torchaudio has published nothing above 2.11.0. Upgrading `torch` alone would install a mismatched ABI pair, so 2.11.0 is a ceiling rather than a preference.
+
+Two properties of Dependabot make a held pin more than a one-line comment, and both have caught this repository out before:
+
+- **`ignore:` does not silence security alerts.** The `ignore:` blocks in [dependabot.yml](../.github/dependabot.yml) suppress *version-update pull requests* only. Security alerts are a separate channel with no YAML equivalent, so a held pin sitting under an open advisory keeps raising alerts that no upgrade can resolve.
+- **The alert recurs, and multiplies.** An advisory's affected range is revised over time, and a fresh alert is raised on every revision, once per manifest that resolves the package. `torch` is declared in [requirements/test.txt](../requirements/test.txt) and [requirements/local.txt](../requirements/local.txt) and reached through `-r` from [requirements/dev.txt](../requirements/dev.txt), so a single revision of one advisory produces three alerts. Dismissing them by hand does not scale.
+
+The policy for a hold is therefore:
+
+1. **Record it in code, not just prose.** Add the hold to `HOLDS` in [scripts/check_held_pins.py](../scripts/check_held_pins.py) with the blocking package and the version that resolves the advisory. Add the matching `ignore:` entry to [dependabot.yml](../.github/dependabot.yml) to stop the pointless update pull requests.
+2. **Enforce that the stack moves together.** Every file declaring part of a matched stack must declare the same version. `python scripts/check_held_pins.py --offline` checks this, runs in CI and in `scripts/check.py`, and covers the requirements files and the worker base-image tag. It fails a bump applied to some declarations and not others.
+3. **Suppress the alerts automatically, not manually.** Add a custom **Dependabot rule** (repository *Settings > Code security > Dependabot rules > New rule*, free on public repositories) matching the held package. For the current hold, set *Target alerts* to `package:torch`, `ecosystem:pip`, and `severity:low` (the filters are ANDed), then tick **Dismiss alerts** and choose **Indefinitely**. The rule re-dismisses on every advisory revision and every new manifest, which is what makes the suppression durable. There is no REST API for these rules; they are configured in the web UI.
+
+   Three choices on that form are easy to get wrong:
+
+   - **Choose *Indefinitely*, not *Until patch is available*.** Dependabot only checks whether a patched version has been published, not whether this dependency graph can install it. GHSA-rrmf-rvhw-rf47 is patched in torch 2.13.0, which torchaudio makes unreachable, so *Until patch is available* would decline to dismiss and the alerts would keep recurring — a rule that looks configured but does nothing.
+   - **Filter on package and severity, not on `ghsa_id`.** A rule naming the one advisory suppresses the instance rather than the class. The torch advisory database currently carries three further low/moderate memory-corruption advisories with no fixed version at all (GHSA-x3gm-94wq-g975, GHSA-c678-jfcj-6jmf, GHSA-f4hp-rmr7-r7v8); any of them can have its affected range widened to include the held version, which is exactly how the current one reached us.
+   - **Do not add a scope filter.** Dependabot reports these manifests as `runtime` scope even though the files are developer-facing, so a `development` filter matches nothing. That is also why the GitHub preset rule *"Dismiss low impact issues for development-scoped dependencies"* does **not** cover this case.
+
+   Restricting the rule to `Low` is what keeps it honest: while the pin is held, no torch advisory of any severity can be fixed by upgrading, so auto-dismissing the local-only low tier costs nothing that could have been acted on, while moderate and above still surface for a human decision. `ecosystem:pip` is not redundant — an npm package named `torch` exists.
+
+   *Open a pull request to resolve alerts* cannot be unticked, which is harmless here: the `ignore:` entry for the same package already stops that pull request being opened.
+4. **Dismiss the alerts that are already open.** Auto-triage rules apply going forward, so clear the backlog once:
+
+   ```bash
+   gh api --method PATCH repos/Valtora/Nojoin/dependabot/alerts/<number> \
+     -f state=dismissed \
+     -f dismissed_reason=tolerable_risk \
+     -f dismissed_comment="<why the risk is tolerable and what blocks the fix>"
+   ```
+
+   Valid reasons are `fix_started`, `inaccurate`, `no_bandwidth`, `not_used`, and `tolerable_risk`; the comment is capped at 280 characters. Prefer `tolerable_risk` over `not_used` unless you have confirmed that no transitive dependency reaches the vulnerable code path.
+5. **Watch for the hold clearing.** Because the alerts are now silenced, nothing would otherwise announce the day the pin can move. [held-pin-watch.yml](../.github/workflows/held-pin-watch.yml) runs `scripts/check_held_pins.py` monthly against PyPI and opens a single `held-pin` issue when the blocking package catches up. Lifting a hold means moving the whole stack, updating `HOLDS`, removing the `ignore:` entry, and **removing the auto-triage rule** so genuine advisories surface again.
+
+A hold is a deliberate, dated, checked decision, not a silence. If a held advisory ever rises above the risk this repository is prepared to carry, the answer is to drop the blocking dependency, not to widen the hold.
+
 ### Image Provenance, SBOM, and Signing
 
 Every published image is signed with cosign keyless (OIDC) signing and carries build-provenance and SBOM attestations (`provenance: mode=max`, `sbom: true` in the build step). The signature is bound to the release workflow identity, so the `server-release` job requires `id-token: write`. Operator verification commands live in [DEPLOYMENT.md](DEPLOYMENT.md#verifying-an-image-before-deploying).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7186,16 +7186,15 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7623,9 +7622,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7641,7 +7640,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
     "follow-redirects": "1.16.0",
     "picomatch": "4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "sharp": "^0.35.0"
   }
 }

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,6 +2,9 @@
 -r worker.txt
 aiosqlite==0.22.1
 pyannote.audio==4.0.5
+# CUDA half of the matched torch stack. Held at the torchaudio ceiling and
+# checked by scripts/check_held_pins.py; see the note in test.txt and
+# "Held Pins and Unfixable Advisories" in docs/DEVELOPMENT.md.
 torch==2.11.0 --index-url https://download.pytorch.org/whl/cu126
 torchvision==0.26.0 --index-url https://download.pytorch.org/whl/cu126
 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/cu126

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,8 +2,12 @@
 -r worker.txt
 aiosqlite==0.22.1
 pytest==9.1.1
-# torch and torchaudio must move together with the CUDA stack in local.txt,
-# the torchcodec pin in worker.txt, and the base image in docker/Dockerfile.worker.
-# torchaudio publishes no 2.12.x, so 2.11.0 is the current matched-stack ceiling.
+# Matched stack. torch and torchaudio must move together with the CUDA pins in
+# local.txt, the torchcodec pin in worker.txt, and the base image in
+# docker/Dockerfile.worker; scripts/check_held_pins.py fails CI if they drift
+# apart. torchaudio has published nothing above 2.11.0 and its wheels are
+# compiled against a matching torch minor, so 2.11.0 is the ceiling. It is held
+# under an open advisory no upgrade can clear -- see "Held Pins and Unfixable
+# Advisories" in docs/DEVELOPMENT.md before touching these two lines.
 torch==2.11.0
 torchaudio==2.11.0

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -27,6 +27,9 @@ CHECKS: dict[str, list[str]] = {
     "format": ["ruff", "format", "--check", "."],
     "whitespace": [sys.executable, "scripts/check_whitespace.py"],
     "filesize": [sys.executable, "scripts/check_file_size.py"],
+    # --offline: the drift half only. The networked half of this script asks
+    # PyPI whether a hold can be lifted and runs on a schedule instead.
+    "heldpins": [sys.executable, "scripts/check_held_pins.py", "--offline"],
     "typecheck": ["mypy"],
     "docs": [sys.executable, "scripts/validate_docs.py"],
     "alembic": [sys.executable, "scripts/validate_alembic.py"],

--- a/scripts/check_held_pins.py
+++ b/scripts/check_held_pins.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Guard the deliberately held dependency pins and report when one can move.
+
+Some pins sit below the newest release because a companion package has not
+shipped a matching build, not because we chose to lag. A held pin keeps
+attracting Dependabot security alerts that no upgrade can fix, so the hold has
+to be re-justified every time the advisory's affected range is revised. The
+policy, and the one-off dismissal procedure, are in
+docs/DEVELOPMENT.md#held-pins-and-unfixable-advisories.
+
+This script does the two things that keep the hold honest:
+
+1. **Drift check (offline).** Every file that declares part of a matched stack
+   must declare the same version. Nothing else enforces that today, so a bump
+   applied to one requirements file and missed in another would install a
+   mismatched, ABI-incompatible pair.
+2. **Release check (network).** Ask PyPI whether the blocking package has
+   published a version that lets the pin move, so the hold is revisited when it
+   can actually be lifted rather than on every alert.
+
+    python scripts/check_held_pins.py            # drift + release check
+    python scripts/check_held_pins.py --offline  # drift check only
+    python scripts/check_held_pins.py --json     # machine-readable report
+
+Exit codes: 0 = consistent and still blocked, 1 = action available (a hold can
+move) or drift found, 2 = a release check could not be completed.
+
+The release check needs network access to pypi.org, so only the ``--offline``
+half runs in scripts/check.py and CI. The networked half runs on a schedule
+from .github/workflows/held-pin-watch.yml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPI_TIMEOUT_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class Hold:
+    """A pin held below the latest release by an upstream blocker."""
+
+    package: str
+    pinned: str
+    blocker: str
+    # First ``package`` version that resolves the advisory below. The hold is
+    # only fully cleared when ``blocker`` reaches this version too, because the
+    # two must be installed as a matched pair.
+    clears_advisory_at: str
+    advisory: str
+    rationale: str
+    # Files whose pins must all agree with ``pinned``. Independently numbered
+    # companions (torchvision, torchcodec) are excluded: they track the stack
+    # but do not share its version string.
+    matched_packages: tuple[str, ...] = ()
+    matched_files: tuple[str, ...] = ()
+    # Docker base images whose tag must start with ``pinned``.
+    matched_images: tuple[str, ...] = field(default_factory=tuple)
+
+
+HOLDS: tuple[Hold, ...] = (
+    Hold(
+        package="torch",
+        pinned="2.11.0",
+        blocker="torchaudio",
+        clears_advisory_at="2.13.0",
+        advisory="GHSA-rrmf-rvhw-rf47",
+        rationale=(
+            "pyannote.audio and torch-audiomentations both require torchaudio, "
+            "whose wheels are compiled against a matching torch minor. "
+            "torchaudio has published nothing above 2.11.0, so torch cannot "
+            "move without breaking the ABI pair."
+        ),
+        matched_packages=("torch", "torchaudio"),
+        matched_files=(
+            "requirements/test.txt",
+            "requirements/local.txt",
+        ),
+        matched_images=("docker/Dockerfile.worker",),
+    ),
+)
+
+# torch==2.11.0, torchaudio==2.11.0 --index-url https://...
+PIN_RE_TEMPLATE = r"^{package}==([^\s;#]+)"
+# FROM pytorch/pytorch:2.11.0-cuda12.6-cudnn9-runtime@sha256:...
+IMAGE_TAG_RE = re.compile(r"^FROM\s+pytorch/pytorch:([^\s@]+)", re.MULTILINE)
+
+
+def parse_version(raw: str) -> tuple[int, ...] | None:
+    """Return a comparable tuple for a final release, or None otherwise.
+
+    Pre-releases (rc/a/b/dev) are deliberately rejected: a hold must not be
+    reported as liftable on the strength of a release candidate.
+    """
+    text = raw.strip().split("+", 1)[0]
+    text = re.sub(r"\.post\d+$", "", text)
+    if not re.fullmatch(r"\d+(\.\d+)*", text):
+        return None
+    return tuple(int(part) for part in text.split("."))
+
+
+def require_version(raw: str) -> tuple[int, ...]:
+    parsed = parse_version(raw)
+    if parsed is None:
+        raise ValueError(f"not a final release version: {raw!r}")
+    return parsed
+
+
+def latest_release(package: str) -> str:
+    """Return the newest non-yanked final release of ``package`` on PyPI."""
+    url = f"https://pypi.org/pypi/{package}/json"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=PYPI_TIMEOUT_SECONDS) as response:
+        payload = json.load(response)
+
+    candidates: list[tuple[tuple[int, ...], str]] = []
+    for version, files in payload.get("releases", {}).items():
+        parsed = parse_version(version)
+        # Skip pre-releases, and releases with no installable file left: a
+        # fully yanked or file-less version must not clear a hold.
+        if parsed is None or not any(not f.get("yanked", False) for f in files):
+            continue
+        candidates.append((parsed, version))
+
+    if not candidates:
+        raise ValueError(f"no final releases found on PyPI for {package}")
+    return max(candidates)[1]
+
+
+def declared_pins(hold: Hold) -> list[tuple[str, int, str, str]]:
+    """Return (file, line, package, version) for every matched pin on disk."""
+    found: list[tuple[str, int, str, str]] = []
+
+    def line_of(text: str, offset: int) -> int:
+        return text.count("\n", 0, offset) + 1
+
+    for relative in hold.matched_files:
+        text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+        for package in hold.matched_packages:
+            pattern = re.compile(
+                PIN_RE_TEMPLATE.format(package=re.escape(package)), re.MULTILINE
+            )
+            for match in pattern.finditer(text):
+                found.append(
+                    (relative, line_of(text, match.start()), package, match.group(1))
+                )
+    for relative in hold.matched_images:
+        text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+        for match in IMAGE_TAG_RE.finditer(text):
+            found.append(
+                (
+                    relative,
+                    line_of(text, match.start()),
+                    "pytorch/pytorch",
+                    match.group(1),
+                )
+            )
+    return found
+
+
+def check_drift(hold: Hold) -> list[str]:
+    """Return a problem description per pin that disagrees with the hold."""
+    problems: list[str] = []
+    pins = declared_pins(hold)
+
+    for package in hold.matched_packages:
+        if not any(found_package == package for _, _, found_package, _ in pins):
+            problems.append(
+                f"{hold.package}: no {package}== pin found in "
+                f"{', '.join(hold.matched_files)}; the drift check is not "
+                f"covering what it claims to."
+            )
+
+    for relative, line, package, version in pins:
+        # An image tag carries a suffix (2.11.0-cuda12.6-...), so compare the
+        # leading version component rather than the whole string.
+        actual = version.split("-", 1)[0] if package == "pytorch/pytorch" else version
+        if actual != hold.pinned:
+            problems.append(
+                f"{hold.package}: {relative}:{line} declares {package} "
+                f"{version}, but the recorded hold is {hold.pinned}. Either the "
+                f"stack moved and HOLDS in {Path(__file__).name} is stale, or "
+                f"the bump was applied inconsistently and the stack is now "
+                f"mismatched."
+            )
+    return problems
+
+
+def evaluate(hold: Hold) -> dict[str, object]:
+    """Ask PyPI whether the blocker has released far enough to move the pin."""
+    latest = latest_release(hold.blocker)
+    latest_key = require_version(latest)
+    pinned_key = require_version(hold.pinned)
+    clears_key = require_version(hold.clears_advisory_at)
+
+    if latest_key >= clears_key:
+        status = "clear"
+        note = (
+            f"{hold.blocker} {latest} is available. Move the whole stack to "
+            f"{latest}, drop the {hold.package} entry from "
+            f".github/dependabot.yml, and close out {hold.advisory}."
+        )
+    elif latest_key > pinned_key:
+        status = "advanced"
+        note = (
+            f"{hold.blocker} {latest} is available, so the stack can move off "
+            f"{hold.pinned}, but {hold.advisory} is not resolved until "
+            f"{hold.package} {hold.clears_advisory_at}. Worth taking; the "
+            f"alert will persist."
+        )
+    else:
+        status = "held"
+        note = f"{hold.blocker} is still at {latest}. The hold stands."
+
+    return {
+        "package": hold.package,
+        "pinned": hold.pinned,
+        "blocker": hold.blocker,
+        "blocker_latest": latest,
+        "clears_advisory_at": hold.clears_advisory_at,
+        "advisory": hold.advisory,
+        "status": status,
+        "note": note,
+    }
+
+
+def check_releases(
+    holds: tuple[Hold, ...],
+) -> tuple[list[dict[str, object]], list[str]]:
+    """Evaluate every hold against PyPI, collecting lookup failures separately."""
+    results: list[dict[str, object]] = []
+    failures: list[str] = []
+    for hold in holds:
+        try:
+            results.append(evaluate(hold))
+        except (urllib.error.URLError, ValueError, json.JSONDecodeError) as error:
+            failures.append(f"{hold.package} (via {hold.blocker}): {error}")
+    return results, failures
+
+
+def render_text(
+    problems: list[str], results: list[dict[str, object]], failures: list[str]
+) -> None:
+    for problem in problems:
+        print(f"DRIFT: {problem}")
+    for result in results:
+        status = str(result["status"]).upper()
+        print(f"[{status:>8}] {result['package']}: {result['note']}")
+    for failure in failures:
+        print(f"ERROR: could not check {failure}")
+    if not problems:
+        print("Matched-stack pins agree with every recorded hold.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check held dependency pins.")
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Run only the drift check; do not contact PyPI.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit the report as JSON on stdout."
+    )
+    args = parser.parse_args()
+
+    problems = [problem for hold in HOLDS for problem in check_drift(hold)]
+    results, failures = ((), []) if args.offline else check_releases(HOLDS)
+    results = list(results)
+    actionable = bool(problems or [r for r in results if r["status"] != "held"])
+
+    if args.json:
+        report = {
+            "drift": problems,
+            "holds": results,
+            "errors": failures,
+            "actionable": actionable,
+        }
+        print(json.dumps(report, indent=2))
+    else:
+        render_text(problems, results, failures)
+
+    if actionable:
+        return 1
+    return 2 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Pull Request

## Description

Closes the three open Dependabot alerts, and makes the recurring one stop recurring.

**postcss (#125, High).** The `overrides` floor was stale at `^8.5.10`, so the lockfile had never been asked to move off 8.5.12 even though the range already permitted the patch. Raised to `^8.5.18` (the patched version) so a future lockfile regeneration cannot drift back below it. `@tailwindcss/postcss`, `next`, and `vite` now all resolve to 8.5.23. The alert closes as fixed once this lands on `main`.

**torch (#123, #124, Low).** These cannot be fixed by upgrading, and both are now dismissed as `tolerable_risk`. GHSA-rrmf-rvhw-rf47 is first patched in torch 2.13.0, but `pyannote.audio==4.0.5` and `torch-audiomentations` both require `torchaudio`, whose newest PyPI release is 2.11.0 and which ships *compiled* per-interpreter wheels ABI-bound to a matching torch minor — so torch 2.13.0 is published but not installable here. torchaudio is also not droppable: `backend/processing/vad.py` uses `torchaudio.transforms.Resample`.

The alerts recur because the advisory's affected range is revised repeatedly, and a fresh alert is raised **per revision, per manifest**. `torch` is declared in `requirements/test.txt` and `requirements/local.txt` and reached via `-r` from `requirements/dev.txt`, so one revision yields three alerts. Manual dismissal does not scale, so this PR adds:

- **`scripts/check_held_pins.py`** — a declarative `HOLDS` table recording each held pin, its blocking package, and the version that would clear the advisory. The `--offline` half asserts every declaration of a matched stack states the same version, across both requirements files and *both* build stages of `docker/Dockerfile.worker`. Nothing previously failed a bump applied to some declarations and not others, which would install a mismatched ABI pair.
- **`held-pins` CI job** — runs the offline half, and is added to `ci-gate`'s `needs:` list. `CI gate` is the only required status check, so a job outside that aggregate would report green and block nothing.
- **`.github/workflows/held-pin-watch.yml`** — monthly, asks PyPI whether torchaudio has caught up and opens one idempotent `held-pin` issue when the hold can be lifted. This exists precisely because the alerts are now suppressed: something has to announce the day the pin can move.
- **`docs/DEVELOPMENT.md` → "Held Pins and Unfixable Advisories"** — the policy, plus the two traps this repository has already hit.

Two findings worth recording, both of which invalidate the previous approach:

- The torch alerts report `scope: runtime`, not `development`, even though `dev.txt` and `local.txt` are developer-facing. That is why the GitHub preset rule *"Dismiss low impact issues for development-scoped dependencies"* never caught them.
- `dependabot.yml`'s `ignore:` blocks suppress version-update *pull requests* only, never security *alerts*. There is no YAML equivalent for alerts.

A custom Dependabot rule (`package:torch`, `ecosystem:pip`, `severity:low`, dismiss **indefinitely**) has been created out-of-band to handle future revisions. It dismisses indefinitely rather than "until patch is available" because a patch exists but is unreachable, and filters on package plus severity rather than a single `ghsa_id` because three further unfixed low/moderate torch advisories (GHSA-x3gm-94wq-g975, GHSA-c678-jfcj-6jmf, GHSA-f4hp-rmr7-r7v8) can widen onto the held version the same way this one did. Restricting to `Low` keeps moderate and above visible.

No new dependencies. `scripts/check_held_pins.py` is pure stdlib.

Fixes # (no issue; tracked as Dependabot alerts #123, #124, #125)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [ ] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` — ran `lint format whitespace filesize heldpins docs typecheck`, all green
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (50 files, 289 tests passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [ ] Alembic validation: `python3 scripts/validate_alembic.py`

`pytest` and the Alembic validator were not run: no backend source and no migration is touched by this PR. CI runs both regardless.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR — `docs/DEVELOPMENT.md` gains a "Held Pins and Unfixable Advisories" section under the existing dependency-update policy, and the inline rationale in `dependabot.yml` and the requirements files now points at it rather than restating it.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

This resolves dependency advisories but does not alter any trust boundary. The accepted risk is stated explicitly: GHSA-rrmf-rvhw-rf47 is Low severity and `AV:L` (local attacker only), against a pin no upgrade can move.

## Manual verification

- `scripts/check_held_pins.py --offline` verified to **catch** drift, not merely to pass: temporarily bumping `torch` in `test.txt` alone was reported as a mismatched pair, and drifting only the runtime stage of `docker/Dockerfile.worker` was attributed to `docker/Dockerfile.worker:51`. Working tree restored after each.
- Networked half confirmed to report `HELD` against the live PyPI index (torchaudio still 2.11.0).
- `held-pin-watch.yml` parsed as YAML, and its issue-body shell logic dry-run outside CI to confirm the nested heredoc renders correctly.
- `ci.yml` verified programmatically so that every job except the deliberately-informational `dependency-scan` is aggregated by `ci-gate`.
- `npm ls postcss --all` confirms all three consumers resolve to 8.5.23.

No capture, recording context-menu, or browser-facing behaviour is touched, so no browser smoke testing applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
