### PR TITLE
fix(api): bound Celery dispatch so an unreachable Redis cannot wedge it

### DIFF
--- a/backend/api/v1/endpoints/settings.py
+++ b/backend/api/v1/endpoints/settings.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.api.deps import get_current_user, get_db
 from backend.api.error_handling import sanitized_http_exception
-from backend.celery_app import celery_app
 from backend.models.notes_template import NotesTemplate, NotesTemplateScope
 from backend.models.recording import Recording, RecordingStatus
 from backend.models.user import User
@@ -427,6 +426,12 @@ async def _dispatch_meeting_edge_refresh_for_active_recordings(
     """
     from sqlalchemy import select as sa_select
 
+    # Imported here rather than at module scope to keep the endpoint modules
+    # from importing one another at import time.
+    from backend.api.v1.endpoints.transcripts.helpers import (
+        _dispatch_meeting_edge_refresh,
+    )
+
     try:
         result = await db.execute(
             sa_select(Recording.id).where(
@@ -441,11 +446,10 @@ async def _dispatch_meeting_edge_refresh_for_active_recordings(
             )
         )
         recording_ids = [row[0] for row in result.all()]
+        # One dispatch per in-flight recording, so an unbounded publish here
+        # multiplied the stall by the number of active recordings.
         for recording_id in recording_ids:
-            celery_app.send_task(
-                "backend.worker.tasks.refresh_meeting_edge_task",
-                args=[recording_id],
-            )
+            await _dispatch_meeting_edge_refresh(recording_id)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "Failed to dispatch Meeting Edge refresh after settings update: %s",

--- a/backend/api/v1/endpoints/transcripts/helpers.py
+++ b/backend/api/v1/endpoints/transcripts/helpers.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
+from starlette.concurrency import run_in_threadpool
 
 from backend.celery_app import celery_app
 from backend.models.pipeline import SpeakerCorrectionScope
@@ -51,12 +52,27 @@ async def _get_owned_recording(
     return recording
 
 
-def _dispatch_meeting_edge_refresh(recording_id: int, *, enabled: bool = True) -> None:
+async def _dispatch_meeting_edge_refresh(
+    recording_id: int, *, enabled: bool = True
+) -> None:
+    """Queue a Meeting Edge refresh. Best-effort by design; see ADR-0007.
+
+    Runs off the event loop because publishing is a blocking socket call, and
+    every caller is an `async def` handler: blocking here stalls that process's
+    other in-flight requests too, not only this one.
+
+    A failure is logged and swallowed rather than surfaced. Meeting Edge is
+    derived guidance that the next transcript mutation or live segment
+    recomputes from scratch, so a lost refresh costs one stale panel until the
+    next edit, while failing the request would lose the edit the user actually
+    made. That is a deliberate policy, not an oversight.
+    """
     if not enabled:
         return
 
     try:
-        celery_app.send_task(
+        await run_in_threadpool(
+            celery_app.send_task,
             "backend.worker.tasks.refresh_meeting_edge_task",
             args=[recording_id],
         )

--- a/backend/api/v1/endpoints/transcripts/routes_notes.py
+++ b/backend/api/v1/endpoints/transcripts/routes_notes.py
@@ -103,7 +103,7 @@ async def update_user_notes(
     db.add(transcript)
     await db.commit()
     await db.refresh(transcript)
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )
@@ -134,7 +134,7 @@ async def update_meeting_edge_focus(
     db.add(transcript)
     await db.commit()
     await db.refresh(transcript)
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )

--- a/backend/api/v1/endpoints/transcripts/routes_segments.py
+++ b/backend/api/v1/endpoints/transcripts/routes_segments.py
@@ -143,7 +143,7 @@ async def update_segment_speaker(
             },
             log=logger,
         )
-        _dispatch_meeting_edge_refresh(
+        await _dispatch_meeting_edge_refresh(
             recording.id,
             enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
         )
@@ -382,7 +382,7 @@ async def update_segment_speaker(
         },
         log=logger,
     )
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )
@@ -484,7 +484,7 @@ async def update_transcript_segment_text(
             },
             log=logger,
         )
-        _dispatch_meeting_edge_refresh(
+        await _dispatch_meeting_edge_refresh(
             recording.id,
             enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
         )
@@ -513,7 +513,7 @@ async def update_transcript_segment_text(
         },
         log=logger,
     )
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )
@@ -574,7 +574,7 @@ async def find_and_replace(
     db.add(transcript)
     await db.commit()
     await db.refresh(transcript)
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )
@@ -634,7 +634,7 @@ async def update_transcript_segments(
 
         await db.commit()
         await db.refresh(transcript)
-        _dispatch_meeting_edge_refresh(
+        await _dispatch_meeting_edge_refresh(
             recording.id,
             enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
         )
@@ -652,7 +652,7 @@ async def update_transcript_segments(
     db.add(transcript)
     await db.commit()
     await db.refresh(transcript)
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )

--- a/backend/api/v1/endpoints/transcripts/routes_utterances.py
+++ b/backend/api/v1/endpoints/transcripts/routes_utterances.py
@@ -222,7 +222,7 @@ async def update_transcript_utterance_text(
         },
         log=logger,
     )
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )
@@ -329,7 +329,7 @@ async def update_transcript_utterance_speaker(
         },
         log=logger,
     )
-    _dispatch_meeting_edge_refresh(
+    await _dispatch_meeting_edge_refresh(
         recording.id,
         enabled=is_meeting_edge_enabled(getattr(current_user, "settings", None)),
     )

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -267,6 +267,80 @@ celery_app.conf.update(
 )
 
 
+# --- Behaviour when Redis is unreachable -------------------------------------
+#
+# Dispatching a task is a blocking call, and the API dispatches from `async def`
+# handlers, so whatever it blocks for stalls that worker process's whole event
+# loop -- every concurrent request, not just the one dispatching.
+#
+# The default bound on that is the operating system's. A broker that refuses
+# connections fails per attempt in microseconds, but one that is merely
+# unreachable (a partition, a hung container, a dropped-packet firewall rule)
+# does not answer at all, and each attempt then waits out the kernel's TCP
+# connect timeout -- roughly two minutes at the default `tcp_syn_retries`.
+# Multiplied by the result backend's own 20 retries that is nearly an hour of
+# wedged event loop for one best-effort refresh nobody is waiting on.
+#
+# Capping the connect is the fix, and it is safe for both processes: it bounds
+# how long one attempt waits for a TCP handshake and does nothing to an
+# established connection, so the worker's blocking queue reads are unaffected.
+# How many attempts to make is where the two processes genuinely differ; see
+# `apply_api_dispatch_limits` below and ADR-0007.
+REDIS_CONNECT_TIMEOUT_SECONDS = 2.0
+
+# The two halves are configured through different surfaces, which is easy to
+# get wrong: the broker reads its transport options, while the result backend
+# reads top-level `redis_*` keys and ignores anything put in
+# `result_backend_transport_options` except its retry policy.
+celery_app.conf.broker_transport_options = {
+    **celery_app.conf.broker_transport_options,
+    "socket_connect_timeout": REDIS_CONNECT_TIMEOUT_SECONDS,
+}
+celery_app.conf.redis_socket_connect_timeout = REDIS_CONNECT_TIMEOUT_SECONDS
+
+
+def apply_api_dispatch_limits() -> None:
+    """Make a dispatch from the API give up quickly. Call from the API only.
+
+    The worker and the API want opposite things from a Redis outage. A worker
+    writing a result is on its own thread with nothing waiting on it, so
+    retrying hard is right: the alternative is a finished job whose result is
+    lost. An API handler is on the event loop, so retrying hard is exactly
+    wrong: it converts one unavailable dependency into a stalled process.
+
+    So the retry *counts* are set here, in the API process, rather than in the
+    shared configuration above. A dispatch against an unreachable broker then
+    costs about 6s rather than being unbounded: a small multiple of the connect
+    cap, since the pubsub reconnect makes an attempt of its own either side of
+    the retry loop. Every API dispatch either queues background work whose
+    failure the caller already tolerates, or returns a task id the client
+    re-polls, so failing fast costs a retry the client can make and never a
+    result that cannot be recovered.
+    """
+    fail_fast = {
+        "max_retries": 1,
+        "interval_start": 0,
+        "interval_step": 0.2,
+        "interval_max": 0.5,
+    }
+
+    celery_app.conf.task_publish_retry_policy = fail_fast
+    # The result backend keeps its own retry policy, which no top-level Celery
+    # setting reaches; `result_backend_transport_options["retry_policy"]` is
+    # the documented way in. It matters because `send_task` subscribes the
+    # backend to the new task's channel *before* publishing, so an unreachable
+    # backend blocks the dispatch even though the caller wants only to enqueue.
+    celery_app.conf.result_backend_transport_options = {
+        **celery_app.conf.result_backend_transport_options,
+        "retry_policy": fail_fast,
+    }
+    # The backend object is built once from the configuration above and cached,
+    # so an already-instantiated one would keep the unbounded policy. Drop both
+    # caches Celery may hold it in and let the next access rebuild it.
+    celery_app._backend_cache = None
+    celery_app._local.__dict__.pop("backend", None)
+
+
 # Heartbeat implementation to keep worker "active" during heavy tasks
 class HeartbeatThread(threading.Thread):
     def __init__(self, redis_url, interval=5.0, expire=15):

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from backend.api.v1.api import api_router
 from backend.api.v1.endpoints.oauth import well_known_router
+from backend.celery_app import apply_api_dispatch_limits
 from backend.mcp_server import (
     NormaliseMcpMountPathMiddleware,
     build_mcp_asgi_app,
@@ -282,6 +283,10 @@ async def lifespan(app: FastAPI):
 
 
 def create_app(*, app_lifespan=lifespan) -> FastAPI:
+    # This process dispatches Celery work from the event loop, so it gives up on
+    # an unreachable Redis quickly rather than retrying like a worker (ADR-0007).
+    apply_api_dispatch_limits()
+
     app = FastAPI(
         title="Nojoin API",
         description="Backend API for Nojoin - Containerized Meeting Intelligence",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -104,14 +104,14 @@ def stub_meeting_edge_dispatch(monkeypatch):
     background work, irrelevant to what the transcript tests assert, and it is
     the dispatch that made the suite slow. Returns the patched module names.
     """
+
+    async def _noop(*args, **kwargs) -> None:
+        return None
+
     patched = []
     for module in transcripts_route_modules():
         if hasattr(module, "_dispatch_meeting_edge_refresh"):
-            monkeypatch.setattr(
-                module,
-                "_dispatch_meeting_edge_refresh",
-                lambda *args, **kwargs: None,
-            )
+            monkeypatch.setattr(module, "_dispatch_meeting_edge_refresh", _noop)
             patched.append(module.__name__)
 
     # A stub that patches nothing is the failure this fixture exists to prevent.

--- a/backend/tests/redis_guard.py
+++ b/backend/tests/redis_guard.py
@@ -45,15 +45,25 @@ def harden_celery_retry_policies() -> None:
     celery_app.conf.broker_connection_max_retries = 0
     celery_app.conf.task_publish_retry_policy = {"max_retries": 0}
     # The publish settings above do not cover the result backend, which is the
-    # expensive half: `RedisBackend.ensure` has its own policy (20 retries, ~1s
-    # apart) that no Celery setting reaches. Zero means "do not retry", so the
-    # first refused connection propagates immediately.
-    celery_app.backend.retry_policy = {
-        "max_retries": 0,
-        "interval_start": 0,
-        "interval_step": 0,
-        "interval_max": 0,
+    # expensive half: `RedisBackend` keeps its own policy (20 retries, ~1s
+    # apart) that no top-level Celery setting reaches. Zero means "do not
+    # retry", so the first refused connection propagates immediately.
+    #
+    # Set through the same transport-options surface the API uses (see
+    # `apply_api_dispatch_limits`) rather than by assigning to the backend, so
+    # that building an app during a test re-derives a bounded policy instead of
+    # discarding this one.
+    celery_app.conf.result_backend_transport_options = {
+        **celery_app.conf.result_backend_transport_options,
+        "retry_policy": {
+            "max_retries": 0,
+            "interval_start": 0,
+            "interval_step": 0,
+            "interval_max": 0,
+        },
     }
+    celery_app._backend_cache = None
+    celery_app._local.__dict__.pop("backend", None)
 
 
 def app_frames(stack: list[str]) -> str:

--- a/backend/tests/test_celery_dispatch_guards.py
+++ b/backend/tests/test_celery_dispatch_guards.py
@@ -28,16 +28,22 @@ from backend.tests.redis_guard import (
 def test_dispatch_retry_policies_are_bounded():
     """A leaked dispatch must cost milliseconds, not seconds.
 
-    The result backend is the expensive half and the one no Celery setting
-    reaches: `send_task` subscribes it to the new task's pubsub channel before
-    publishing, and its own policy retries 20 times a second apart.
+    The result backend is the expensive half and the one no top-level Celery
+    setting reaches: `send_task` subscribes it to the new task's pubsub channel
+    before publishing, and its own policy retries 20 times a second apart.
+
+    Bounded rather than exactly zero, because building an app during a test
+    applies the API's own limits (`apply_api_dispatch_limits`, one retry). The
+    property that matters is that neither is the stock 20.
     """
-    assert celery_app.backend.retry_policy["max_retries"] == 0
+    assert celery_app.backend.retry_policy["max_retries"] <= 1
+    assert celery_app.conf.task_publish_retry_policy["max_retries"] <= 1
     assert celery_app.conf.task_publish_retry is False
     assert celery_app.conf.broker_connection_retry is False
 
 
-def test_a_swallowed_dispatch_is_still_recorded(redis_contact_guard):
+@pytest.mark.anyio
+async def test_a_swallowed_dispatch_is_still_recorded(redis_contact_guard):
     """The swallow hides the failure from the caller, not from the guard.
 
     This is the exact shape of the original bug: the dispatcher catches
@@ -45,7 +51,7 @@ def test_a_swallowed_dispatch_is_still_recorded(redis_contact_guard):
     ever have noticed. The guard records at the connection layer instead.
     """
     started = time.perf_counter()
-    _dispatch_meeting_edge_refresh(1)
+    await _dispatch_meeting_edge_refresh(1)
     elapsed = time.perf_counter() - started
 
     assert redis_contact_guard, "an unstubbed dispatch was not recorded"

--- a/backend/tests/test_celery_dispatch_policy.py
+++ b/backend/tests/test_celery_dispatch_policy.py
@@ -1,0 +1,77 @@
+"""How the API behaves when Redis is unreachable (ADR-0007).
+
+Dispatching is a blocking socket call made from `async def` handlers, so an
+unbounded wait does not slow one request, it stalls the process. These assert
+the bounds that make that impossible, and the process asymmetry behind them.
+"""
+
+import inspect
+
+from backend.api.v1.endpoints.transcripts import helpers
+from backend.celery_app import (
+    REDIS_CONNECT_TIMEOUT_SECONDS,
+    apply_api_dispatch_limits,
+    celery_app,
+)
+
+
+def test_connect_attempts_are_capped_on_both_redis_subsystems():
+    """The broker and the result backend are configured through different keys.
+
+    This is the trap: the broker reads `broker_transport_options`, but the
+    result backend reads top-level `redis_*` keys and silently ignores a
+    `socket_connect_timeout` placed in `result_backend_transport_options`. A
+    cap that lands on only one of them leaves the other waiting out the
+    kernel's TCP connect timeout, which is around two minutes per attempt.
+    """
+    assert (
+        celery_app.conf.broker_transport_options["socket_connect_timeout"]
+        == REDIS_CONNECT_TIMEOUT_SECONDS
+    )
+    assert (
+        celery_app.backend.connparams["socket_connect_timeout"]
+        == REDIS_CONNECT_TIMEOUT_SECONDS
+    )
+
+
+def test_api_limits_bound_both_retry_policies():
+    """Worst case per dispatch is (1 + max_retries) * the connect cap."""
+    apply_api_dispatch_limits()
+
+    assert celery_app.conf.task_publish_retry_policy["max_retries"] <= 1
+    # Not reachable through any top-level Celery setting; the backend keeps its
+    # own policy, which defaults to 20 retries roughly a second apart.
+    assert celery_app.backend.retry_policy["max_retries"] <= 1
+
+
+def test_api_limits_rebuild_an_already_created_backend():
+    """The backend is built once and cached, so applying limits must drop it.
+
+    Without this the API would keep whichever policy happened to be in force
+    the first time anything touched `celery_app.backend`, which is ordering
+    dependent and would silently be the unbounded default.
+    """
+    celery_app.conf.result_backend_transport_options = {
+        **celery_app.conf.result_backend_transport_options,
+        "retry_policy": {"max_retries": 20},
+    }
+    celery_app._backend_cache = None
+    celery_app._local.__dict__.pop("backend", None)
+    assert celery_app.backend.retry_policy["max_retries"] == 20
+
+    apply_api_dispatch_limits()
+
+    assert celery_app.backend.retry_policy["max_retries"] <= 1
+
+
+def test_best_effort_refresh_does_not_dispatch_on_the_event_loop():
+    """Publishing blocks, so the one dispatch every mutation makes is offloaded.
+
+    A coroutine function is the observable half of that: a plain `def` here
+    would mean the publish ran inline on the loop, stalling every other request
+    the process is serving rather than only this one.
+    """
+    assert inspect.iscoroutinefunction(helpers._dispatch_meeting_edge_refresh)
+    assert "run_in_threadpool" in inspect.getsource(
+        helpers._dispatch_meeting_edge_refresh
+    )

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -940,17 +940,13 @@ async def seed_transcript(session_maker, *, recording_id: int, user_notes: str) 
 
 
 @pytest.fixture
-def no_meeting_edge_dispatch(monkeypatch):
+def no_meeting_edge_dispatch(stub_meeting_edge_dispatch):
     """Stop the delegated notes update from dispatching a Meeting Edge refresh.
 
-    Otherwise update_user_notes calls celery_app.send_task, which blocks for
-    the broker connection timeout — irrelevant to the append logic here.
+    Irrelevant to the append logic here. Delegates to the shared fixture, which
+    patches every module that binds the dispatcher rather than only this one.
     """
-    import backend.api.v1.endpoints.transcripts.routes_notes as routes_notes
-
-    monkeypatch.setattr(
-        routes_notes, "_dispatch_meeting_edge_refresh", lambda *a, **k: None
-    )
+    return stub_meeting_edge_dispatch
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_model_preparation_api.py
+++ b/backend/tests/test_model_preparation_api.py
@@ -226,15 +226,10 @@ async def _post_settings(payload: dict):
         await engine.dispose()
 
 
-def test_changing_the_transcription_model_queues_no_download(monkeypatch):
+def test_changing_the_transcription_model_queues_no_download(
+    monkeypatch, stub_celery_dispatch
+):
     monkeypatch.setattr(settings_ep, "config_manager", _FakeConfigManager())
-
-    sent: list[str] = []
-    monkeypatch.setattr(
-        settings_ep.celery_app,
-        "send_task",
-        lambda name, *args, **kwargs: sent.append(name),
-    )
 
     response = asyncio.run(
         _post_settings(
@@ -244,4 +239,4 @@ def test_changing_the_transcription_model_queues_no_download(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["whisper_model_size"] == "medium"
-    assert DOWNLOAD_TASK not in sent
+    assert DOWNLOAD_TASK not in [name for name, _, _ in stub_celery_dispatch]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,8 @@ The backend is responsible for:
 
 The processing-heavy work runs in Celery workers rather than inside API endpoints.
 
+Dispatching that work is a blocking socket call to Redis, and the API dispatches from `async def` handlers, so an unreachable broker would otherwise stall the whole event loop rather than one request. The API therefore gives up quickly: connect attempts are capped at two seconds and the API process caps publish and result-backend retries at one, so a dispatch against a dead broker fails in milliseconds and against an unreachable one in a few seconds instead of being unbounded. Workers keep Celery's generous defaults, because a worker retrying to write a result has nothing waiting on it. The best-effort Meeting Edge refresh additionally runs off the event loop. See [ADR-0007](adr/0007-bounded-fail-fast-task-dispatch.md).
+
 Per-user AI inference resolves to one of three usage models — install-wide Ollama, install-wide/BYOK API keys, or the per-user **CLI OAuth** mode, which routes through a user's Claude subscription via the Claude Code CLI running in the `worker-io` lane (see [ADR-0002](adr/0002-cli-oauth-subscription-mode.md)). CLI OAuth degrades cleanly through the server's default provider chain (the primary provider first, then the secondary) and is never load-bearing.
 
 Celery work is split across three resource lanes so a long recording finalise
@@ -163,7 +165,11 @@ runs:
    a microphone-only capture reads as clear microphone dominance for every
    region including speech from everyone else in the room.
 5. After new live segments land, the API/worker layer best-effort dispatches a
-   separate `refresh_meeting_edge_task`. That task builds a bounded recent
+   separate `refresh_meeting_edge_task`. Best-effort means the dispatch failing
+   is logged and swallowed rather than failing the request that triggered it:
+   the refresh is derived guidance that the next mutation or live segment
+   recomputes from scratch, whereas failing the request would discard the edit
+   the user actually made. That task builds a bounded recent
    transcript window, reuses the previous run's dedicated rolling summary (a
    model-maintained 150-300 word running context of decisions, open threads,
    and action items, falling back to the short displayed summary for older

--- a/docs/adr/0007-bounded-fail-fast-task-dispatch.md
+++ b/docs/adr/0007-bounded-fail-fast-task-dispatch.md
@@ -1,0 +1,126 @@
+# ADR-0007: Bounded, fail-fast task dispatch from the API
+
+- **Status:** Accepted
+- **Date:** 2026-07-28
+- **Deciders:** @Valtora
+
+## Context
+
+The API dispatches Celery work from `async def` request handlers, in 34 places.
+`celery_app.send_task` is a blocking socket call, so under uvicorn it runs on
+the event loop: whatever it waits for stalls that worker process's other
+in-flight requests, not only the request that dispatched.
+
+Nothing bounded that wait. Two Redis subsystems are involved and both retried
+generously by default. `send_task` first subscribes the **result backend** to
+the new task's pubsub channel, which retried 20 times about a second apart, and
+then publishes on the **broker**, which retried again. How long one attempt
+takes is the operating system's business: a broker that refuses connections
+fails per attempt in microseconds, but one that is merely unreachable — a
+partition, a hung container, a firewall dropping packets — never answers, and
+each attempt waits out the kernel's TCP connect timeout, roughly two minutes at
+the default `tcp_syn_retries` of 6.
+
+Measured on this repository against a broker that refuses, one dispatch blocked
+for 19.04s and a concurrent request issued 50ms later took 18.99s. Against a
+broker that drops packets, the dispatching request had not returned after 70s
+and no concurrent request completed at all. The theoretical worst case is 20
+retries times a ~127s connect, or roughly 42 minutes of wedged event loop, for
+one best-effort refresh that nobody is waiting on.
+
+This was invisible in production because Redis is normally reachable, and
+invisible in tests because every dispatcher swallows its own failure. It
+surfaced only as a slow test suite (see the commit that added
+`backend/tests/redis_guard.py`).
+
+This affects the deployment contract: how the API behaves when a runtime
+dependency is unavailable.
+
+## Decision
+
+We will treat an unreachable Redis as a fast, local failure in the API rather
+than something to wait out, and we will keep the event loop free while it is
+being detected.
+
+1. **Bound every connect attempt, in both processes.** `broker_transport_options`
+   and the top-level `redis_socket_connect_timeout` both get a 2s connect
+   timeout, in `backend/celery_app.py`. This caps how long a single TCP
+   handshake may take and does nothing to an established connection, so the
+   worker's blocking queue reads are unaffected. Note the asymmetry that makes
+   this easy to get wrong: the broker reads its transport options, while the
+   result backend reads top-level `redis_*` keys and ignores everything in
+   `result_backend_transport_options` except its retry policy.
+2. **Bound the number of attempts in the API only**, through
+   `apply_api_dispatch_limits()`, called by `create_app`. The API caps the
+   publish retry policy and the result backend's retry policy at one retry.
+   The worker keeps Celery's defaults.
+3. **Dispatch the best-effort Meeting Edge refresh off the event loop**, via
+   `run_in_threadpool` in `backend/api/v1/endpoints/transcripts/helpers.py`.
+4. **Keep swallowing a failed best-effort refresh**, deliberately rather than
+   incidentally. It is logged at warning level and the request succeeds.
+
+The worker and the API are deliberately configured differently because they
+want opposite things from an outage. A worker writing a result is on its own
+thread with nothing waiting on it, so retrying hard is right: the alternative
+is a finished job whose result is lost. An API handler is on the event loop, so
+retrying hard is exactly wrong: it converts one unavailable dependency into a
+stalled process. Every API dispatch either queues background work whose failure
+the caller already tolerates, or returns a task id the client re-polls, so
+failing fast costs at most a retry the client can make, never a result that
+cannot be recovered.
+
+## Consequences
+
+A dispatch against a refused broker now costs 0.03s rather than 19.04s, and
+against an unreachable one 6.03s rather than being unbounded. During the latter
+the event loop stays free: 60 concurrent no-op requests kept a 1.0ms median and
+a 0.00s worst case, where previously not one completed. The healthy path is
+unchanged at 0.7ms.
+
+Three residual limits are accepted rather than solved:
+
+- The other 33 dispatch sites are bounded but still synchronous, so during a
+  total Redis outage each stalls its own request for up to ~6s. They are not
+  best-effort — their responses carry a task id — so they must wait for the
+  dispatch regardless; only the event-loop occupancy is worth removing, and
+  doing so is a mechanical follow-up rather than part of this decision.
+- `run_in_threadpool` borrows an anyio worker thread for the duration. During a
+  sustained outage a burst of transcript mutations can occupy the default pool
+  of 40. The degradation is graceful — further dispatches queue for a thread
+  while the loop stays responsive — but it is a bound worth knowing.
+- A lost Meeting Edge refresh is not retried. The next transcript mutation or
+  live segment recomputes it from scratch, so the cost is one stale panel until
+  the next edit.
+
+Contributors adding a dispatch to an `async def` handler should assume it can
+block for seconds and treat the event loop accordingly. Operators see no new
+configuration; the timeouts are not tunable by design, because they encode a
+property of the deployment topology (Redis is a container away) rather than a
+preference.
+
+## Alternatives Considered
+
+**Leave it alone and rely on Redis being up.** Rejected on the numbers. The
+failure mode is not a slow request but a process that stops serving every
+client for as long as the network problem lasts, and a brief partition is an
+ordinary event rather than an exotic one.
+
+**Bound the publish retry policy only.** This is the obvious reading of the
+symptom and it does nothing: measured, `task_publish_retry=False` plus
+`broker_connection_retry=False` left a dispatch at 19.01s, because `send_task`
+reaches the result backend first and never gets to the publish.
+
+**Configure the retry counts globally instead of per process.** Simpler, but it
+would make the worker drop results during a blip to solve a problem the worker
+does not have.
+
+**Move every dispatch off the loop and skip the bounding.** This fixes the
+head-of-line blocking but leaves an individual request able to hang for 42
+minutes, and it would leak threads at exactly the rate the outage produces
+requests. Bounding is what makes the offload safe, so bounding is the primary
+decision and the offload is secondary.
+
+**Fire and forget with `asyncio.create_task`.** Returns the request
+immediately, but detaches the work from any request scope and grows an unbounded
+set of pending tasks precisely when Redis is unavailable. Awaiting a bounded
+threadpool call keeps the failure observable and the concurrency accounted for.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,3 +29,4 @@ A routine bug fix, refactor, dependency bump, or documentation edit does **not**
 - [0004-anonymous-opt-out-telemetry.md](0004-anonymous-opt-out-telemetry.md) — Anonymous, opt-out telemetry with a public collector and a consent-gated rollout (Accepted).
 - [0005-versioned-voiceprint-extraction.md](0005-versioned-voiceprint-extraction.md) — Versioned voiceprint extraction, never compared across versions, plus an optional per-recording speaker cap (Accepted).
 - [0006-user-editable-notes-structure.md](0006-user-editable-notes-structure.md) — A protected/editable split for the meeting-notes prompt, with two-tier templates, provenance snapshots, and a merged glossary (Accepted).
+- [0007-bounded-fail-fast-task-dispatch.md](0007-bounded-fail-fast-task-dispatch.md) — Bounded, fail-fast Celery dispatch from the API, with the best-effort refresh moved off the event loop (Accepted).


### PR DESCRIPTION
# Pull Request

## Description

Investigation first, then a fix. **The answer to every question in the brief is yes, and the severity is worse than it looked.** No new dependencies.

### Does `send_task` block the event loop?

Yes. Nothing absorbs it — no thread pool, no executor, no non-blocking transport option. Measured on a throwaway uvicorn app that calls the real `_dispatch_meeting_edge_refresh`, with a `/ping` endpoint that does no work, so its latency reads event-loop availability directly. Against a refusing broker: the dispatch blocked **19.04s**, and a `/ping` issued 50ms later took **18.99s**. Only one ping completed in the whole window, because the loop never came back to accept another.

### What is the real production behaviour when Redis is briefly unreachable?

Much worse than the refusing case, and this is the finding that decided the PR. "Unreachable" splits in two:

| Failure mode | What happens per attempt |
| --- | --- |
| Refuses connections (container down, port closed) | Instant `RST`, so 20 retries ~1s apart = **19s** |
| Drops packets (partition, hung container, firewall) | No answer at all, so each attempt waits out the kernel TCP connect timeout — **~127s** at the default `tcp_syn_retries=6` |

The second is the ordinary network-partition case, and nothing bounded it. Measured: the dispatching request had **not returned after 70s**, and no concurrent request completed at all — the process was still wedged when I checked afterwards. The theoretical worst case is 20 retries × ~127s ≈ **42 minutes** of a completely unresponsive API process, for one best-effort refresh nobody is waiting on.

Note also that the retry that dominates is **not** the publish retry. `send_task` subscribes the result backend to the new task's pubsub channel (`backend.on_task_call`) *before* publishing, and `RedisBackend` keeps its own policy of 20 retries a second apart that no top-level Celery setting reaches. Setting `task_publish_retry=False` and `broker_connection_retry=False` leaves a dispatch at 19.01s, unchanged, because the publish is never reached.

### How widespread is it?

An AST survey of every `send_task`/`.delay(`/`apply_async` outside tests and the worker: **34 of 41 sites are directly inside an `async def`**, across recordings, capture, import/upload, speakers, chat, notes, backup, documents, settings, system and cli_oauth. Exactly one passed `ignore_result`. So this was never specific to Meeting Edge.

`settings.py` was the worst shape: it dispatched **once per in-flight recording in a loop**, multiplying the stall by the number of active recordings.

### Is the swallowed exception right?

Yes, but it should be a decision rather than an accident, so it is now stated in the code, in `ARCHITECTURE.md` and in the ADR. Meeting Edge is derived guidance that the next transcript mutation or live segment recomputes from scratch; failing the request instead would discard the edit the user actually made. Losing a refresh costs one stale panel until the next edit.

### The fix

1. **Cap connect attempts at 2s in both processes** (`backend/celery_app.py`). Safe for the worker: it bounds a TCP handshake and does nothing to an established connection, so blocking queue reads are unaffected.
2. **Cap retry counts in the API only**, via `apply_api_dispatch_limits()` called from `create_app`. The worker keeps Celery's defaults deliberately — a worker writing a result has nothing waiting on it, so retrying hard is right there and wrong on an event loop.
3. **Move the best-effort Meeting Edge refresh off the loop** with `run_in_threadpool`, awaited at all eleven call sites; `settings.py` now goes through the same helper instead of its own copy.
4. **ADR-0007** records the policy, including why the two processes are configured differently.

**A trap worth flagging for review:** the broker and the result backend take their connect timeout from *different* configuration surfaces. The broker reads `broker_transport_options`; the result backend reads the top-level `redis_socket_connect_timeout` and silently ignores a `socket_connect_timeout` placed in `result_backend_transport_options`. I got this wrong first time — it looked correct and changed nothing, and only the black-hole experiment caught it. `test_connect_attempts_are_capped_on_both_redis_subsystems` now asserts both.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

No frontend files are touched. 1150 tests pass (1146 plus four new), and the gate is green end to end:

```
OK: lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests
```

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/ARCHITECTURE.md` gains the dispatch contract in the API/worker boundary section, and states what "best-effort dispatch" means for the Meeting Edge refresh. [ADR-0007](docs/adr/0007-bounded-fail-fast-task-dispatch.md) records the decision and is listed in the ADR index. An ADR is warranted under `docs/adr/README.md` because the behaviour of a core service when a runtime dependency is unavailable is now a deliberate deployment contract, and because a future maintainer would otherwise be surprised that the API and the worker are configured differently on purpose.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

No auth, token, encryption or ownership boundary is touched. Worth noting for review that the change reduces a denial-of-service surface: before it, anything that made Redis unreachable took the whole API process down with it for as long as the condition lasted.

## Manual verification

A minimal uvicorn app calling the production `_dispatch_meeting_edge_refresh`, with `/ping` doing no work so its latency reads event-loop availability. Three broker states, before and after.

| Scenario | Metric | Before | After |
| --- | --- | --- | --- |
| **A** Broker refuses (`127.0.0.1:6379`, nothing listening) | dispatch request | 19.04s | **0.03s** |
| | concurrent `/ping` | 18.99s | dispatch finished before the first 100ms poll |
| **B** Broker unreachable (`10.255.255.1`, packets dropped) | dispatch request | **never returned; still blocked at 70s** | **6.03s** |
| | concurrent `/ping`, worst | never completed (0 of 1 returned) | **0.00s** |
| | concurrent `/ping`, median over 60 samples | — | **0.0010s** |
| | pings stalled > 1s | 1 of 1 | **0 of 60** |
| **C** Broker healthy (real Redis in Docker) | dispatch | 0.0007s | 0.0007s |

Scenario B is the headline: the request that dispatches now fails in 6.03s instead of hanging indefinitely, and during those 6s the process served 60 concurrent requests at a 1.0ms median where previously it served none.

Scenario C confirms no regression on the healthy path and that dispatch still genuinely works: after the change, `redis-cli llen io` showed the tasks queued on the correct lane.

Supporting measurement, isolating which knob matters (dispatch against a dead broker):

```
default conf                                                    19.01s
task_publish_retry=False + broker_connection_retry=False        19.01s   <- no effect
+ result backend retry_policy bounded                            0.003s
```

And the black-hole case after bounding, showing the connect cap reaching the backend:

```
backend connparams socket_connect_timeout: 2.0
backend retry_policy: {'max_retries': 1, ...}
blackhole dispatch elapsed: 6.01s
```

The throwaway Redis container and the harness were removed afterwards; nothing from the experiment is in the diff.

## Accepted residuals

Stated rather than hidden, and recorded in the ADR:

- The other 33 dispatch sites are bounded but still synchronous, so during a total outage each stalls its own request for up to ~6s. Their responses carry a task id, so they must wait for the dispatch regardless; removing their event-loop occupancy is a mechanical follow-up and is deliberately not in this PR.
- `run_in_threadpool` borrows an anyio worker thread for the duration, so a sustained outage plus a burst of transcript mutations can occupy the default pool of 40. Degradation is graceful — further dispatches queue for a thread while the loop stays responsive.
- A lost Meeting Edge refresh is not retried, by design.

## Screenshots (if relevant)

Not applicable.
