### PR TITLE
docs(adr): record why inline dispatch stays correct in the worker

### DIFF
--- a/backend/core/backup/restore/stages.py
+++ b/backend/core/backup/restore/stages.py
@@ -313,12 +313,6 @@ def _restore_preflight_overwrite(
         logger.error(f"Pre-flight cleanup failed: {e}")
 
 
-def _enqueue_proxy_generation(recording_id: int) -> None:
-    from backend.worker.tasks import generate_proxy_task
-
-    generate_proxy_task.delay(recording_id)
-
-
 def _enqueue_recording_finalization(recording_id: int, needs_proxy: bool) -> None:
     from backend.worker.tasks import finalize_restored_recording_task
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -250,6 +250,15 @@ small database connection pool. The default PostgreSQL `max_connections` (100)
 comfortably covers the reference `3` / `4` lane sizing; if you scale the lanes
 much wider, raise `max_connections` to match.
 
+Change `--concurrency` freely, but treat `--pool` as load-bearing. `solo` and
+`prefork` both give a task an operating-system process to itself, which is what
+makes it safe for worker code to queue follow-on Celery work with a blocking
+call: it can stall only the task making it. A pool that shares one process
+between concurrent tasks, such as `gevent`, `eventlet` or `threads`, breaks that
+and reintroduces the head-of-line blocking described in
+[ADR-0007](adr/0007-bounded-fail-fast-task-dispatch.md), which documents the
+reasoning and what would need to change first.
+
 ### GPU Acceleration
 
 The worker image installs Triton in its virtual environment so Whisper word-level timestamps use GPU-accelerated kernels. Without Triton, `whisper/timing.py` falls back to slower CPU-based implementations for word alignment.

--- a/docs/adr/0007-bounded-fail-fast-task-dispatch.md
+++ b/docs/adr/0007-bounded-fail-fast-task-dispatch.md
@@ -120,12 +120,54 @@ longer consume the threads those handlers need. It is also what lets the same
 helper be imported by `calendar_service`, which the worker image loads and
 which therefore cannot depend on an ASGI stack.
 
-Worker-side code still calls `celery_app.send_task` directly, deliberately. It
-has no event loop to protect, and the guard test only inspects `async def`.
+Worker-side code still calls `celery_app.send_task` directly, deliberately.
 
 Measured after the change, against an unreachable broker, unchanged from the
 numbers above: 6.03s to fail the dispatch, with 60 concurrent no-op requests at
 a 0.9ms median and a 0.00s worst case.
+
+### Why inline dispatch stays correct in the worker, 2026-07-28
+
+Recorded because it is not self-evident and the earlier wording implied
+something untrue. It is not that the worker has no event loop. It has several:
+`worker/tasks/calendar.py` drives calendar sync through `asyncio.run`, and in
+`worker-io` `processing/cli/manager.py` does the same per CLI turn, one of them
+on a dedicated thread feeding a streaming queue.
+
+Inline dispatch is safe there for three reasons, each of which is checkable and
+none of which is permanent:
+
+1. **The pools isolate work into processes.** The lanes run `--pool=solo`
+   (gpu, concurrency 1) and `--pool=prefork` (cpu 3, io 4), with no gevent or
+   eventlet anywhere in the image. Prefork means one task per operating-system
+   process, so a blocking publish stalls exactly the task making it, with no
+   second request in the process to starve. **This is the load-bearing
+   assumption, and it lives in `docker-compose`, not in the code.** Moving a
+   lane to `--pool=gevent` or `--pool=threads` would put concurrent tasks back
+   in one process and reintroduce precisely the head-of-line blocking this ADR
+   removed from the API. Revisit this section before changing a pool type.
+2. **Those loops carry no concurrency.** There is no `asyncio.gather`,
+   `create_task` or `TaskGroup` anywhere in worker-reachable async code, so each
+   loop drives a single coroutine chain and a blocking call has nothing to stall
+   but itself.
+3. **No synchronous dispatcher is reachable from a loop.** The remaining inline
+   dispatchers live in `core/backup/restore/stages.py`,
+   `processing/live_transcribe.py` and `processing/segment_transcode.py`, all of
+   which contain no `async def` at all and are entered from synchronous task
+   bodies.
+
+Note what the guard test does and does not cover. It walks the whole backend,
+not only the API, so worker code dispatching inline inside an `async def` would
+fail it. It cannot see a *synchronous* function that dispatches and is called
+from a loop, which is exactly how `_enqueue_push_channel_refresh` escaped the
+first count. Point 3 is therefore checked by reading rather than by CI.
+
+The worker is not unbounded either, which the original text left unclear. The
+connect cap is global, so only the retry *count* is API-only. Against a broker
+that drops packets, a worker dispatch fails in a measured 63.1s rather than the
+20 by roughly 127s, near enough 42 minutes, it would cost without the cap. That
+ties up one prefork child, during an outage in which that child cannot be sent
+work anyway.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
# Pull Request

## Description

Two commits from reviewing the assumption ADR-0007 left implicit: that worker-side code can keep dispatching Celery work inline. **The conclusion holds, but the stated reason was wrong**, and the real reason lives in `docker-compose` rather than in the code, so nothing would have caught it being invalidated.

### 1. `docs(adr)` — record why inline dispatch stays correct in the worker

ADR-0007 said worker code dispatches inline because it "has no event loop to protect". That is not true and was never checked. The worker runs several:

- `worker/tasks/calendar.py` drives calendar sync through `asyncio.run` per task.
- In `worker-io`, `processing/cli/manager.py` does the same per CLI turn, one of them on a dedicated thread feeding a streaming queue.

Inline dispatch is nonetheless safe, for three reasons that are each checkable and none of which is permanent:

1. **The pools isolate work into processes.** `--pool=solo` (gpu) and `--pool=prefork` (cpu 3, io 4), with no gevent or eventlet in the image. One task per OS process, so a blocking publish stalls only the task making it.
2. **Those loops carry no concurrency.** No `asyncio.gather`, `create_task` or `TaskGroup` anywhere in worker-reachable async code, so each loop drives a single coroutine chain.
3. **No synchronous dispatcher is reachable from a loop.** The three that remain (`restore/stages.py`, `live_transcribe.py`, `segment_transcode.py`) live in modules containing no `async def` at all, entered from synchronous task bodies.

**Reason 1 is the load-bearing one and it is a compose flag, not code.** Moving a lane to `--pool=gevent`, `eventlet` or `threads` would put concurrent tasks back in one process and reintroduce exactly the head-of-line blocking ADR-0007 removed from the API. That warning now sits both in the ADR and in `docs/DEPLOYMENT.md` beside the lane sizing, where someone tuning `--concurrency` would actually be reading.

Two corrections included:

- **The worker is not unbounded.** The connect cap is global; only the retry *count* is API-only. Measured against a broker that drops packets, a worker dispatch fails in **63.1s**, not the 20 × ~127s (≈42 minutes) it would cost without the cap. That ties up one prefork child during an outage in which that child cannot be sent work anyway.
- **The guard test's blind spot is now stated.** It walks the whole backend, not only the API, so worker code dispatching inline inside an `async def` would fail it. It cannot see a *synchronous* function that dispatches and is called from a loop — which is exactly how `_enqueue_push_channel_refresh` escaped the original count of 33. Reason 3 above is therefore checked by reading, not by CI.

### 2. `refactor(backup)` — drop the superseded restore proxy fan-out

`_enqueue_proxy_generation` has had no caller since **c9958ba**, whose own message says it "replace[d] the proxy-only fan-out with a single `finalize_restored_recording_task` per recording that runs on the io lane and dispatches ffmpeg work to the cpu lane". Its behaviour lives on in that task, which takes `needs_proxy` and dispatches `generate_proxy_task` itself at [system.py:379-382](https://github.com/Valtora/Nojoin/blob/main/backend/worker/tasks/system.py#L379-L382).

It was then carried into the new package unchanged when #131 decomposed `backup_manager`, so it has looked like part of the restore pipeline ever since without being wired to anything.

Confirmed dead rather than assumed:

- module-private, and its name appears exactly once in the tree (its own definition)
- no test references it
- not reachable through any `getattr` or string lookup
- `stages.py` exports no `__all__`, and nothing imports from it
- the sibling `_restore_enqueue_finalization` docstring already describes the arrangement that replaced it

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update (plus one dead-code removal, kept as its own commit)

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Green end to end with 1151 tests passing, run after the code removal:

```
OK: lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests
```

No frontend file is touched.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

The documentation *is* the change. ADR-0007 gains a dated section (the decision is unchanged, so the original text stands rather than being rewritten to claim something it did not say), and `docs/DEPLOYMENT.md` gains the pool caveat beside the lane sizing.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Every claim in the ADR text was checked rather than reasoned about:

- **Event loops in worker code** — grep for `asyncio.run`, `new_event_loop`, `run_until_complete`, `anyio.run` outside `backend/api/`. Found in `worker/tasks/calendar.py` and `processing/cli/manager.py`.
- **No concurrency in those loops** — grep for `asyncio.gather`, `create_task`, `TaskGroup` across `calendar_service/`, `calendar_push_service.py` and `processing/cli/`. No matches.
- **Sync dispatchers isolated from loops** — AST walk confirming `restore/stages.py`, `live_transcribe.py` and `segment_transcode.py` contain zero `async def`.
- **No unawaited coroutine anywhere** — AST walk over every call to `dispatch_task`, `dispatch_task_best_effort`, `enqueue_model_preparation`, `_enqueue_push_channel_refresh` and `_dispatch_meeting_edge_refresh`, checking each is inside an `Await`. This was the highest-risk silent failure from #162, since an unawaited coroutine is a no-op that raises nothing and logs nothing. Result: none.
- **No gevent or eventlet** in `requirements/`, `docker/` or the compose file.
- **The 63.1s worker bound** — measured by driving `dispatch_task_best_effort` under `asyncio.run` with `REDIS_URL` pointed at a black-holed address and without `apply_api_dispatch_limits()`, reproducing worker configuration:

```
worker-mode (no apply_api_dispatch_limits called)
  backend retry_policy: {'max_retries': 20, 'interval_start': 0, 'interval_step': 1, 'interval_max': 1}
  connect timeout: 2.0
  blackhole dispatch in worker mode: 63.1s
```

The same probe against a refusing broker returned `None` in 19.04s with the failure logged, confirming `dispatch_task_best_effort` behaves correctly under a worker-style `asyncio.run` loop and that `dispatch_task` propagates rather than swallowing.

## Screenshots (if relevant)

Not applicable.
