### PR TITLE
fix(notes): make the install default notes structure take effect

### DIFF
--- a/backend/api/v1/endpoints/settings.py
+++ b/backend/api/v1/endpoints/settings.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.api.deps import get_current_user, get_db
 from backend.api.error_handling import sanitized_http_exception
 from backend.celery_app import celery_app
+from backend.models.notes_template import NotesTemplate, NotesTemplateScope
 from backend.models.recording import Recording, RecordingStatus
 from backend.models.user import User
 from backend.services.model_preparation import enqueue_model_preparation
@@ -285,6 +286,13 @@ def _apply_default_user_settings(
 
 
 def _persist_install_wide_ai_settings(update_data: dict[str, Any]) -> None:
+    """Write the install-wide keys to config.json.
+
+    Reloads first so a config edited out of band (by an operator, or by a
+    restore) is not reverted by this process's older in-memory copy, and lets a
+    failed write propagate: these keys live nowhere else, so reporting success
+    on a write that did not happen is how a setting silently stays unset.
+    """
     install_wide_updates = {
         key: value
         for key, value in update_data.items()
@@ -293,6 +301,7 @@ def _persist_install_wide_ai_settings(update_data: dict[str, Any]) -> None:
     if not install_wide_updates:
         return
 
+    config_manager.reload()
     config_data = config_manager.get_all()
     config_data.update(install_wide_updates)
     config_manager.save_config(config_data)
@@ -383,6 +392,31 @@ def _build_settings_update_data(
     return update_data
 
 
+async def _validate_install_notes_template(
+    update_data: dict[str, Any],
+    db: AsyncSession,
+) -> None:
+    """Reject an install default that does not name an install-scoped template.
+
+    The id is a foreign key held in a flat config file with nothing to enforce
+    it, and resolution degrades to the built-in structure rather than failing,
+    so a wrong id would otherwise be accepted and then quietly do nothing.
+    """
+    if "install_notes_template_id" not in update_data:
+        return
+
+    template_id = update_data["install_notes_template_id"]
+    if template_id is None:
+        return
+
+    template = await db.get(NotesTemplate, template_id)
+    if template is None or template.scope != NotesTemplateScope.INSTALL.value:
+        raise HTTPException(
+            status_code=400,
+            detail="The install default must be an install-scoped notes structure.",
+        )
+
+
 async def _dispatch_meeting_edge_refresh_for_active_recordings(
     db: AsyncSession,
     current_user: User,
@@ -450,8 +484,22 @@ async def _save_user_settings(
             exc=e,
         )
 
+    await _validate_install_notes_template(update_data, db)
+
     if is_admin:
-        _persist_install_wide_ai_settings(update_data)
+        try:
+            _persist_install_wide_ai_settings(update_data)
+        except Exception as e:  # noqa: BLE001
+            raise sanitized_http_exception(
+                logger=logger,
+                status_code=500,
+                client_message=(
+                    "Could not save install-wide settings: the configuration "
+                    "file could not be written."
+                ),
+                log_message="Failed to persist install-wide settings to config.",
+                exc=e,
+            )
 
     user_scoped_updates = {
         key: value

--- a/backend/tests/test_install_notes_default.py
+++ b/backend/tests/test_install_notes_default.py
@@ -1,0 +1,184 @@
+"""Setting a notes structure as the install default (issue #149).
+
+The install default is unusual: it is the only notes setting that lives in
+config.json rather than on the user row, and the UI renders it from the
+server's template list rather than from the settings object. Both of those
+made a failure silent, so these tests pin the write actually landing, a
+failed write being reported, and a bad id being refused.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import backend.models.registry  # noqa: F401
+from backend.api.deps import get_current_user, get_db
+from backend.api.v1.endpoints import settings as settings_ep
+from backend.models.notes_template import NotesTemplate, NotesTemplateScope
+from backend.models.user import User
+from backend.tests.sqlite_schemas import NOTES_TEMPLATES_SCHEMA, USERS_SCHEMA
+
+SECTIONS = "## Summary\nWhat happened."
+INSTALL_TEMPLATE_ID = 1
+PERSONAL_TEMPLATE_ID = 2
+
+
+class _FakeConfigManager:
+    """Stands in for the module-level config_manager singleton."""
+
+    def __init__(self, *, fail: bool = False):
+        self.config: dict = {}
+        self.fail = fail
+        self.saves = 0
+        self.reloads = 0
+
+    def get_all(self):
+        return dict(self.config)
+
+    def save_config(self, config_data):
+        self.saves += 1
+        if self.fail:
+            raise OSError("Read-only file system")
+        self.config = dict(config_data)
+
+    def reload(self):
+        self.reloads += 1
+
+    def validate_config_value(self, key, value):
+        return True
+
+
+@pytest.fixture()
+def fake_config(monkeypatch):
+    fake = _FakeConfigManager()
+    monkeypatch.setattr(settings_ep, "config_manager", fake)
+    return fake
+
+
+async def _build_app(*, role: str = "owner", is_superuser: bool = True):
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.execute(text(USERS_SCHEMA))
+        await conn.execute(text(NOTES_TEMPLATES_SCHEMA))
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    # One session for the whole request: the endpoint writes the current user
+    # back, so the authenticated user has to be attached to the same session
+    # the dependency hands out.
+    session = maker()
+    session.add(
+        User(
+            username="owner",
+            hashed_password="x",
+            role=role,
+            is_superuser=is_superuser,
+            settings={},
+        )
+    )
+    session.add(
+        NotesTemplate(
+            name="Board pack",
+            description="",
+            sections=SECTIONS,
+            scope=NotesTemplateScope.INSTALL.value,
+            user_id=None,
+        )
+    )
+    session.add(
+        NotesTemplate(
+            name="My own",
+            description="",
+            sections=SECTIONS,
+            scope=NotesTemplateScope.PERSONAL.value,
+            user_id=1,
+        )
+    )
+    await session.commit()
+    user = (await session.execute(select(User))).scalars().one()
+
+    app = FastAPI()
+    app.include_router(settings_ep.router, prefix="/settings")
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = lambda: user
+    return engine, app, session
+
+
+async def _post_install_default(value, *, role="owner", is_superuser=True):
+    engine, app, session = await _build_app(role=role, is_superuser=is_superuser)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t"
+        ) as client:
+            return await client.post(
+                "/settings", json={"install_notes_template_id": value}
+            )
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+def test_install_default_is_written_to_the_install_config(fake_config):
+    response = asyncio.run(_post_install_default(INSTALL_TEMPLATE_ID))
+
+    assert response.status_code == 200
+    assert fake_config.config["install_notes_template_id"] == INSTALL_TEMPLATE_ID
+    # Reloaded before the read-modify-write too, so a config edited out of band
+    # is not reverted by this process's stale in-memory copy.
+    assert fake_config.reloads >= 2
+
+
+def test_a_failed_config_write_is_reported_rather_than_swallowed(monkeypatch):
+    monkeypatch.setattr(settings_ep, "config_manager", _FakeConfigManager(fail=True))
+
+    response = asyncio.run(_post_install_default(INSTALL_TEMPLATE_ID))
+
+    assert response.status_code == 500
+    assert "could not be written" in response.json()["detail"]
+
+
+def test_a_personal_structure_cannot_become_the_install_default(fake_config):
+    response = asyncio.run(_post_install_default(PERSONAL_TEMPLATE_ID))
+
+    assert response.status_code == 400
+    assert "install_notes_template_id" not in fake_config.config
+
+
+def test_an_unknown_structure_cannot_become_the_install_default(fake_config):
+    response = asyncio.run(_post_install_default(9999))
+
+    assert response.status_code == 400
+    assert "install_notes_template_id" not in fake_config.config
+
+
+def test_clearing_the_install_default_is_allowed(fake_config):
+    fake_config.config["install_notes_template_id"] = INSTALL_TEMPLATE_ID
+
+    response = asyncio.run(_post_install_default(None))
+
+    assert response.status_code == 200
+    assert fake_config.config["install_notes_template_id"] is None
+
+
+def test_a_non_admin_write_is_dropped_before_it_reaches_the_config(fake_config):
+    response = asyncio.run(
+        _post_install_default(INSTALL_TEMPLATE_ID, role="user", is_superuser=False)
+    )
+
+    assert response.status_code == 200
+    assert fake_config.config == {}

--- a/backend/utils/config_manager.py
+++ b/backend/utils/config_manager.py
@@ -356,8 +356,17 @@ class ConfigManager:
                 logger.info(
                     f"Configuration file not found at {self.config_path}. Using default settings."
                 )
-                # Save the default config if the file doesn't exist
-                self._save_config(config)
+                # Save the default config if the file doesn't exist. Best effort
+                # only: a config directory we cannot write is a problem for
+                # saving settings later, not a reason to refuse to start.
+                try:
+                    self._save_config(config)
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Could not write the initial configuration file at %s. "
+                        "Install-wide settings will not be persistable.",
+                        self.config_path,
+                    )
 
             # Ensure necessary directories exist
             self._ensure_dirs_exist(config)
@@ -408,7 +417,12 @@ class ConfigManager:
         self._save_config(config_data)
 
     def _save_config(self, config_data):
-        """Saves the current configuration state to the file, excluding sensitive keys."""
+        """Saves the current configuration state to the file, excluding sensitive keys.
+
+        Raises on failure. Install-wide settings live only in this file, so a
+        swallowed write turns "saved" into a value that quietly reverts on the
+        next reload -- the caller has to be able to tell the operator.
+        """
         try:
             safe_config = {
                 k: v for k, v in config_data.items() if k not in SENSITIVE_KEYS
@@ -416,15 +430,17 @@ class ConfigManager:
             with open(self.config_path, "w", encoding="utf-8") as f:
                 json.dump(safe_config, f, indent=4)
             logger.info(f"Configuration saved to {self.config_path}")
-        except IOError as e:
+        except OSError as e:
             logger.error(
                 f"Error saving configuration to {self.config_path}: {e}", exc_info=True
             )
+            raise
         except Exception as e:
             logger.error(
                 f"An unexpected error occurred while saving configuration: {e}",
                 exc_info=True,
             )
+            raise
 
     def _ensure_dirs_exist(self, config):
         """Creates directories specified in the config if they don't exist."""

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -248,6 +248,13 @@ Nojoin splits configuration between:
 The first-run setup wizard can pre-fill many values from environment variables to speed up deployment.
 On uninitialised systems, that prefill flow is itself locked behind `FIRST_RUN_PASSWORD`.
 
+Install-wide settings that an administrator changes in the UI (the AI provider and models, the install
+glossary, the install default notes structure) are written to `data/config.json` rather than to the
+database, so the mounted `data/` directory must be writable by the API container's user. If it is not,
+saving any of those settings now fails with an explicit error instead of appearing to succeed and then
+reverting on the next restart. If you see that error, check the ownership of the host directory bound to
+`/app/data`.
+
 ## CLI OAuth (worker-io image)
 
 The per-user CLI OAuth AI mode (routing inference through a user's own Claude or ChatGPT subscription) needs Node.js plus the Claude Code CLI and the OpenAI Codex CLI, which ship **only** in the `worker-io` image (`docker/Dockerfile.worker-io`, layered on the shared worker image). Point the `worker-io` service at that image via the `image:`/`build:` override in `docker-compose.example.yml`; `worker-gpu` and `worker-cpu` stay on the base image. No new `.env` is required — the encrypted credential reuses `DATA_ENCRYPTION_KEY`. Note the Codex CLI adds a large (~336 MB) native binary to this image only; `NOJOIN_CODEX_PATH` overrides the codex binary path if needed (default `/usr/local/bin/codex`). See [ADR-0002](adr/0002-cli-oauth-subscription-mode.md).

--- a/frontend/src/components/settings/AISettings.tsx
+++ b/frontend/src/components/settings/AISettings.tsx
@@ -47,12 +47,16 @@ export default function AISettings({
 
   // Apply a change and save it immediately, for discrete controls (selects,
   // switches, routing radios). Continuous controls use `onUpdate` (1s debounce).
-  const persistNow = (updates: Settings) => {
+  // Returns a promise that settles when the save does, so a section whose UI is
+  // rendered from server state (rather than from `settings`) can refetch once
+  // the write has landed. Rejections are still handled here, so callers that
+  // ignore the result behave exactly as before.
+  const persistNow = (updates: Settings): Promise<void> => {
     onUpdate(updates);
     if (!onPersist) {
-      return;
+      return Promise.resolve();
     }
-    void onPersist(updates).catch((error) => {
+    return onPersist(updates).catch((error) => {
       console.error("Failed to persist AI settings update", error);
       addNotification({
         type: "error",

--- a/frontend/src/components/settings/NotesTemplatesSection.test.tsx
+++ b/frontend/src/components/settings/NotesTemplatesSection.test.tsx
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const listNotesTemplates = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  listNotesTemplates: () => listNotesTemplates(),
+  createNotesTemplate: vi.fn(),
+  updateNotesTemplate: vi.fn(),
+  deleteNotesTemplate: vi.fn(),
+  copyNotesTemplate: vi.fn(),
+  resetNotesTemplate: vi.fn(),
+  previewNotesTemplate: vi.fn(),
+  generateNotesTemplate: vi.fn(),
+}));
+
+import NotesTemplatesSection from "./NotesTemplatesSection";
+
+const template = (isInstallDefault: boolean) => ({
+  id: 7,
+  name: "Board pack",
+  description: "",
+  sections: "## Summary",
+  scope: "install",
+  user_id: null,
+  builtin_version: null,
+  is_editable: true,
+  is_stale: false,
+  is_install_default: isInstallDefault,
+  is_user_default: false,
+});
+
+const listResponse = (isInstallDefault: boolean) => ({
+  templates: [template(isInstallDefault)],
+  builtin: { name: "Nojoin default", description: "", sections: "## Summary" },
+  limits: { max_sections_length: 8000, max_description_length: 200 },
+});
+
+describe("NotesTemplatesSection install default", () => {
+  beforeEach(() => {
+    listNotesTemplates.mockReset();
+  });
+
+  // Issue #149: the badge is server state, so without a refetch a successful
+  // save left the row untouched and the link read as dead.
+  it("shows the badge once the save has landed", async () => {
+    listNotesTemplates
+      .mockResolvedValueOnce(listResponse(false))
+      .mockResolvedValue(listResponse(true));
+    const onPersist = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <NotesTemplatesSection
+        settings={{ install_notes_template_id: null }}
+        onPersist={onPersist}
+        isAdmin
+      />,
+    );
+
+    fireEvent.click(await screen.findByText("Use as install default"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Remove as install default")).toBeTruthy(),
+    );
+    expect(screen.getByText("Install default")).toBeTruthy();
+    expect(onPersist).toHaveBeenCalledWith(
+      expect.objectContaining({ install_notes_template_id: 7 }),
+    );
+    expect(listNotesTemplates).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the install default and refetches", async () => {
+    listNotesTemplates
+      .mockResolvedValueOnce(listResponse(true))
+      .mockResolvedValue(listResponse(false));
+    const onPersist = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <NotesTemplatesSection
+        settings={{ install_notes_template_id: 7 }}
+        onPersist={onPersist}
+        isAdmin
+      />,
+    );
+
+    fireEvent.click(await screen.findByText("Remove as install default"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Use as install default")).toBeTruthy(),
+    );
+    expect(onPersist).toHaveBeenCalledWith(
+      expect.objectContaining({ install_notes_template_id: null }),
+    );
+  });
+
+  // A rejected save must not leave the row claiming a default that the server
+  // never accepted.
+  it("keeps showing the server's answer when the save fails", async () => {
+    listNotesTemplates.mockResolvedValue(listResponse(false));
+    const onPersist = vi.fn().mockRejectedValue(new Error("read-only config"));
+
+    render(
+      <NotesTemplatesSection
+        settings={{ install_notes_template_id: null }}
+        onPersist={onPersist}
+        isAdmin
+      />,
+    );
+
+    fireEvent.click(await screen.findByText("Use as install default"));
+
+    await waitFor(() => expect(onPersist).toHaveBeenCalled());
+    expect(screen.getByText("Use as install default")).toBeTruthy();
+    expect(screen.queryByText("Install default")).toBeNull();
+  });
+
+  it("does not offer the install default to a non-admin", async () => {
+    listNotesTemplates.mockResolvedValue(listResponse(false));
+
+    render(
+      <NotesTemplatesSection
+        settings={{ install_notes_template_id: null }}
+        onPersist={vi.fn()}
+      />,
+    );
+
+    await screen.findByText("Board pack");
+    expect(screen.queryByText("Use as install default")).toBeNull();
+  });
+});

--- a/frontend/src/components/settings/NotesTemplatesSection.tsx
+++ b/frontend/src/components/settings/NotesTemplatesSection.tsx
@@ -28,8 +28,11 @@ import NotesTemplateEditorModal from "./NotesTemplateEditorModal";
 
 interface NotesTemplatesSectionProps {
   settings: Settings;
-  /** Apply and save immediately (default selection is a discrete control). */
-  onPersist: (newSettings: Settings) => void;
+  /**
+   * Apply and save immediately (default selection is a discrete control).
+   * Resolves once the save has settled, so the install default can refetch.
+   */
+  onPersist: (newSettings: Settings) => void | Promise<void>;
   isAdmin?: boolean;
 }
 
@@ -53,6 +56,7 @@ export default function NotesTemplatesSection({
   const [creatingScope, setCreatingScope] = useState<"install" | "personal">(
     "personal",
   );
+  const [savingInstallDefault, setSavingInstallDefault] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -79,8 +83,23 @@ export default function NotesTemplatesSection({
     onPersist({ ...settings, notes_template_id: templateId });
   };
 
-  const handleSelectInstallDefault = (templateId: number | null) => {
-    onPersist({ ...settings, install_notes_template_id: templateId });
+  // Unlike the per-user default -- whose tick is rendered from `settings`, so
+  // it updates optimistically -- the install default badge comes from
+  // `is_install_default` on the server's template list. Without refetching, a
+  // save that worked perfectly still leaves the row unchanged and reads as a
+  // dead link (issue #149).
+  const handleSelectInstallDefault = async (templateId: number | null) => {
+    setSavingInstallDefault(true);
+    try {
+      await onPersist({ ...settings, install_notes_template_id: templateId });
+    } catch (error) {
+      // The caller reports the failure to the user; refetching below is what
+      // stops the row from claiming a default the server never stored.
+      console.error("Failed to set the install default notes structure", error);
+    } finally {
+      await refresh();
+      setSavingInstallDefault(false);
+    }
   };
 
   const handleSave = async (
@@ -275,12 +294,13 @@ export default function NotesTemplatesSection({
                   {isAdmin && template.scope === "install" && (
                     <button
                       type="button"
+                      disabled={savingInstallDefault}
                       onClick={() =>
-                        handleSelectInstallDefault(
+                        void handleSelectInstallDefault(
                           template.is_install_default ? null : template.id,
                         )
                       }
-                      className="mt-2 text-xs contrast-helper hover:text-gray-900 dark:hover:text-white"
+                      className="mt-2 text-xs contrast-helper hover:text-gray-900 dark:hover:text-white disabled:opacity-60"
                     >
                       {template.is_install_default
                         ? "Remove as install default"


### PR DESCRIPTION
# Pull Request

## Description

Clicking **Use as install default** on an install-scoped notes structure appeared to do nothing. The click was reaching the API and the value was being stored, but the **Install default** badge and the link label are rendered from `is_install_default` on `GET /notes-templates`, which was only fetched when the section mounts. A save that succeeded end to end therefore left the row byte-identical, so the control read as dead. By contrast the per-user default's tick renders from `settings.notes_template_id`, which `persistNow` updates optimistically, which is why one control looked healthy and the other looked broken.

The section now awaits the save and refetches the list, in a `finally` block so the row reflects what the server actually stored whether the save succeeded or failed. That required `persistNow` in `AISettings` to return its promise. It still catches and reports failures, so every other caller is unchanged.

A second defect followed from the first. The client held the value optimistically and the autosave layer skips any save whose serialised payload matches the last one it stored, so **every click after the first emitted no HTTP request at all**, which matches the "no corresponding request reaches the API" in the report. That trap only springs when the API returns 200 without having stored anything, which `ConfigManager` allowed: `_save_config` caught write errors, logged them, and returned normally, so `_persist_install_wide_ai_settings` reported success on a write that never happened. Install-wide settings live only in `config.json`, so on a deployment whose `data/` directory is not writable by the container user, every such save silently reverted on the next reload. The write now raises and the endpoint returns an explicit error. The first-run bootstrap write stays best effort so an unwritable directory cannot block startup.

Two smaller hardening changes come with it. The install-wide write now reloads before its read-modify-write, so a config edited out of band is not reverted by a stale in-memory copy, matching what `telemetry._write_config` already did. And `install_notes_template_id` is validated against the database, since it is a foreign key held in a flat file with nothing enforcing it and resolution degrades silently to the built-in structure, so a wrong id was previously accepted and then quietly did nothing.

No new dependencies.

Refs #149

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1087 passed)
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, whitespace, file size, held pins, mypy, doc and Alembic validators all passed)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (293 passed, 51 files)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/DEPLOYMENT.md` now states that install-wide settings are written to `data/config.json` rather than the database, that the directory must be writable by the API container's user, and that a failed write is now reported instead of silently reverting.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

The new admin-only validation narrows what an administrator can set; it does not widen any boundary. The non-admin path is unchanged and covered by a test asserting the key is still dropped before it reaches the config.

## Manual verification

Not a capture change, so no browser smoke set applies.

Verified against a live deployment before writing the fix, to establish that the backend half was already correct. Driving the real settings router in-process against the running instance's database and a copy of its `config.json`, a `POST` carrying `install_notes_template_id` wrote the value, survived `reload`, and came back on the next `GET`, twice in succession. That is what isolated the defect to the missing refetch rather than the save.

Both new defects are pinned by tests that fail without the change:

- `NotesTemplatesSection.test.tsx` asserts the badge appears and the link flips after a save, that clearing works, that a rejected save leaves the server's answer on screen, and that a non-admin is never offered the control.
- `test_install_notes_default.py` asserts the value reaches the config, that a failed write is a reported error rather than a silent success, that a personal-scoped or unknown id is refused, that clearing is allowed, and that a non-admin write is dropped.

Still worth doing on a real deployment before merge, since automated tests cannot cover the browser path:

1. As Owner, go to **Settings > AI > Notes structure** and click **Use as install default**. The badge should appear and the link should flip without a reload.
2. Reload and confirm both persist.
3. Click **Remove as install default** and confirm it reverts.
4. Optionally `chmod a-w data/config.json`, click the link, and confirm an explicit error appears instead of a silent success. Restore the permission afterwards.
