### PR TITLE
fix(release): include worker-io in the release-notes digest list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -686,7 +686,7 @@ jobs:
 
           # Resolve the published image digests for reproducible-pin guidance.
           : > image-digests.txt
-          for suffix in -api -worker -frontend; do
+          for suffix in -api -worker -worker-io -frontend; do
             digest="$(docker buildx imagetools inspect "${IMAGE_BASE}${suffix}:${VERSION}" \
               --format '{{ .Manifest.Digest }}' 2>/dev/null || echo unknown)"
             printf -- '- `%s%s@%s`\n' "${IMAGE_BASE}" "${suffix}" "${digest}" >> image-digests.txt


### PR DESCRIPTION
# Pull Request

## Description

The `publish-release-notes` job renders the pinnable digest list from a hardcoded loop over `-api`, `-worker` and `-frontend`. That loop predates the `worker-io` image and was never extended when the image was added, so every release since has shipped release notes with no pinnable digest for it.

Every other stage of the pipeline already knows about `worker-io`: `worker-io-release` builds, Trivy-scans and cosign-signs it, and `publish-mutable-tags` promotes it through the same rolling-tag matrix as the other three. Only the notes were out of step, so the maintainer has been adding the digest by hand after each release.

This adds `-worker-io` to the loop, ordered after `-worker` so the rendered list follows build order (api, worker, worker-io, frontend). Nothing else in the workflow changes: the pinned action SHAs, the pinned base-image digests and the gated job ordering that [ADR-0001](https://github.com/Valtora/Nojoin/blob/main/docs/adr/0001-gated-signed-release-model.md) depends on are untouched. No new dependencies.

**The change takes effect at the next tag.** It does not retroactively amend the v2.0.0 release notes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

Tick the checks you ran for the areas you touched (see `CONTRIBUTING.md`).

- [ ] Backend tests: `source .venv/bin/activate && pytest`
- [ ] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

The backend and frontend suites are not applicable and are not gated for this path. A deployment change under the CI path rules means `docker/**`, `docker-compose*.yml`, `nginx/**` or `.github/workflows/ci.yml`; `release.yml` runs on its own tag trigger and no unit suite can exercise it. The workflow was additionally confirmed to still parse as YAML.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

The release-notes template (`.github/release-notes-template.md`) substitutes `{{IMAGE_DIGESTS}}` as an opaque block and does not enumerate the images, so it needs no change. No guide under `docs/` lists the digest set either; the image inventory in `docs/DEPLOYMENT.md` already documents `worker-io`.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

This is a release-pipeline change, so it falls in the sensitive **Deployment / release** review scope. The obligations for that scope are met: the pinned action SHAs and pinned base-image digests are unmodified, and the `server-release` -> `worker-io-release` -> `health-smoke` -> `publish-mutable-tags` -> `publish-release-notes` `needs:` graph is unchanged. The effect is strictly additive to the notes body, and it publishes one more digest that is already public.

## Manual verification

The job only runs on a tag push or `workflow_dispatch`, never on a pull request, so CI cannot exercise it here. The shell block was instead run verbatim against the already-published v2.0.0 images, with `-worker-io` added:

```bash
IMAGE_BASE=ghcr.io/valtora/nojoin VERSION=2.0.0
: > image-digests.txt
for suffix in -api -worker -worker-io -frontend; do
  digest="$(docker buildx imagetools inspect "${IMAGE_BASE}${suffix}:${VERSION}" \
    --format '{{ .Manifest.Digest }}' 2>/dev/null || echo unknown)"
  printf -- '- `%s%s@%s`\n' "${IMAGE_BASE}" "${suffix}" "${digest}" >> image-digests.txt
done
```

Rendered output, which is exactly what would be substituted into `{{IMAGE_DIGESTS}}`:

```
- `ghcr.io/valtora/nojoin-api@sha256:75ebf1240a9025f579e9ce3f94cfdb14564108467f636fdf49d6fe8b239008a9`
- `ghcr.io/valtora/nojoin-worker@sha256:080c43e054f76cb6c7886942a42c1664f4bee3016ca1979fee6c98e07a2f238f`
- `ghcr.io/valtora/nojoin-worker-io@sha256:1527674e01e337777bbd336271ba36d9c788a88a1cceaaa03e05709230de8057`
- `ghcr.io/valtora/nojoin-frontend@sha256:76b815eadfe285a9f815b9e3da6642806f82bffa67907e0413fa1e784b0957ce`
```

All four suffixes resolve to a real digest and none falls through to `unknown`, which confirms `worker-io` is published under the plain `${VERSION}` tag the loop assumes (`type=raw,value=<version>` in `worker-io-release`) rather than a separately versioned tag.

## Screenshots (if relevant)

Not applicable.
