### PR TITLE
feat(settings): ask before downloading a newly selected model

### DIFF
--- a/backend/api/v1/endpoints/settings.py
+++ b/backend/api/v1/endpoints/settings.py
@@ -11,7 +11,6 @@ from backend.celery_app import celery_app
 from backend.models.notes_template import NotesTemplate, NotesTemplateScope
 from backend.models.recording import Recording, RecordingStatus
 from backend.models.user import User
-from backend.services.model_preparation import enqueue_model_preparation
 from backend.utils.config_manager import (
     APP_THEMES,
     INSTALL_WIDE_AI_SETTING_KEYS,
@@ -517,31 +516,10 @@ async def _save_user_settings(
     if meeting_edge_keys.intersection(update_data):
         await _dispatch_meeting_edge_refresh_for_active_recordings(db, current_user)
 
-    model_keys = {
-        "whisper_model_size",
-        "transcription_backend",
-        "parakeet_model",
-        "canary_model",
-    }
-    if is_admin and model_keys.intersection(update_data):
-        prepared_settings = dict(current_settings)
-        try:
-            enqueue_model_preparation(
-                whisper_model_size=prepared_settings.get("whisper_model_size"),
-                transcription_backend=prepared_settings.get("transcription_backend"),
-                parakeet_model=prepared_settings.get("parakeet_model"),
-                canary_model=prepared_settings.get("canary_model"),
-                include_core=(
-                    "whisper_model_size" in update_data
-                    or update_data.get("transcription_backend") == "whisper"
-                ),
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.error(
-                "Failed to queue model preparation after settings update: %s",
-                e,
-                exc_info=True,
-            )
+    # Changing the transcription model deliberately does not download anything.
+    # Preparation runs on the GPU lane, so it is requested explicitly through
+    # POST /system/models/prepare after the admin has been asked; a model that is
+    # never prepared is still fetched lazily on first use.
 
     return await _merge_settings(current_user.settings, db)
 

--- a/backend/api/v1/endpoints/system.py
+++ b/backend/api/v1/endpoints/system.py
@@ -581,6 +581,82 @@ async def get_models_status(
     return status
 
 
+class ModelPreparationRequest(BaseModel):
+    """Which assets to prepare.
+
+    ``active`` covers whatever the saved transcription settings actually need,
+    which is what the Settings prompt asks about. The remaining targets exist so
+    a single missing row in Model dependencies can be repaired on its own.
+    """
+
+    target: str = Field(default="active")
+
+    @field_validator("target")
+    @classmethod
+    def validate_target(cls, value: str) -> str:
+        allowed = {"active", "core", "parakeet", "canary"}
+        if value not in allowed:
+            raise ValueError(f"target must be one of {sorted(allowed)}")
+        return value
+
+
+@router.post("/models/prepare")
+async def prepare_models_endpoint(
+    payload: ModelPreparationRequest | None = None,
+    current_user: User = Depends(get_current_admin_user),
+) -> Any:
+    """
+    Queue preparation of local model assets.
+
+    Preparation is explicit: saving a transcription model change no longer
+    downloads anything by itself, because the preparation task runs on the GPU
+    lane and would otherwise queue in front of live work unannounced.
+    """
+    target = (payload or ModelPreparationRequest()).target
+
+    if is_download_in_progress():
+        raise HTTPException(
+            status_code=409,
+            detail="Model preparation is already running. Wait for it to finish.",
+        )
+
+    # The transcription keys are user-scoped rather than install-wide, so the
+    # admin's own row wins over config.json. Reading config alone would prepare
+    # whatever the install default happens to be, not the model just chosen.
+    user_settings = current_user.settings or {}
+
+    def effective(key: str, default: str) -> str:
+        value = user_settings.get(key)
+        return str(value) if value else str(config_manager.get(key, default))
+
+    if target == "active":
+        transcription_backend = effective("transcription_backend", "whisper")
+        include_core = transcription_backend == "whisper"
+    elif target == "core":
+        transcription_backend = "whisper"
+        include_core = True
+    else:
+        transcription_backend = target
+        include_core = False
+
+    try:
+        task_id = enqueue_model_preparation(
+            whisper_model_size=effective("whisper_model_size", "turbo"),
+            transcription_backend=transcription_backend,
+            parakeet_model=effective("parakeet_model", "parakeet-tdt-0.6b-v3"),
+            canary_model=effective("canary_model", "nemo-canary-1b-v2"),
+            include_core=include_core,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.error("Failed to queue model preparation: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="Could not queue model preparation. Is the worker running?",
+        )
+
+    return {"task_id": task_id, "target": target, "status": "queued"}
+
+
 @router.delete("/models/{model_name}")
 async def delete_model_endpoint(
     model_name: str,

--- a/backend/api/v1/endpoints/system.py
+++ b/backend/api/v1/endpoints/system.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from typing import Any, Optional
 
+from celery.exceptions import TimeoutError as CeleryTimeoutError
 from celery.result import AsyncResult
 from docker.client import DockerClient
 from docker.errors import DockerException, NotFound
@@ -35,6 +36,7 @@ from backend.api.v1.endpoints.setup import (
     is_system_initialized,
     require_first_run_password,
 )
+from backend.celery_app import celery_app
 from backend.core.security import (
     MIN_PASSWORD_LENGTH,
     hash_user_password,
@@ -53,6 +55,11 @@ from backend.utils.model_utils import WHISPER_MODEL_SIZES_MB
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+MODEL_DELETION_TASK = "backend.worker.tasks.delete_model_task"
+# Deleting a cached model is an rmtree on a local volume, so seconds; the ceiling
+# is here so an absent worker fails the request rather than holding the thread.
+MODEL_DELETION_TIMEOUT_S = 60
 
 RETIRED_COMPANION_RESPONSE = {
     "error": "companion_retired",
@@ -665,25 +672,50 @@ async def delete_model_endpoint(
 ) -> Any:
     """
     Delete a specific model from the cache.
+
+    Dispatched to a worker: the API mounts the shared model volume read-only, so
+    deleting from this process fails with EROFS. The call still waits for the
+    result, because the UI refreshes model status as soon as it returns.
     """
-    from backend.preload_models import delete_model
+    del current_user
 
     if model_name not in ["whisper", "pyannote", "embedding", "parakeet", "canary"]:
         raise HTTPException(status_code=400, detail="Invalid model name")
 
     try:
-        success = delete_model(model_name, whisper_model_size=variant)
-        if success:
-            return {"message": f"Model {model_name} deleted successfully"}
-        else:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Model {model_name} not found or could not be deleted",
-            )
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        task = celery_app.send_task(
+            MODEL_DELETION_TASK,
+            kwargs={"model_name": model_name, "variant": variant},
+        )
+        result = await asyncio.to_thread(task.get, timeout=MODEL_DELETION_TIMEOUT_S)
+    except CeleryTimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                "Model deletion did not finish in time. It may still be running "
+                "on the worker; refresh model status in a moment."
+            ),
+        )
     except Exception as e:  # noqa: BLE001
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("Model deletion task failed for %s: %s", model_name, e)
+        raise HTTPException(
+            status_code=503,
+            detail="Could not reach the worker to delete the model.",
+        )
+
+    status = (result or {}).get("status")
+    message = (result or {}).get("message") or f"Model {model_name} deleted."
+
+    if status == "deleted":
+        return {"message": message}
+    if status == "not_found":
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model {model_name} not found or could not be deleted",
+        )
+    if status == "forbidden":
+        raise HTTPException(status_code=400, detail=message)
+    raise HTTPException(status_code=500, detail=message)
 
 
 @router.post("/seed-demo")

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -200,6 +200,9 @@ TASK_ROUTES = {
     "backend.worker.tasks.ensure_calendar_push_channels_task": {"queue": IO_QUEUE},
     "backend.worker.tasks.renew_calendar_push_channels_task": {"queue": IO_QUEUE},
     "backend.worker.tasks.cleanup_temp_recordings": {"queue": IO_QUEUE},
+    # Local disk work on the model volume. Belongs on a worker at all because
+    # the API mounts that volume read-only.
+    "backend.worker.tasks.delete_model_task": {"queue": IO_QUEUE},
     "backend.worker.tasks.send_telemetry_ping_task": {"queue": IO_QUEUE},
 }
 

--- a/backend/preload_models.py
+++ b/backend/preload_models.py
@@ -40,6 +40,19 @@ WHISPER_FILENAMES = {
     "turbo": "large-v3-turbo.pt",
 }
 
+# Hugging Face cache directory fragments for the ONNX ASR models, used to detect
+# them without importing onnx-asr into the API process.
+#
+# These are fragments of the *repo* name, not of the Nojoin model id, because the
+# two diverge: `nemo-canary-1b-v2` is cached as `models--istupakov--canary-1b-v2-onnx`,
+# with no `nemo-` prefix. Matching the Nojoin id reported Canary as permanently
+# missing however many times it was downloaded, which also made it undeletable,
+# since deletion resolves its path through the same status check.
+ONNX_ASR_CACHE_FRAGMENTS = {
+    "parakeet": "parakeet-tdt-0.6b-v3",
+    "canary": "canary-1b-v2",
+}
+
 
 def _is_onnx_asr_model_cached(model_substring: str) -> bool:
     """Check if an onnx-asr model is present in the Hugging Face hub cache."""
@@ -510,7 +523,7 @@ def check_model_status(whisper_model_size=None):
                     status["whisper"]["downloaded"] = True
                     status["whisper"]["path"] = default_filepath
 
-    # Check Parakeet
+    # Check the ONNX ASR models.
     # Best-effort detection: onnx-asr caches the model under the Hugging Face hub
     # cache. Detection is a directory-name match; the exact repo dir name may vary
     # by onnx-asr version, so this is treated as a heuristic, not authoritative.
@@ -525,35 +538,20 @@ def check_model_status(whisper_model_size=None):
     if default_hf_cache not in parakeet_hf_caches:
         parakeet_hf_caches.append(default_hf_cache)
 
-    for cache_dir in parakeet_hf_caches:
-        status["parakeet"]["checked_paths"].append(cache_dir)
-        if os.path.isdir(cache_dir):
-            try:
-                for entry in os.listdir(cache_dir):
-                    if "parakeet-tdt-0.6b-v3" in entry:
-                        status["parakeet"]["downloaded"] = True
-                        status["parakeet"]["path"] = os.path.join(cache_dir, entry)
-                        break
-            except OSError:
-                pass
-        if status["parakeet"]["downloaded"]:
-            break
-
-    # Check Canary
-    # Same best-effort HF-cache directory-name match as Parakeet above.
-    for cache_dir in parakeet_hf_caches:
-        status["canary"]["checked_paths"].append(cache_dir)
-        if os.path.isdir(cache_dir):
-            try:
-                for entry in os.listdir(cache_dir):
-                    if "nemo-canary-1b-v2" in entry:
-                        status["canary"]["downloaded"] = True
-                        status["canary"]["path"] = os.path.join(cache_dir, entry)
-                        break
-            except OSError:
-                pass
-        if status["canary"]["downloaded"]:
-            break
+    for status_key, fragment in ONNX_ASR_CACHE_FRAGMENTS.items():
+        for cache_dir in parakeet_hf_caches:
+            status[status_key]["checked_paths"].append(cache_dir)
+            if os.path.isdir(cache_dir):
+                try:
+                    for entry in os.listdir(cache_dir):
+                        if fragment in entry:
+                            status[status_key]["downloaded"] = True
+                            status[status_key]["path"] = os.path.join(cache_dir, entry)
+                            break
+                except OSError:
+                    pass
+            if status[status_key]["downloaded"]:
+                break
 
     for status_key, model_id in (
         ("pyannote", "pyannote/speaker-diarization-community-1"),

--- a/backend/tests/test_model_cache_detection.py
+++ b/backend/tests/test_model_cache_detection.py
@@ -1,0 +1,46 @@
+"""Detecting cached ONNX ASR models on disk.
+
+The status heuristic matches Hugging Face cache directory names. It has to match
+the *repo* name rather than the Nojoin model id, because the two diverge:
+onnx-asr caches `nemo-canary-1b-v2` as `models--istupakov--canary-1b-v2-onnx`.
+Matching the Nojoin id reported Canary as missing however many times it was
+prepared, and made it undeletable with it, since deletion resolves its path
+through this same check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.preload_models import check_model_status
+
+# The directory names a real install ends up with, taken from a live cache.
+CACHED_REPOS = (
+    "models--istupakov--canary-1b-v2-onnx",
+    "models--istupakov--parakeet-tdt-0.6b-v3-onnx",
+)
+
+
+@pytest.mark.parametrize("model", ["parakeet", "canary"])
+def test_a_downloaded_onnx_model_is_reported_as_present(model, monkeypatch, tmp_path):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    for repo in CACHED_REPOS:
+        (hub / repo).mkdir()
+    monkeypatch.setenv("HF_HOME", str(tmp_path))
+
+    status = check_model_status(whisper_model_size="turbo")
+
+    assert status[model]["downloaded"] is True
+    assert status[model]["path"].startswith(str(hub))
+
+
+@pytest.mark.parametrize("model", ["parakeet", "canary"])
+def test_an_empty_cache_reports_the_model_as_missing(model, monkeypatch, tmp_path):
+    (tmp_path / "hub").mkdir()
+    monkeypatch.setenv("HF_HOME", str(tmp_path))
+
+    status = check_model_status(whisper_model_size="turbo")
+
+    assert status[model]["downloaded"] is False
+    assert status[model]["path"] is None

--- a/backend/tests/test_model_deletion_api.py
+++ b/backend/tests/test_model_deletion_api.py
@@ -1,0 +1,162 @@
+"""Deleting a cached model.
+
+Deletion used to run inside the API process, which mounts the shared model
+volume read-only, so every attempt failed with EROFS on a Docker install. The
+work now goes to a worker lane, which is the only place with write access, and
+these tests pin the dispatch plus the mapping of its result back onto the status
+codes the UI already handles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from celery.exceptions import TimeoutError as CeleryTimeoutError
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from backend.api.deps import get_current_user
+from backend.api.v1.endpoints import system
+
+DELETE_TASK = "backend.worker.tasks.delete_model_task"
+
+
+class _FakeTask:
+    def __init__(self, result=None, raises=None):
+        self._result = result
+        self._raises = raises
+
+    def get(self, timeout=None):
+        del timeout
+        if self._raises:
+            raise self._raises
+        return self._result
+
+
+@pytest.fixture()
+def delete_app(monkeypatch):
+    """System router with the delete task recorded rather than sent."""
+    sent: list[tuple[str, dict]] = []
+    box = SimpleNamespace(task=_FakeTask({"status": "deleted", "message": "Gone."}))
+
+    def fake_send_task(name, kwargs=None, **_):
+        sent.append((name, kwargs or {}))
+        return box.task
+
+    monkeypatch.setattr(system.celery_app, "send_task", fake_send_task)
+
+    app = FastAPI()
+    app.include_router(system.router, prefix="/system")
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id=1, role="owner", is_superuser=True, settings={}
+    )
+    return app, sent, box
+
+
+async def _delete(app, model="canary", query=""):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as client:
+        return await client.delete(f"/system/models/{model}{query}")
+
+
+def test_deletion_is_dispatched_to_a_worker(delete_app):
+    app, sent, _ = delete_app
+
+    response = asyncio.run(_delete(app, "whisper", "?variant=medium"))
+
+    assert response.status_code == 200
+    # The worker resolves the path itself; only the model identity is sent.
+    assert sent == [(DELETE_TASK, {"model_name": "whisper", "variant": "medium"})]
+
+
+def test_a_missing_model_is_reported_as_not_found(delete_app):
+    app, _, box = delete_app
+    box.task = _FakeTask({"status": "not_found", "message": "nope"})
+
+    response = asyncio.run(_delete(app))
+
+    assert response.status_code == 404
+
+
+def test_a_bundled_asset_is_refused_rather_than_deleted(delete_app):
+    app, _, box = delete_app
+    box.task = _FakeTask({"status": "forbidden", "message": "bundled with the repo"})
+
+    response = asyncio.run(_delete(app, "pyannote"))
+
+    assert response.status_code == 400
+    assert "bundled" in response.json()["detail"]
+
+
+def test_a_worker_failure_is_surfaced(delete_app):
+    app, _, box = delete_app
+    box.task = _FakeTask({"status": "error", "message": "disk exploded"})
+
+    response = asyncio.run(_delete(app))
+
+    assert response.status_code == 500
+
+
+def test_an_unreachable_worker_does_not_hang_the_request(delete_app):
+    app, _, box = delete_app
+    box.task = _FakeTask(raises=CeleryTimeoutError("no worker"))
+
+    response = asyncio.run(_delete(app))
+
+    assert response.status_code == 504
+    assert "still be running" in response.json()["detail"]
+
+
+def test_an_unknown_model_name_is_rejected_before_dispatch(delete_app):
+    app, sent, _ = delete_app
+
+    response = asyncio.run(_delete(app, "../../etc"))
+
+    assert response.status_code in (400, 404)
+    assert sent == []
+
+
+def test_a_non_admin_cannot_delete_a_model(delete_app):
+    app, sent, _ = delete_app
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id=2, role="user", is_superuser=False, settings={}
+    )
+
+    response = asyncio.run(_delete(app))
+
+    assert response.status_code == 403
+    assert sent == []
+
+
+# --- The worker side --------------------------------------------------------------
+
+
+def test_the_task_reports_a_refusal_rather_than_raising(monkeypatch):
+    """Celery's JSON serialiser would not carry the exception type across."""
+    from backend.worker.tasks import system as worker_system
+
+    def boom(model_name, whisper_model_size=None):
+        raise ValueError("bundled with the repository")
+
+    monkeypatch.setattr("backend.preload_models.delete_model", boom)
+
+    result = worker_system.delete_model_task.run(model_name="pyannote", variant=None)
+
+    assert result["status"] == "forbidden"
+    assert "bundled" in result["message"]
+
+
+def test_the_task_reports_success(monkeypatch):
+    from backend.worker.tasks import system as worker_system
+
+    monkeypatch.setattr(
+        "backend.preload_models.delete_model",
+        lambda model_name, whisper_model_size=None: True,
+    )
+
+    result = worker_system.delete_model_task.run(model_name="canary", variant=None)
+
+    assert result["status"] == "deleted"

--- a/backend/tests/test_model_preparation_api.py
+++ b/backend/tests/test_model_preparation_api.py
@@ -1,0 +1,247 @@
+"""Explicit model preparation (Settings > AI).
+
+Selecting a transcription model used to queue a download as a side effect of
+saving the setting. That download runs on the GPU lane, in front of live work,
+with no indication in the UI that it had started. Preparation is now requested
+explicitly, so these tests pin both halves: the settings save queues nothing,
+and the dedicated endpoint queues the model the admin actually has selected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import backend.models.registry  # noqa: F401
+from backend.api.deps import get_current_user, get_db
+from backend.api.v1.endpoints import settings as settings_ep
+from backend.api.v1.endpoints import system
+from backend.models.user import User
+from backend.tests.sqlite_schemas import NOTES_TEMPLATES_SCHEMA, USERS_SCHEMA
+
+DOWNLOAD_TASK = "backend.worker.tasks.download_models_task"
+
+
+class _FakeConfigManager:
+    """Install config with none of the transcription keys set.
+
+    Deliberately empty: the transcription keys are user-scoped, so anything the
+    endpoint resolves has to come from the user row rather than from here.
+    """
+
+    def __init__(self, values: dict | None = None):
+        self.config = dict(values or {})
+
+    def get(self, key, default=None):
+        return self.config.get(key, default)
+
+    def get_all(self):
+        return dict(self.config)
+
+    def save_config(self, config_data):
+        self.config = dict(config_data)
+
+    def reload(self):
+        return None
+
+    def validate_config_value(self, key, value):
+        return True
+
+
+# --- POST /system/models/prepare -------------------------------------------------
+
+
+@pytest.fixture()
+def prepare_app(monkeypatch):
+    """System router with the enqueue call recorded rather than sent."""
+    calls: list[dict] = []
+
+    def fake_enqueue(**kwargs):
+        calls.append(kwargs)
+        return "task-123"
+
+    monkeypatch.setattr(system, "enqueue_model_preparation", fake_enqueue)
+    monkeypatch.setattr(system, "is_download_in_progress", lambda: False)
+    monkeypatch.setattr(system, "config_manager", _FakeConfigManager())
+
+    app = FastAPI()
+    app.include_router(system.router, prefix="/system")
+    return app, calls
+
+
+def _as_user(app, **overrides):
+    attrs = {"id": 1, "role": "owner", "is_superuser": True, "settings": {}}
+    attrs.update(overrides)
+    user = SimpleNamespace(**attrs)
+    app.dependency_overrides[get_current_user] = lambda: user
+    return user
+
+
+async def _post_prepare(app, payload=None):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as client:
+        return await client.post("/system/models/prepare", json=payload or {})
+
+
+def test_preparation_is_refused_for_non_admins(prepare_app):
+    app, calls = prepare_app
+    _as_user(app, role="user", is_superuser=False)
+
+    response = asyncio.run(_post_prepare(app))
+
+    assert response.status_code == 403
+    assert calls == []
+
+
+def test_active_target_prepares_the_admins_own_selection(prepare_app):
+    app, calls = prepare_app
+    _as_user(app, settings={"whisper_model_size": "medium"})
+
+    response = asyncio.run(_post_prepare(app, {"target": "active"}))
+
+    assert response.status_code == 200
+    assert response.json()["task_id"] == "task-123"
+    # The user row wins over the install config, which has none of these keys.
+    assert calls == [
+        {
+            "whisper_model_size": "medium",
+            "transcription_backend": "whisper",
+            "parakeet_model": "parakeet-tdt-0.6b-v3",
+            "canary_model": "nemo-canary-1b-v2",
+            "include_core": True,
+        }
+    ]
+
+
+def test_active_target_on_an_onnx_engine_skips_the_core_batch(prepare_app):
+    app, calls = prepare_app
+    _as_user(app, settings={"transcription_backend": "parakeet"})
+
+    response = asyncio.run(_post_prepare(app, {"target": "active"}))
+
+    assert response.status_code == 200
+    assert calls[0]["transcription_backend"] == "parakeet"
+    assert calls[0]["include_core"] is False
+
+
+def test_a_missing_row_can_be_repaired_on_its_own(prepare_app):
+    app, calls = prepare_app
+    _as_user(app, settings={"transcription_backend": "whisper"})
+
+    response = asyncio.run(_post_prepare(app, {"target": "canary"}))
+
+    assert response.status_code == 200
+    assert calls[0]["transcription_backend"] == "canary"
+    assert calls[0]["include_core"] is False
+
+
+def test_the_core_target_prepares_whisper_and_the_pyannote_models(prepare_app):
+    app, calls = prepare_app
+    _as_user(app, settings={"transcription_backend": "canary"})
+
+    response = asyncio.run(_post_prepare(app, {"target": "core"}))
+
+    assert response.status_code == 200
+    assert calls[0]["transcription_backend"] == "whisper"
+    assert calls[0]["include_core"] is True
+
+
+def test_a_second_preparation_is_refused_while_one_is_running(prepare_app, monkeypatch):
+    app, calls = prepare_app
+    monkeypatch.setattr(system, "is_download_in_progress", lambda: True)
+    _as_user(app)
+
+    response = asyncio.run(_post_prepare(app))
+
+    assert response.status_code == 409
+    assert calls == []
+
+
+def test_an_unknown_target_is_rejected(prepare_app):
+    app, calls = prepare_app
+    _as_user(app)
+
+    response = asyncio.run(_post_prepare(app, {"target": "everything"}))
+
+    assert response.status_code == 422
+    assert calls == []
+
+
+# --- POST /settings ---------------------------------------------------------------
+
+
+async def _build_settings_app():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.execute(text(USERS_SCHEMA))
+        await conn.execute(text(NOTES_TEMPLATES_SCHEMA))
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    session = maker()
+    session.add(
+        User(
+            username="owner",
+            hashed_password="x",
+            role="owner",
+            is_superuser=True,
+            settings={},
+        )
+    )
+    await session.commit()
+    user = (await session.execute(select(User))).scalars().one()
+
+    app = FastAPI()
+    app.include_router(settings_ep.router, prefix="/settings")
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = lambda: user
+    return engine, app, session
+
+
+async def _post_settings(payload: dict):
+    engine, app, session = await _build_settings_app()
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t"
+        ) as client:
+            return await client.post("/settings", json=payload)
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+def test_changing_the_transcription_model_queues_no_download(monkeypatch):
+    monkeypatch.setattr(settings_ep, "config_manager", _FakeConfigManager())
+
+    sent: list[str] = []
+    monkeypatch.setattr(
+        settings_ep.celery_app,
+        "send_task",
+        lambda name, *args, **kwargs: sent.append(name),
+    )
+
+    response = asyncio.run(
+        _post_settings(
+            {"whisper_model_size": "medium", "transcription_backend": "whisper"}
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.json()["whisper_model_size"] == "medium"
+    assert DOWNLOAD_TASK not in sent

--- a/backend/worker/tasks/system.py
+++ b/backend/worker/tasks/system.py
@@ -62,6 +62,41 @@ def download_models_task(
     return {"status": "success", "message": "Model preparation complete."}
 
 
+@celery_app.task(name="backend.worker.tasks.delete_model_task", bind=True)
+def delete_model_task(self, model_name: str, variant: str | None = None):
+    """
+    Remove a cached model from the shared model volume.
+
+    Deletion runs here rather than in the API because the API mounts that volume
+    read-only, so every delete failed with EROFS. The worker lanes are the only
+    processes with write access to it.
+
+    The path is resolved here too, not passed in: the same volume is mounted at a
+    different path in each container, so an API-supplied path would be wrong, and
+    a delete sink that trusts a caller-supplied path is worth not building.
+
+    Returns a status dict rather than raising, because Celery's JSON serialiser
+    would not carry the distinction between "not found" and "refused" across the
+    boundary intact.
+    """
+    from backend.preload_models import delete_model
+
+    try:
+        deleted = delete_model(model_name, whisper_model_size=variant)
+    except ValueError as e:
+        # Repo-bundled assets are read-only by policy, not by accident.
+        return {"status": "forbidden", "message": str(e)}
+    except Exception as e:  # noqa: BLE001
+        logger.error("Failed to delete model %s: %s", model_name, e, exc_info=True)
+        return {"status": "error", "message": str(e)}
+
+    if not deleted:
+        return {"status": "not_found", "message": f"Model {model_name} not found."}
+
+    logger.info("Deleted model %s (variant=%s)", model_name, variant)
+    return {"status": "deleted", "message": f"Model {model_name} deleted."}
+
+
 @celery_app.task(name="backend.worker.tasks.get_worker_device_status", bind=True)
 def get_worker_device_status(self):
     """

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -63,7 +63,7 @@ Admin-only sections let you:
 - Configure the Ollama API URL and context window. The context window is sent to Ollama as `num_ctx` for full-context meeting prompts; if Ollama still reports a length stop, Nojoin surfaces that as a chat error instead of saving a truncated answer.
 - Configure a secondary LLM provider for fallback. When the primary provider fails, the system automatically retries with the secondary provider. The secondary provider has its own independent configuration (provider, model, API key, Ollama URL) set through `SECONDARY_` prefixed environment variables.
 - View installed Whisper models.
-- Remove local model cache entries. Required default models are prepared on first run, and repo-bundled model assets remain read-only in the UI.
+- Remove local model cache entries. Required default models are prepared on first run, and repo-bundled model assets remain read-only in the UI. Deletion runs on a worker, since the API mounts the model cache read-only, so it needs a running worker to succeed.
 - Choose when a newly selected transcription model is downloaded. Picking a model that is not on the server prompts you to fetch it now, so it is ready before the next recording, or to leave it until first use. Declining is safe: the model is downloaded when it is first needed, but live transcription and Meeting Edge wait for that download to finish.
 - Download any model listed as **Missing** in **Model dependencies**, with progress shown in place. One preparation runs at a time, so the buttons are disabled while another is in flight.
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -63,7 +63,9 @@ Admin-only sections let you:
 - Configure the Ollama API URL and context window. The context window is sent to Ollama as `num_ctx` for full-context meeting prompts; if Ollama still reports a length stop, Nojoin surfaces that as a chat error instead of saving a truncated answer.
 - Configure a secondary LLM provider for fallback. When the primary provider fails, the system automatically retries with the secondary provider. The secondary provider has its own independent configuration (provider, model, API key, Ollama URL) set through `SECONDARY_` prefixed environment variables.
 - View installed Whisper models.
-- Remove local model cache entries. Required default models are prepared automatically, and repo-bundled model assets remain read-only in the UI.
+- Remove local model cache entries. Required default models are prepared on first run, and repo-bundled model assets remain read-only in the UI.
+- Choose when a newly selected transcription model is downloaded. Picking a model that is not on the server prompts you to fetch it now, so it is ready before the next recording, or to leave it until first use. Declining is safe: the model is downloaded when it is first needed, but live transcription and Meeting Edge wait for that download to finish.
+- Download any model listed as **Missing** in **Model dependencies**, with progress shown in place. One preparation runs at a time, so the buttons are disabled while another is in flight.
 
 **Notes structure and Glossary** are also administered from **Settings > AI**. Both are two-tier: an install value you maintain for everyone, plus a per-user value.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -118,9 +118,15 @@ restarts. Optional calendar live sync (push notifications) additionally requires
 the instance to be reachable from the public internet over HTTPS at
 `WEB_APP_URL`; see [CALENDAR.md](CALENDAR.md).
 
-If an administrator switches transcription to Parakeet or Canary, Nojoin queues
-preparation for the selected ONNX ASR model after the setting is saved. Live and
-final processing still load inference models only for active work. After each
+Changing the transcription model later does not download anything on its own.
+Preparation runs on the GPU lane, so an unannounced download would queue in
+front of live work; instead **Settings > AI** asks whether to fetch a newly
+selected model now, and **Model dependencies** offers a `Download` action plus
+live progress for anything still missing. A model that is never prepared is
+fetched on first use, which delays live transcription and Meeting Edge until it
+is ready. Only one preparation runs at a time; a second request is refused with
+409 while one is in flight. Live and final processing still load inference
+models only for active work. After each
 worker task, Nojoin releases model caches and clears CUDA memory when
 `keep_models_loaded` is unset or false — except while a recording is actively
 uploading (live capture), where the live ASR model is kept resident so

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -125,8 +125,11 @@ selected model now, and **Model dependencies** offers a `Download` action plus
 live progress for anything still missing. A model that is never prepared is
 fetched on first use, which delays live transcription and Meeting Edge until it
 is ready. Only one preparation runs at a time; a second request is refused with
-409 while one is in flight. Live and final processing still load inference
-models only for active work. After each
+409 while one is in flight. Deleting a cached model also runs on a worker, not
+in the API: the API mounts the model volume read-only (`model_cache:ro`), so it
+has no write access to that cache by design. Both actions therefore need a
+running worker. Live and final processing still load inference models only for
+active work. After each
 worker task, Nojoin releases model caches and clears CUDA memory when
 `keep_models_loaded` is unset or false — except while a recording is actively
 uploading (live capture), where the live ASR model is kept resident so

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -271,7 +271,7 @@ Settings are grouped by task.
 - **Profile**: account details and password changes.
 - **Capture**: microphone selection, shared-audio gain, microphone gain, browser audio-processing toggles, and a local mic input test for browser recording.
 - **AI**: per-user AI routing (the server's configured provider, or your own Claude or ChatGPT subscription), the server provider and model, Meeting Edge, automatic meeting intelligence, language, and secondary-provider fallback. Install-wide controls (provider, models, the Ollama endpoint, fallback, and "Enable Meeting Edge") are shown only to administrators; a non-admin sees a read-only summary of the active provider instead.
-- **Transcription**: transcription backend and model choices.
+- **Transcription**: transcription backend and model choices. Administrators picking a model the server does not have yet are asked whether to download it now, so it is ready before the next recording, or to leave it until first use.
 - **Calendar**: user calendar connections and timezone behaviour.
 - **Help**: tours and support surfaces.
 - **Admin**: user, invitations, CLI usage, system, provider, release, and maintenance settings for administrators.

--- a/frontend/src/components/settings/AISettings.tsx
+++ b/frontend/src/components/settings/AISettings.tsx
@@ -257,6 +257,7 @@ export default function AISettings({
           settings={settings}
           onPersist={persistNow}
           isAdmin={isAdmin}
+          models={models}
         />
       )}
 
@@ -266,6 +267,9 @@ export default function AISettings({
           deleting={models.deleting}
           handleDeleteModel={models.handleDeleteModel}
           isAdmin={isAdmin}
+          downloadProgress={models.downloadProgress}
+          preparationRunning={models.preparationRunning}
+          startPreparation={models.startPreparation}
         />
       )}
     </div>

--- a/frontend/src/components/settings/AiModelDependenciesSection.tsx
+++ b/frontend/src/components/settings/AiModelDependenciesSection.tsx
@@ -1,6 +1,10 @@
-import { Check, Loader2, Trash2, X } from "lucide-react";
+import { Check, Download, Loader2, Trash2, X } from "lucide-react";
 
-import { SystemModelStatus } from "@/types";
+import {
+  DownloadProgress,
+  ModelPreparationTarget,
+  SystemModelStatus,
+} from "@/types";
 import SettingsPanel from "./SettingsPanel";
 import SettingsSection from "./SettingsSection";
 import SettingsStatusBadge from "./SettingsStatusBadge";
@@ -10,38 +14,54 @@ interface AiModelDependenciesSectionProps {
   deleting: string | null;
   handleDeleteModel: (modelName: string) => void;
   isAdmin: boolean;
+  downloadProgress: DownloadProgress | null;
+  preparationRunning: boolean;
+  startPreparation: (target: ModelPreparationTarget) => Promise<boolean>;
 }
 
-const DEPENDENCY_MODELS = [
+/** `target` is what a repair of this row queues. The Whisper and Pyannote
+ * assets are prepared as one core batch, so each of those rows maps to it. */
+const DEPENDENCY_MODELS: {
+  id: string;
+  label: string;
+  desc: string;
+  target: ModelPreparationTarget;
+}[] = [
   {
     id: "whisper",
     label: "Whisper (Transcription)",
     desc: "OpenAI Whisper model for speech-to-text. (MIT License)",
+    target: "core",
   },
   {
     id: "parakeet",
     label: "Parakeet ASR Model (Transcription)",
     desc: "NVIDIA FastConformer ASR model.",
+    target: "parakeet",
   },
   {
     id: "canary",
     label: "Canary ASR Model (Transcription)",
     desc: "NVIDIA Canary 1B multi-lingual ASR model.",
+    target: "canary",
   },
   {
     id: "pyannote",
     label: "Pyannote (Diarization)",
     desc: "Speaker diarization model weights.",
+    target: "core",
   },
   {
     id: "embedding",
     label: "Voice Embedding",
     desc: "Speaker identification model weights.",
+    target: "core",
   },
   {
     id: "segmentation",
     label: "Segmentation Refinement",
     desc: "Pyannote segmentation-3.0 model weights.",
+    target: "core",
   },
 ];
 
@@ -52,7 +72,15 @@ export default function AiModelDependenciesSection({
   deleting,
   handleDeleteModel,
   isAdmin,
+  downloadProgress,
+  preparationRunning,
+  startPreparation,
 }: AiModelDependenciesSectionProps) {
+  const progressPercent = Math.min(
+    100,
+    Math.max(0, downloadProgress?.progress ?? 0),
+  );
+
   return (
     <SettingsSection
       eyebrow="Administration"
@@ -60,6 +88,26 @@ export default function AiModelDependenciesSection({
       description="Inspect and manage local AI model assets on the server."
     >
       <SettingsPanel className="mx-auto max-w-3xl space-y-6">
+        {preparationRunning && (
+          <div className="rounded-lg border border-orange-300 dark:border-orange-800 bg-orange-50 dark:bg-orange-950/40 p-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+              <Loader2 className="w-4 h-4 animate-spin text-orange-600" />
+              Preparing models
+              <span className="ml-auto tabular-nums">{progressPercent}%</span>
+            </div>
+            <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-orange-100 dark:bg-orange-900/60">
+              <div
+                className="h-full rounded-full bg-orange-600 transition-all duration-500"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+            <p className="mt-2 text-xs contrast-helper">
+              {downloadProgress?.message || "Waiting for the worker..."}
+              {downloadProgress?.eta ? ` (${downloadProgress.eta} left)` : ""}
+            </p>
+          </div>
+        )}
+
         <div className="bg-gray-50 dark:bg-gray-900/50 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
           <div className="space-y-3">
             {DEPENDENCY_MODELS.map((model) => (
@@ -107,9 +155,24 @@ export default function AiModelDependenciesSection({
                     </>
                   ) : (
                     <div className="flex flex-col items-end">
-                      <SettingsStatusBadge tone="error" className="gap-1">
-                        <X className="w-3 h-3" /> Missing
-                      </SettingsStatusBadge>
+                      <div className="flex items-center gap-3">
+                        <SettingsStatusBadge tone="error" className="gap-1">
+                          <X className="w-3 h-3" /> Missing
+                        </SettingsStatusBadge>
+                        <button
+                          onClick={() => void startPreparation(model.target)}
+                          disabled={!isAdmin || preparationRunning}
+                          className="flex items-center gap-1.5 rounded-md border border-gray-300 px-2.5 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                          title={
+                            preparationRunning
+                              ? "A model preparation is already running"
+                              : "Download this model now"
+                          }
+                        >
+                          <Download className="w-3.5 h-3.5" />
+                          Download
+                        </button>
+                      </div>
                       {modelStatus?.[model.id]?.checked_paths &&
                         modelStatus[model.id].checked_paths.length > 0 && (
                           <span
@@ -127,8 +190,11 @@ export default function AiModelDependenciesSection({
           </div>
 
           <p className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 text-center text-xs contrast-helper">
-            Required default models are prepared automatically. Parakeet and
-            Canary models are prepared after their settings are saved.
+            Required default models are prepared on first run. After that,
+            changing the transcription model asks whether to download it now,
+            and a missing model can be fetched here at any time. Anything left
+            missing is downloaded on first use, which delays live transcription
+            and Meeting Edge until it is ready.
           </p>
         </div>
       </SettingsPanel>

--- a/frontend/src/components/settings/AiTranscriptionSection.test.tsx
+++ b/frontend/src/components/settings/AiTranscriptionSection.test.tsx
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const getModelsStatus = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  getModelsStatus: (...args: unknown[]) => getModelsStatus(...args),
+  deleteModel: vi.fn(),
+}));
+
+import AiTranscriptionSection from "./AiTranscriptionSection";
+import type { AISettingsModels } from "./useAISettingsModels";
+import type { Settings } from "@/types";
+
+const modelStatus = (downloaded: boolean) => ({
+  whisper: { downloaded: true, path: null, checked_paths: [] },
+  parakeet: { downloaded, path: null, checked_paths: [] },
+  canary: { downloaded: false, path: null, checked_paths: [] },
+  pyannote: { downloaded: true, path: null, checked_paths: [] },
+  embedding: { downloaded: true, path: null, checked_paths: [] },
+  segmentation: { downloaded: true, path: null, checked_paths: [] },
+});
+
+const renderSection = () => {
+  const onPersist = vi.fn().mockResolvedValue(undefined);
+  const startPreparation = vi.fn().mockResolvedValue(true);
+  const models = {
+    refreshStatus: vi.fn(),
+    startPreparation,
+  } as unknown as AISettingsModels;
+
+  render(
+    <AiTranscriptionSection
+      settings={{ transcription_backend: "whisper" } as Settings}
+      onPersist={onPersist}
+      isAdmin
+      models={models}
+    />,
+  );
+
+  return { onPersist, startPreparation };
+};
+
+const selectParakeet = () =>
+  fireEvent.change(screen.getByRole("combobox"), {
+    target: { value: "parakeet" },
+  });
+
+describe("AiTranscriptionSection download prompt", () => {
+  beforeEach(() => {
+    getModelsStatus.mockReset();
+  });
+
+  it("offers to download a model that is not on the server yet", async () => {
+    getModelsStatus.mockResolvedValue(modelStatus(false));
+    const { onPersist, startPreparation } = renderSection();
+
+    selectParakeet();
+
+    expect(await screen.findByText("Download Parakeet now?")).toBeTruthy();
+    // The change is saved either way; only the download is in question.
+    expect(onPersist).toHaveBeenCalledWith(
+      expect.objectContaining({ transcription_backend: "parakeet" }),
+    );
+
+    fireEvent.click(screen.getByText("Download now"));
+    await waitFor(() => expect(startPreparation).toHaveBeenCalledWith("active"));
+  });
+
+  it("does not prompt for a model that is already downloaded", async () => {
+    getModelsStatus.mockResolvedValue(modelStatus(true));
+    const { onPersist, startPreparation } = renderSection();
+
+    selectParakeet();
+
+    await waitFor(() => expect(onPersist).toHaveBeenCalled());
+    await waitFor(() => expect(getModelsStatus).toHaveBeenCalled());
+    expect(screen.queryByText("Download Parakeet now?")).toBeNull();
+    expect(startPreparation).not.toHaveBeenCalled();
+  });
+
+  it("keeps the model change when the download is declined", async () => {
+    getModelsStatus.mockResolvedValue(modelStatus(false));
+    const { onPersist, startPreparation } = renderSection();
+
+    selectParakeet();
+    fireEvent.click(await screen.findByText("Download later"));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Download Parakeet now?")).toBeNull(),
+    );
+    expect(startPreparation).not.toHaveBeenCalled();
+    expect(onPersist).toHaveBeenCalledWith(
+      expect.objectContaining({ transcription_backend: "parakeet" }),
+    );
+  });
+});

--- a/frontend/src/components/settings/AiTranscriptionSection.tsx
+++ b/frontend/src/components/settings/AiTranscriptionSection.tsx
@@ -2,10 +2,13 @@ import { useState } from "react";
 import { HelpCircle } from "lucide-react";
 
 import { Settings } from "@/types";
+import { getModelsStatus } from "@/lib/api";
 import Tooltip from "@/components/ui/Tooltip";
 import SettingsPanel from "./SettingsPanel";
 import SettingsSection from "./SettingsSection";
 import WhisperModelModal from "./WhisperModelModal";
+import ModelDownloadPromptModal from "./ModelDownloadPromptModal";
+import type { AISettingsModels } from "./useAISettingsModels";
 
 const WHISPER_MODELS = [
   { id: "tiny", label: "Tiny", params: "39 M", vram: "~1 GB", speed: "~10x" },
@@ -31,8 +34,9 @@ const WHISPER_MODELS = [
 interface AiTranscriptionSectionProps {
   settings: Settings;
   /** Apply and save immediately (engine and model are discrete controls). */
-  onPersist: (newSettings: Settings) => void;
+  onPersist: (newSettings: Settings) => void | Promise<void>;
   isAdmin: boolean;
+  models: AISettingsModels;
 }
 
 /** Admin-only "Transcription model" section. */
@@ -40,8 +44,50 @@ export default function AiTranscriptionSection({
   settings,
   onPersist,
   isAdmin,
+  models,
 }: AiTranscriptionSectionProps) {
   const [showWhisperModal, setShowWhisperModal] = useState(false);
+  const [downloadPromptLabel, setDownloadPromptLabel] = useState<string | null>(
+    null,
+  );
+  const [promptBusy, setPromptBusy] = useState(false);
+
+  /**
+   * Save the model change, then offer to fetch it.
+   *
+   * The save has to land first: preparation resolves the target from the saved
+   * settings, and a model already on disk should not raise a prompt at all.
+   */
+  const applyModelChange = async (
+    next: Settings,
+    statusKey: "whisper" | "parakeet" | "canary",
+    whisperSize: string,
+    label: string,
+  ) => {
+    await onPersist(next);
+    models.refreshStatus();
+
+    try {
+      const status = await getModelsStatus(whisperSize);
+      if (!status?.[statusKey]?.downloaded) {
+        setDownloadPromptLabel(label);
+      }
+    } catch (e: unknown) {
+      // A status check that fails is not a reason to block the setting change;
+      // the model still downloads lazily on first use.
+      console.error("Failed to check model status after change", e);
+    }
+  };
+
+  const confirmDownloadNow = async () => {
+    setPromptBusy(true);
+    await models.startPreparation("active");
+    setPromptBusy(false);
+    setDownloadPromptLabel(null);
+  };
+
+  const whisperLabelFor = (size: string) =>
+    `Whisper ${WHISPER_MODELS.find((m) => m.id === size)?.label || size}`;
 
   return (
     <SettingsSection
@@ -65,12 +111,22 @@ export default function AiTranscriptionSection({
           </label>
           <select
             value={settings.transcription_backend || "whisper"}
-            onChange={(e) =>
-              onPersist({
-                ...settings,
-                transcription_backend: e.target.value,
-              })
-            }
+            onChange={(e) => {
+              const engine = e.target.value as "whisper" | "parakeet" | "canary";
+              const whisperSize = settings.whisper_model_size || "turbo";
+              const label =
+                engine === "whisper"
+                  ? whisperLabelFor(whisperSize)
+                  : engine === "parakeet"
+                    ? "Parakeet"
+                    : "Canary 1B";
+              void applyModelChange(
+                { ...settings, transcription_backend: engine },
+                engine,
+                whisperSize,
+                label,
+              );
+            }}
             disabled={!isAdmin}
             className="w-full p-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 outline-none transition-all"
           >
@@ -184,8 +240,8 @@ export default function AiTranscriptionSection({
             </div>
             <p className="mt-2 text-xs contrast-helper">
               Click &apos;Change Model&apos; to select a different Whisper model
-              variant. Missing model files are prepared automatically after the
-              change is saved.
+              variant. If the model is not on the server yet, Nojoin asks
+              whether to download it now or on first use.
             </p>
           </div>
         )}
@@ -194,9 +250,22 @@ export default function AiTranscriptionSection({
           onClose={() => setShowWhisperModal(false)}
           currentSize={settings.whisper_model_size || "turbo"}
           isAdmin={isAdmin}
-          onUpdate={(newSize) =>
-            onPersist({ ...settings, whisper_model_size: newSize })
-          }
+          onUpdate={(newSize) => {
+            void applyModelChange(
+              { ...settings, whisper_model_size: newSize },
+              "whisper",
+              newSize,
+              whisperLabelFor(newSize),
+            );
+          }}
+        />
+
+        <ModelDownloadPromptModal
+          isOpen={downloadPromptLabel !== null}
+          modelLabel={downloadPromptLabel || ""}
+          busy={promptBusy}
+          onDownloadNow={() => void confirmDownloadNow()}
+          onLater={() => setDownloadPromptLabel(null)}
         />
       </SettingsPanel>
     </SettingsSection>

--- a/frontend/src/components/settings/ModelDownloadPromptModal.tsx
+++ b/frontend/src/components/settings/ModelDownloadPromptModal.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Download, Loader2, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ModelDownloadPromptModalProps {
+  isOpen: boolean;
+  /** Human-readable name of the newly selected model, e.g. "Whisper Turbo". */
+  modelLabel: string;
+  /** True while the preparation request is in flight. */
+  busy?: boolean;
+  /** Queue preparation now. */
+  onDownloadNow: () => void;
+  /** Dismiss without downloading. Backdrop, Escape and the close button all
+   * land here: declining is the safe answer, so it must be the easy one. */
+  onLater: () => void;
+}
+
+/**
+ * Asks whether a newly selected transcription model should be fetched now.
+ *
+ * Preparation runs on the GPU worker lane, the same lane that serves live
+ * transcription, so it is a decision worth surfacing rather than a side effect
+ * of saving a setting.
+ */
+export default function ModelDownloadPromptModal({
+  isOpen,
+  modelLabel,
+  busy = false,
+  onDownloadNow,
+  onLater,
+}: ModelDownloadPromptModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !busy) onLater();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, busy, onLater]);
+
+  if (!isOpen || !mounted) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-9999 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+      onClick={() => {
+        if (!busy) onLater();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="model-download-prompt-title"
+        className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md max-h-[calc(100dvh-2rem)] overflow-y-auto border border-gray-300 dark:border-gray-800 p-6 relative animate-in fade-in zoom-in-95 duration-200"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex justify-between items-start mb-4">
+          <h3
+            id="model-download-prompt-title"
+            className="text-lg font-bold text-gray-900 dark:text-white"
+          >
+            Download {modelLabel} now?
+          </h3>
+          <button
+            onClick={onLater}
+            disabled={busy}
+            aria-label="Close"
+            className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-50"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <p className="text-gray-600 dark:text-gray-300 mb-4">
+          {modelLabel} is not on the server yet. Downloading it now means it is
+          ready before your next recording starts.
+        </p>
+        <p className="text-sm contrast-helper mb-6">
+          If you skip this, the model is fetched the first time it is needed.
+          That works, but Meeting Edge and live transcription stay unavailable
+          until the download finishes and the model has loaded.
+        </p>
+
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onLater}
+            disabled={busy}
+            className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg text-sm font-medium disabled:opacity-50"
+          >
+            Download later
+          </button>
+          <button
+            onClick={onDownloadNow}
+            disabled={busy}
+            className="px-4 py-2 flex items-center gap-2 bg-orange-600 hover:bg-orange-700 text-white rounded-lg text-sm font-medium disabled:opacity-50"
+          >
+            {busy ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Download className="w-4 h-4" />
+            )}
+            Download now
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/settings/WhisperModelModal.tsx
+++ b/frontend/src/components/settings/WhisperModelModal.tsx
@@ -196,8 +196,8 @@ export default function WhisperModelModal({
 
             {!isDownloaded && !loadingStatus && (
               <p className="text-sm contrast-helper">
-                The {modelInfo?.label} model is not cached yet. Nojoin will
-                prepare it automatically after this change is saved.
+                The {modelInfo?.label} model is not cached yet. Nojoin will ask
+                whether to download it once this change is saved.
               </p>
             )}
           </div>

--- a/frontend/src/components/settings/useAISettingsModels.ts
+++ b/frontend/src/components/settings/useAISettingsModels.ts
@@ -2,12 +2,20 @@
 
 import { useEffect, useState } from "react";
 
-import { LanguageRegistry, Settings, SystemModelStatus } from "@/types";
+import {
+  DownloadProgress,
+  LanguageRegistry,
+  ModelPreparationTarget,
+  Settings,
+  SystemModelStatus,
+} from "@/types";
 import {
   deleteModel,
+  getDownloadProgress,
   getLanguageOptions,
   getModelsStatus,
   listModels,
+  prepareModels,
   validateLLM,
 } from "@/lib/api";
 import { useNotificationStore } from "@/lib/notificationStore";
@@ -30,6 +38,14 @@ export interface AISettingsModels {
   modelStatus: SystemModelStatus | null;
   languageRegistry: LanguageRegistry | null;
   deleting: string | null;
+
+  /** Live preparation progress, or null before the first read. */
+  downloadProgress: DownloadProgress | null;
+  /** Target of the preparation this session queued, while it is running. */
+  preparing: ModelPreparationTarget | null;
+  /** True whenever the server reports a preparation in flight, whoever started it. */
+  preparationRunning: boolean;
+  startPreparation: (target: ModelPreparationTarget) => Promise<boolean>;
 
   availableModels: string[];
   setAvailableModels: React.Dispatch<React.SetStateAction<string[]>>;
@@ -69,6 +85,13 @@ export function useAISettingsModels(
   const [languageRegistry, setLanguageRegistry] =
     useState<LanguageRegistry | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
+
+  const [downloadProgress, setDownloadProgress] =
+    useState<DownloadProgress | null>(null);
+  const [preparing, setPreparing] = useState<ModelPreparationTarget | null>(
+    null,
+  );
+  const [pollingProgress, setPollingProgress] = useState(false);
 
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [fetchingModels, setFetchingModels] = useState(false);
@@ -199,6 +222,85 @@ export function useAISettingsModels(
       .catch(console.error);
   };
 
+  // One read on open, so a preparation started elsewhere (first-run setup, or
+  // another admin) is visible immediately instead of only after a local action.
+  useEffect(() => {
+    let cancelled = false;
+    getDownloadProgress()
+      .then((progress) => {
+        if (cancelled) return;
+        setDownloadProgress(progress);
+        if (progress.in_progress) setPollingProgress(true);
+      })
+      .catch(console.error);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!pollingProgress) return;
+
+    let cancelled = false;
+    const timer = setInterval(async () => {
+      try {
+        const progress = await getDownloadProgress();
+        if (cancelled) return;
+        setDownloadProgress(progress);
+
+        if (progress.status === "complete") {
+          setPollingProgress(false);
+          setPreparing(null);
+          refreshStatus();
+          addNotification({
+            type: "success",
+            message: "Model preparation complete.",
+          });
+        } else if (progress.status === "error") {
+          setPollingProgress(false);
+          setPreparing(null);
+          addNotification({
+            type: "error",
+            message: progress.message || "Model preparation failed.",
+          });
+        }
+      } catch (e: unknown) {
+        console.error("Failed to read model preparation progress", e);
+      }
+    }, 2000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pollingProgress]);
+
+  const startPreparation = async (
+    target: ModelPreparationTarget,
+  ): Promise<boolean> => {
+    setPreparing(target);
+    try {
+      await prepareModels(target);
+      setPollingProgress(true);
+      addNotification({
+        type: "success",
+        message: "Model preparation started. Progress is shown below.",
+      });
+      return true;
+    } catch (e: unknown) {
+      setPreparing(null);
+      addNotification({
+        type: "error",
+        message: `Could not start model preparation: ${getErrorMessage(
+          e,
+          "Unknown error",
+        )}`,
+      });
+      return false;
+    }
+  };
+
   const handleDeleteModel = async (modelName: string) => {
     if (
       !confirm(
@@ -232,6 +334,10 @@ export function useAISettingsModels(
     modelStatus,
     languageRegistry,
     deleting,
+    downloadProgress,
+    preparing,
+    preparationRunning: pollingProgress,
+    startPreparation,
     availableModels,
     setAvailableModels,
     fetchingModels,

--- a/frontend/src/lib/api.contract.test.ts
+++ b/frontend/src/lib/api.contract.test.ts
@@ -140,6 +140,7 @@ describe("api public surface", () => {
         "mergeSpeakers",
         "pauseRecordingCapture",
         "permanentlyDeleteRecording",
+        "prepareModels",
         "previewNotesPrompt",
         "promoteToGlobalSpeaker",
         "recalibrateSpeaker",

--- a/frontend/src/lib/api/models.ts
+++ b/frontend/src/lib/api/models.ts
@@ -1,4 +1,9 @@
-import type { DownloadProgress, SystemModelStatus } from "@/types";
+import type {
+  DownloadProgress,
+  ModelPreparationResponse,
+  ModelPreparationTarget,
+  SystemModelStatus,
+} from "@/types";
 import api, { buildFirstRunRequestConfig } from "./client";
 
 export const listModels = async (
@@ -46,6 +51,16 @@ export const getModelsStatus = async (
 
 export const getDownloadProgress = async (): Promise<DownloadProgress> => {
   const response = await api.get<DownloadProgress>("/system/download-progress");
+  return response.data;
+};
+
+export const prepareModels = async (
+  target: ModelPreparationTarget = "active",
+): Promise<ModelPreparationResponse> => {
+  const response = await api.post<ModelPreparationResponse>(
+    "/system/models/prepare",
+    { target },
+  );
   return response.data;
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -710,6 +710,16 @@ export interface SystemModelStatus {
   [key: string]: ModelStatusInfo;
 }
 
+/** Which local model assets a preparation request should fetch. `active` covers
+ * whatever the saved transcription settings need. */
+export type ModelPreparationTarget = "active" | "core" | "parakeet" | "canary";
+
+export interface ModelPreparationResponse {
+  task_id: string;
+  target: ModelPreparationTarget;
+  status: string;
+}
+
 export interface DownloadProgress {
   progress: number;
   message: string;


### PR DESCRIPTION
# Pull Request

## Description

Selecting a transcription model queued a download as a side effect of saving the setting. That download runs on the GPU lane, the same lane that serves live transcription, so on a single-card host it could sit in front of a meeting. Nothing in the UI said it had started, and the setup wizard's promise to "check progress later in Settings" was never honoured by anything.

Preparation is now explicit. Selecting a model that is not on the server prompts for a choice: fetch it now so it is ready for the next recording, or leave it to the lazy fetch on first use, which delays live transcription and Meeting Edge until the download completes. Selecting a model already on disk saves silently, so the prompt only appears when there is something to download.

A new admin-only `POST /system/models/prepare` carries the request, with targets for the active selection, the core batch, and each ONNX ASR model, so a single missing row in Model dependencies can be repaired on its own. It refuses a second request with 409 while one is in flight, and resolves the model from the admin's own settings rather than the install config, since the transcription keys are user-scoped and reading config alone would prepare the install default instead. Model dependencies gains a Download action on every missing row plus a live progress strip, so declining the prompt is recoverable and a running preparation is visible however it was started.

Two pre-existing bugs surfaced while validating this against a real install and are fixed here, since the new Download button is unusable without them.

**Canary was reported as missing however many times it was downloaded.** The status check matched the Nojoin model id against Hugging Face cache directory names, but onnx-asr caches `nemo-canary-1b-v2` under the repo `istupakov/canary-1b-v2-onnx`, so the id never appeared in the directory name. Parakeet escaped the bug only because its id happens to be a substring of its repo name. Matching a fragment of the repo name instead also unblocks deletion and the admin health card, both of which read the same status. Resolving the id through onnx-asr would be exact, but that would pull the ASR stack into the API process, which the torch boundary test exists to prevent.

**Deleting a model failed on every Docker install with EROFS.** The API mounts the shared model volume read-only, by design, so the delete could never have worked from there. The delete now goes to the io lane, which mounts that volume read-write. The task resolves the path itself rather than accepting one from the API, because the same volume is mounted at a different path in each container, and a delete sink that trusts a caller-supplied path is worth not building. It returns a status dict rather than raising, since the JSON serialiser would not carry the difference between "not found" and "refused" across the boundary. The request still waits for the result so the UI keeps refreshing status the moment it returns, with a 60 second ceiling that fails the request rather than holding a thread when no worker answers.

No new dependencies.

### Behaviour changes worth noting

- Saving settings through the API no longer prepares models for any caller. Lazy fetch on first use still covers that path.
- Deleting a model now requires a running worker. With no worker the request returns 504 explaining that, rather than the old EROFS error.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test`
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

`scripts/check.py` reported OK across lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic and tests, with 1122 backend tests passing. Frontend: 296 tests across 52 files, lint clean, build clean.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/DEPLOYMENT.md` (worker startup: preparation is opt-in, deletion needs a worker, the read-only mount), `docs/ADMIN.md` (the new admin actions), `docs/USAGE.md` (the prompt in Settings).

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

Both new endpoints are admin-only. The model deletion task takes a model identity from a fixed allowlist rather than a path, so nothing caller-supplied reaches the filesystem sink, and the API keeps its read-only mount on the model volume.

## Manual verification

Verified against a live install on the deployment host:

- Confirmed the Canary asset was present on disk as `models--istupakov--canary-1b-v2-onnx` while the UI reported it Missing, which is what led to the detection fix. Confirmed the corrected matcher reports both ONNX models present using those exact directory names.
- Confirmed the API container mounts the model volume read-only and the worker lanes mount it read-write, which is the cause of the delete failure.
- Observed the preparation flow end to end: queueing, the progress strip, and the completion toast.

Still pending, because the running containers predate these commits and both fixes need the api and worker images rebuilt:

- The Canary row flipping to Ready without a download, once the api image ships the corrected detection.
- A successful delete through the worker lane.

No capture, recording context-menu, or migration changes in this PR.
