### PR TITLE
fix(data): stop the permission repair following persisted symlinks

### DIFF
--- a/backend/tests/test_umask_security.py
+++ b/backend/tests/test_umask_security.py
@@ -91,3 +91,50 @@ def test_repair_data_permissions(tmp_path, monkeypatch):
     assert (secret_file.stat().st_mode & 0o777) == 0o600
 
     _reset_path_manager_singleton()
+
+
+def test_repair_data_permissions_does_not_follow_symlinks(tmp_path, monkeypatch):
+    """A link inside the data directory must not re-permission its target.
+
+    Regression test for issue #164: the Codex CLI persists argv[0] dispatch
+    links under the data volume that point at its own binary inside the image,
+    and the repair pass chmod-ed the binary to 0600 through them, leaving it
+    unexecutable for the worker.
+    """
+    _reset_path_manager_singleton()
+    monkeypatch.setattr(PathManager, "_get_project_root", lambda self: tmp_path)
+    monkeypatch.setattr(PathManager, "_is_containerized_runtime", lambda self: True)
+
+    manager = PathManager()
+    user_data_dir = tmp_path / "data"
+    user_data_dir.mkdir(parents=True)
+    monkeypatch.setattr(manager, "_user_data_directory", user_data_dir)
+
+    # Targets outside the data directory, standing in for files in the image.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_binary = outside / "codex"
+    outside_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    outside_binary.chmod(0o755)
+    outside_dir = outside / "vendor"
+    outside_dir.mkdir()
+    outside_dir.chmod(0o755)
+
+    # Links persisted inside the data directory, as the Codex CLI leaves them.
+    arg0_dir = user_data_dir / "cli-oauth" / "1" / "codex" / "tmp" / "arg0"
+    arg0_dir.mkdir(parents=True)
+    file_link = arg0_dir / "apply_patch"
+    file_link.symlink_to(outside_binary)
+    dir_link = arg0_dir / "vendor"
+    dir_link.symlink_to(outside_dir, target_is_directory=True)
+
+    manager.repair_data_permissions()
+
+    # Link targets are untouched, so the binary stays executable.
+    assert (outside_binary.stat().st_mode & 0o777) == 0o755
+    assert (outside_dir.stat().st_mode & 0o777) == 0o755
+
+    # Real entries in the same tree are still repaired.
+    assert (arg0_dir.stat().st_mode & 0o777) == 0o700
+
+    _reset_path_manager_singleton()

--- a/backend/utils/path_manager.py
+++ b/backend/utils/path_manager.py
@@ -194,6 +194,17 @@ class PathManager:
         Recursively scans the user data directory and enforces:
           - 0700 (owner read/write/execute) on all directories.
           - 0600 (owner read/write) on all files.
+
+        Symbolic links found in the tree are skipped rather than re-permissioned.
+        ``chmod`` dereferences, and ``os.walk`` yields a link-to-file under
+        ``files`` and a link-to-directory under ``dirs``, so a link persisted
+        inside the data directory would otherwise have its *target* set to
+        0600/0700 — anywhere on the filesystem. That is how issue #164 left the
+        bundled Codex binary at 0600 and unexecutable: the Codex CLI keeps
+        argv[0] dispatch links under ``CODEX_HOME/tmp/arg0`` pointing back at
+        itself inside the image, and ``CODEX_HOME`` lives on the persistent data
+        volume. Skipping is the only option here — Linux has no ``lchmod``, so
+        ``os.chmod(..., follow_symlinks=False)`` raises ``NotImplementedError``.
         """
         user_data_dir = self._user_data_directory
         if not user_data_dir.exists():
@@ -211,8 +222,12 @@ class PathManager:
 
         # Walk the directory structure recursively
         for root, dirs, files in os.walk(user_data_dir):
+            root_path = Path(root)
+            # Pruned in place so the walk neither descends into a symlinked
+            # directory nor chmods it below (which would follow the link).
+            dirs[:] = [d for d in dirs if not (root_path / d).is_symlink()]
             for d in dirs:
-                dir_path = Path(root) / d
+                dir_path = root_path / d
                 try:
                     dir_path.chmod(0o700)
                 except OSError as e:
@@ -220,7 +235,9 @@ class PathManager:
                         "Could not set permissions on directory %s: %s", dir_path, e
                     )
             for f in files:
-                file_path = Path(root) / f
+                file_path = root_path / f
+                if file_path.is_symlink():
+                    continue
                 try:
                     file_path.chmod(0o600)
                 except OSError as e:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -688,7 +688,7 @@ Pinning a deployment to an exact image digest (`ghcr.io/valtora/nojoin-api@sha25
   ```bash
   chmod 600 nginx/cert.key
   ```
-- **Confidential Data File Permissions (SEC-006):** For security hardening, all confidential application data files (audio recordings, JWT keys, logs, documents, configuration files) now default to owner-only permissions. A recursive startup repair pass automatically secures existing data inside the container-mounted directory. If you are using host-mounted directories and want to align host-level permissions, you can manually restrict them:
+- **Confidential Data File Permissions (SEC-006):** For security hardening, all confidential application data files (audio recordings, JWT keys, logs, documents, configuration files) now default to owner-only permissions. A recursive startup repair pass automatically secures existing data inside the container-mounted directory. The pass skips symbolic links, so a link stored under the data directory never has its target re-permissioned elsewhere on the filesystem. If you are using host-mounted directories and want to align host-level permissions, you can manually restrict them:
   ```bash
   chmod -R 700 ./data
   ```


### PR DESCRIPTION
## Description

`repair_data_permissions` walks the data directory and chmods every entry to 0700 or 0600. `chmod` dereferences, and `os.walk` yields a link-to-file under `files` and a link-to-directory under `dirs`, so any symlink stored under the data directory had its **target** re-permissioned instead, anywhere on the filesystem it pointed.

The Codex CLI keeps argv[0] dispatch links under `CODEX_HOME/tmp/arg0` pointing back at its own binary inside the image, and Nojoin sets `CODEX_HOME` to a per-user directory on the persistent data volume because the subscription `auth.json` has to live there. Those links survive restarts, so a privileged pass set the bundled `codex` binary to 0600 and `worker-io` then failed every Codex-backed generation with `EACCES`.

The pass now skips symlinks: the directory list is pruned in place so the walk neither descends into a symlinked directory nor chmods it on the way past, and symlinked files are skipped before the chmod. Skipping is the only correction available, because Linux has no `lchmod` and `os.chmod(..., follow_symlinks=False)` raises `NotImplementedError`. Coreutils already behaves this way, so the `chmod -R` the deployment guide gives operators was never affected.

Under the gosu-dropped runtime user the chmod always failed with `EPERM` and only logged a warning, which is why the defect stayed latent in normal operation rather than being caught earlier. It becomes live the moment the pass runs privileged, which a root `docker exec ... python ...` does, since the worker image intentionally keeps `USER root` and `backend.utils.config_manager` builds its singleton at import.

Deliberately not paired with a cleanup of the Codex scratch directory, which was the other candidate fix. Codex reuses one lock-guarded `arg0` directory rather than accumulating them, verified across repeated runs, and `worker-io` runs prefork with concurrency 4, so deleting that directory would race a live Codex process for no gain. `TMPDIR` does not relocate it either.

Existing deployments self-heal on upgrade: the 0600 lives in the container's writable overlay layer, so recreating `worker-io` restores 0755, and with this change it cannot be set again.

No new dependencies.

Fixes #164

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test`
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR. The SEC-006 note in `docs/DEPLOYMENT.md` now states that the repair pass skips symbolic links.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

No auth, token, encryption or exposure boundary moves. The change does narrow a hardening gap as a side effect: while it stood, any symlink placed under the data directory gave the pass a chmod primitive over its target whenever the pass ran privileged. `docs/SECURITY.md` describes no behaviour that changes here, so it is untouched.

## Manual verification

Reproduced and fixed inside the shipped `nojoin-worker-io:local` image, using the real Codex symlink target from the issue report and the real entrypoint sequence (root ownership repair, gosu drop to uid 1000).

Before, a root pass left the binary at `uid=0 gid=0 mode=600` and `codex` failed to exec as uid 1000 with permission denied. After, the same root pass leaves it at `uid=0 gid=0 mode=755` and `codex-cli 0.145.0` runs as uid 1000.

Also confirmed against the real CLI rather than a synthetic fixture: Codex writes four links (`apply_patch`, `applypatch`, `codex-execve-wrapper`, `codex-linux-sandbox`), all pointing at the vendored binary named in the issue, and three consecutive runs produce one `arg0` directory rather than three.

No capture, recording context-menu, or frontend surface touched.
