### PR TITLE
fix(worker): run ONNX ASR on the GPU and recover orphaned recordings

### DIFF
--- a/backend/processing/engines/onnx_asr_engine.py
+++ b/backend/processing/engines/onnx_asr_engine.py
@@ -23,6 +23,24 @@ SEGMENT_PAUSE_THRESHOLD_S = 0.8
 # and the call never returns. Longer audio is transcribed in windows capped here.
 MAX_CHUNK_DURATION_S = 240.0
 
+# Tighter cap for GPU runs. The CUDA provider needs the fp32 weights (int8 has no
+# CUDA kernels), whose attention activations grow with the square of the window, so
+# 240s overflows an 8GB card while 160s fits. 120s is the largest window that still
+# leaves the card room for diarization afterwards.
+GPU_MAX_CHUNK_DURATION_S = 120.0
+
+
+def max_chunk_duration_s() -> float:
+    """Longest window to feed onnx-asr in one recognize() call, for this device.
+
+    Takes the smaller of the two caps on a GPU host so that tests, which shrink
+    MAX_CHUNK_DURATION_S to keep fixtures tiny, stay effective either way.
+    """
+    if gpu_is_present():
+        return min(MAX_CHUNK_DURATION_S, GPU_MAX_CHUNK_DURATION_S)
+    return MAX_CHUNK_DURATION_S
+
+
 # Half-width (seconds) of the search window used to snap a chunk boundary onto
 # the quietest nearby point, so a window never cuts through a spoken word.
 CHUNK_SNAP_RADIUS_S = 18.0
@@ -156,7 +174,7 @@ def _chunk_boundaries(audio, sample_rate: int) -> list[tuple[int, int]]:
     Returns a list of (start_frame, end_frame) pairs covering the whole signal.
     """
     total_frames = len(audio)
-    target = int(MAX_CHUNK_DURATION_S * sample_rate)
+    target = int(max_chunk_duration_s() * sample_rate)
     radius = int(CHUNK_SNAP_RADIUS_S * sample_rate)
     probe = max(1, int(0.2 * sample_rate))
 
@@ -282,7 +300,7 @@ class OnnxAsrEngine(TranscriptionEngine):
 
             logger.info(f"Starting {self.name} transcription for {audio_path}")
 
-            if audio_duration is not None and audio_duration > MAX_CHUNK_DURATION_S:
+            if audio_duration is not None and audio_duration > max_chunk_duration_s():
                 result = self._transcribe_chunked(
                     recognizer,
                     audio_path,
@@ -338,7 +356,7 @@ class OnnxAsrEngine(TranscriptionEngine):
         boundaries = _chunk_boundaries(audio, sample_rate)
         logger.info(
             f"{self.name}: {audio_duration:.0f}s audio exceeds the "
-            f"{MAX_CHUNK_DURATION_S:.0f}s single-pass limit; transcribing in "
+            f"{max_chunk_duration_s():.0f}s single-pass limit; transcribing in "
             f"{len(boundaries)} windows."
         )
 

--- a/backend/processing/engines/onnx_asr_engine.py
+++ b/backend/processing/engines/onnx_asr_engine.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 from ...utils.languages import resolve_transcription_language_code
-from ..onnx_providers import verify_gpu_providers
+from ..onnx_providers import gpu_is_present, verify_gpu_providers
 from .base import TranscriptionEngine
 
 logger = logging.getLogger(__name__)
@@ -217,10 +217,19 @@ class OnnxAsrEngine(TranscriptionEngine):
             import onnx_asr
 
             providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            logger.info(f"Loading {self.name} model: {onnx_id}")
+            # int8 is a CPU optimisation and defeats CUDA: onnxruntime has no CUDA
+            # kernels for most quantized ops, so it claims the session and then hands
+            # nearly every node back to CPU, inserting a memcpy at each handoff (1046
+            # of them for canary-1b). Load the fp32 weights where a GPU is present,
+            # which cuts that to 66 and keeps the graph on the card.
+            quantization = None if gpu_is_present() else "int8"
+            logger.info(
+                f"Loading {self.name} model: {onnx_id} "
+                f"(quantization={quantization or 'none'})"
+            )
             model = onnx_asr.load_model(
                 onnx_id,
-                quantization="int8",
+                quantization=quantization,
                 providers=providers,
             )
             # onnxruntime silently drops a provider it cannot load, so confirm the

--- a/backend/processing/engines/onnx_asr_engine.py
+++ b/backend/processing/engines/onnx_asr_engine.py
@@ -6,6 +6,7 @@ import logging
 import os
 
 from ...utils.languages import resolve_transcription_language_code
+from ..onnx_providers import verify_gpu_providers
 from .base import TranscriptionEngine
 
 logger = logging.getLogger(__name__)
@@ -215,12 +216,19 @@ class OnnxAsrEngine(TranscriptionEngine):
         if onnx_id not in self._model_cache:
             import onnx_asr
 
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
             logger.info(f"Loading {self.name} model: {onnx_id}")
-            self._model_cache[onnx_id] = onnx_asr.load_model(
+            model = onnx_asr.load_model(
                 onnx_id,
                 quantization="int8",
-                providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+                providers=providers,
             )
+            # onnxruntime silently drops a provider it cannot load, so confirm the
+            # session actually landed on the GPU instead of assuming it did.
+            verify_gpu_providers(
+                model, component=f"{self.name} model {onnx_id}", requested=providers
+            )
+            self._model_cache[onnx_id] = model
             logger.info(f"{self.name} model {onnx_id} loaded successfully.")
         return self._model_cache[onnx_id]
 

--- a/backend/processing/onnx_providers.py
+++ b/backend/processing/onnx_providers.py
@@ -1,0 +1,141 @@
+# nojoin/processing/onnx_providers.py
+# Verification that ONNX Runtime sessions got the execution providers we asked for.
+#
+# ONNX Runtime treats its `providers` argument as a preference, not a contract. When a
+# requested provider cannot be instantiated -- a CUDA or cuDNN shared library missing
+# from the loader path being the usual cause -- it is dropped and the session is built
+# on the next provider in the list. A total loss of GPU acceleration therefore surfaces
+# only as "still works, just slower", which is easy to miss for a long time.
+#
+# onnxruntime.get_available_providers() does not detect this: it reports what the build
+# was compiled with, so it lists CUDAExecutionProvider even in a container with no GPU
+# and no working cuDNN. The only trustworthy signal is what a constructed session
+# reports, so the helpers here inspect live sessions and log a CPU fallback loudly.
+
+import glob
+import logging
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CUDA_PROVIDER = "CUDAExecutionProvider"
+
+# Character devices the NVIDIA container runtime exposes when a GPU is passed in.
+_NVIDIA_DEVICE_GLOB = "/dev/nvidia*"
+
+# How deep to walk a loaded model's attributes looking for sessions. Model wrappers
+# nest them shallowly (onnx-asr hangs _encoder/_decoder off the model object, fastembed
+# keeps one a couple of levels down), and a bounded walk stays cheap.
+_MAX_SEARCH_DEPTH = 4
+
+
+def iter_inference_sessions(
+    obj: Any, _depth: int = 0, _seen: set[int] | None = None
+) -> Iterator[Any]:
+    """Yield every onnxruntime InferenceSession reachable from an object.
+
+    Model loaders keep their sessions under library-specific private attribute names
+    (`_model`, `_encoder`, `_decoder_joint`, ...), so this walks the object graph
+    rather than binding to any one library's internals.
+
+    Args:
+        obj: The loaded model object to search.
+
+    Yields:
+        Each distinct InferenceSession found, up to a bounded search depth.
+    """
+    import onnxruntime as rt
+
+    if _seen is None:
+        _seen = set()
+    if obj is None or _depth > _MAX_SEARCH_DEPTH or id(obj) in _seen:
+        return
+    _seen.add(id(obj))
+
+    if isinstance(obj, rt.InferenceSession):
+        yield obj
+        return
+
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        children: list[Any] = list(obj)
+    elif isinstance(obj, dict):
+        children = list(obj.values())
+    else:
+        # Read __dict__ directly so the walk never triggers a property or descriptor.
+        children = list(vars(obj).values()) if hasattr(obj, "__dict__") else []
+
+    for child in children:
+        yield from iter_inference_sessions(child, _depth + 1, _seen)
+
+
+def gpu_is_present() -> bool:
+    """Report whether an NVIDIA GPU is visible to this process.
+
+    Checked by device node rather than by asking a CUDA library, so it stays cheap
+    and does not itself depend on the library loading correctly. Distinguishes the
+    CPU-only lanes and CPU-only deployments, where running on CPU is intended, from
+    a GPU host where a CPU fallback means something is misconfigured.
+    """
+    return bool(glob.glob(_NVIDIA_DEVICE_GLOB))
+
+
+def verify_gpu_providers(
+    model: Any, *, component: str, requested: Sequence[str]
+) -> bool:
+    """Warn when a model asked for the CUDA provider but its sessions fell back to CPU.
+
+    Args:
+        model: A loaded model object holding one or more InferenceSessions.
+        component: Human-readable name for the model, used in log messages.
+        requested: The provider list that was passed to the loader.
+
+    Returns:
+        True when CUDA was requested and every session is running on it. False when
+        CUDA was not requested, when a session fell back to CPU, or when no session
+        could be found to inspect.
+    """
+    if CUDA_PROVIDER not in requested:
+        return False
+
+    try:
+        sessions = list(iter_inference_sessions(model))
+        # Resolve the providers here too, inside the guard, so a session that objects
+        # to being queried cannot take the caller down with it.
+        session_providers = [s.get_providers() for s in sessions]
+    except Exception as e:  # noqa: BLE001
+        # Provider verification is diagnostic only and must never break model loading.
+        logger.debug(f"{component}: could not inspect ONNX Runtime sessions: {e}")
+        return False
+
+    if not sessions:
+        logger.debug(f"{component}: found no ONNX Runtime session to verify.")
+        return False
+
+    degraded = [p for p in session_providers if CUDA_PROVIDER not in p]
+    if degraded:
+        active = sorted({name for providers in degraded for name in providers})
+        summary = (
+            f"{component}: {len(degraded)} of {len(sessions)} ONNX Runtime session(s) "
+            f"are on CPU (active: {', '.join(active)})"
+        )
+        if gpu_is_present():
+            # A GPU is attached but ONNX Runtime is not using it, which is the
+            # misconfiguration worth shouting about.
+            logger.warning(
+                f"{summary}, despite a GPU being present. Inference will be far "
+                "slower than expected. This usually means the CUDA/cuDNN shared "
+                "libraries are not on the loader path; check this log for 'Failed to "
+                "load library libonnxruntime_providers_cuda.so'."
+            )
+        else:
+            # No GPU is attached: the CPU-only lanes and CPU-only deployments both
+            # land here, where running on CPU is the intended outcome, not a fault.
+            logger.info(f"{summary}, as expected with no GPU attached.")
+        return False
+
+    logger.info(
+        f"{component} is using the ONNX Runtime CUDA execution provider "
+        f"({len(sessions)} session(s))."
+    )
+    return True

--- a/backend/processing/text_embedding.py
+++ b/backend/processing/text_embedding.py
@@ -2,6 +2,8 @@ import logging
 import os
 from typing import Any, List, Union
 
+from .onnx_providers import verify_gpu_providers
+
 logger = logging.getLogger(__name__)
 
 # Model configuration
@@ -27,9 +29,17 @@ class TextEmbeddingService:
             try:
                 from fastembed import TextEmbedding
 
+                providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
                 self._model = TextEmbedding(
                     model_name=MODEL_NAME,
-                    providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+                    providers=providers,
+                )
+                # A TextEmbedding built with an unloadable CUDA provider still
+                # succeeds, on CPU, so the exception handler below never fires.
+                verify_gpu_providers(
+                    self._model,
+                    component=f"Text embedding model {MODEL_NAME}",
+                    requested=providers,
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning(

--- a/backend/tests/test_onnx_providers.py
+++ b/backend/tests/test_onnx_providers.py
@@ -182,3 +182,18 @@ def test_asr_engine_picks_fp32_on_gpu_and_int8_on_cpu(monkeypatch):
         engine._model_cache = {}
         engine._get_model({})
         assert captured["quantization"] == expected
+
+
+def test_window_cap_tightens_on_gpu_and_respects_test_overrides(monkeypatch):
+    """fp32 attention activations blow an 8GB card at the CPU-sized window."""
+    from backend.processing.engines import onnx_asr_engine as e
+
+    monkeypatch.setattr(e, "gpu_is_present", lambda: False)
+    assert e.max_chunk_duration_s() == e.MAX_CHUNK_DURATION_S
+
+    monkeypatch.setattr(e, "gpu_is_present", lambda: True)
+    assert e.max_chunk_duration_s() == e.GPU_MAX_CHUNK_DURATION_S
+
+    # Tests shrink MAX_CHUNK_DURATION_S to keep fixtures tiny; that must still win.
+    monkeypatch.setattr(e, "MAX_CHUNK_DURATION_S", 4.0)
+    assert e.max_chunk_duration_s() == 4.0

--- a/backend/tests/test_onnx_providers.py
+++ b/backend/tests/test_onnx_providers.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import logging
+
+import onnxruntime as rt
+
+from backend.processing import onnx_providers
+from backend.processing.onnx_providers import (
+    CUDA_PROVIDER,
+    iter_inference_sessions,
+    verify_gpu_providers,
+)
+
+CPU_PROVIDER = "CPUExecutionProvider"
+REQUESTED = [CUDA_PROVIDER, CPU_PROVIDER]
+
+
+class StubSession(rt.InferenceSession):
+    """A real InferenceSession subclass that skips loading an actual model.
+
+    The helper matches on isinstance(obj, rt.InferenceSession), so the stub has to
+    share that type; bypassing __init__ avoids needing an .onnx file on disk.
+    """
+
+    def __init__(self, providers: list[str]) -> None:  # noqa: D107
+        self._providers = providers
+
+    def get_providers(self) -> list[str]:  # type: ignore[override]
+        return self._providers
+
+
+def cuda_session() -> StubSession:
+    return StubSession([CUDA_PROVIDER, CPU_PROVIDER])
+
+
+def cpu_session() -> StubSession:
+    return StubSession([CPU_PROVIDER])
+
+
+class ModelStub:
+    """Stands in for a loaded onnx-asr / fastembed model wrapper."""
+
+    def __init__(self, **sessions: object) -> None:
+        self.__dict__.update(sessions)
+
+
+def test_finds_sessions_across_attributes_containers_and_nesting():
+    inner = ModelStub(_decoder=cuda_session())
+    model = ModelStub(
+        _encoder=cuda_session(),
+        _parts=[cuda_session()],
+        _by_name={"joiner": cuda_session()},
+        _nested=inner,
+        _unrelated="not a session",
+    )
+
+    # One plain attribute, one inside a list, one inside a dict, one a level deeper.
+    assert len(list(iter_inference_sessions(model))) == 4
+
+
+def test_tolerates_reference_cycles():
+    model = ModelStub(_model=cuda_session())
+    model.__dict__["_self"] = model
+
+    assert len(list(iter_inference_sessions(model))) == 1
+
+
+def test_returns_true_when_every_session_is_on_cuda(caplog):
+    model = ModelStub(_encoder=cuda_session(), _decoder=cuda_session())
+
+    with caplog.at_level(logging.INFO):
+        assert verify_gpu_providers(model, component="Canary", requested=REQUESTED)
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_warns_when_a_session_fell_back_to_cpu_on_a_gpu_host(caplog, monkeypatch):
+    # The exact production failure: a GPU is attached, but the CUDA provider could
+    # not be loaded, so onnxruntime built on CPU and reported success anyway.
+    monkeypatch.setattr(onnx_providers, "gpu_is_present", lambda: True)
+    model = ModelStub(_encoder=cpu_session(), _decoder=cpu_session())
+
+    with caplog.at_level(logging.INFO):
+        assert not verify_gpu_providers(model, component="Canary", requested=REQUESTED)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "despite a GPU being present" in warnings[0].message
+    assert "libonnxruntime_providers_cuda.so" in warnings[0].message
+
+
+def test_warns_when_only_some_sessions_fell_back(caplog, monkeypatch):
+    monkeypatch.setattr(onnx_providers, "gpu_is_present", lambda: True)
+    model = ModelStub(_encoder=cuda_session(), _decoder=cpu_session())
+
+    with caplog.at_level(logging.WARNING):
+        assert not verify_gpu_providers(model, component="Canary", requested=REQUESTED)
+
+    assert "1 of 2 ONNX Runtime session(s) are on CPU" in caplog.records[0].message
+
+
+def test_cpu_only_host_is_reported_as_expected_not_as_a_fault(caplog, monkeypatch):
+    # The CPU-only worker lanes and CPU-only deployments both land here. Running on
+    # CPU is the intended outcome, so it must not raise a warning on every load.
+    monkeypatch.setattr(onnx_providers, "gpu_is_present", lambda: False)
+    model = ModelStub(_encoder=cpu_session(), _decoder=cpu_session())
+
+    with caplog.at_level(logging.INFO):
+        assert not verify_gpu_providers(model, component="Canary", requested=REQUESTED)
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert "as expected with no GPU attached" in caplog.records[0].message
+
+
+def test_gpu_presence_is_detected_from_device_nodes(monkeypatch):
+    monkeypatch.setattr(onnx_providers.glob, "glob", lambda pattern: [])
+    assert not onnx_providers.gpu_is_present()
+
+    monkeypatch.setattr(
+        onnx_providers.glob, "glob", lambda pattern: ["/dev/nvidia0", "/dev/nvidiactl"]
+    )
+    assert onnx_providers.gpu_is_present()
+
+
+def test_stays_quiet_when_cuda_was_never_requested(caplog):
+    model = ModelStub(_encoder=cpu_session())
+
+    with caplog.at_level(logging.WARNING):
+        assert not verify_gpu_providers(
+            model, component="Canary", requested=[CPU_PROVIDER]
+        )
+
+    assert not caplog.records
+
+
+def test_no_sessions_found_is_not_reported_as_success(caplog):
+    with caplog.at_level(logging.WARNING):
+        assert not verify_gpu_providers(
+            ModelStub(), component="Canary", requested=REQUESTED
+        )
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_get_available_providers_is_not_a_substitute_for_this_check():
+    """Documents why this module exists.
+
+    get_available_providers() reports what the onnxruntime build was compiled with,
+    not what can actually be instantiated, so it lists CUDAExecutionProvider even
+    where no CUDA session can be created. Any health check built on it would have
+    reported the GPU as healthy throughout the CPU-fallback regression.
+    """
+    if CUDA_PROVIDER not in rt.get_available_providers():
+        # A CPU-only onnxruntime build; nothing to assert about the trap.
+        return
+
+    session_providers = cpu_session().get_providers()
+    assert CUDA_PROVIDER not in session_providers

--- a/backend/tests/test_onnx_providers.py
+++ b/backend/tests/test_onnx_providers.py
@@ -156,3 +156,29 @@ def test_get_available_providers_is_not_a_substitute_for_this_check():
 
     session_providers = cpu_session().get_providers()
     assert CUDA_PROVIDER not in session_providers
+
+
+def test_asr_engine_picks_fp32_on_gpu_and_int8_on_cpu(monkeypatch):
+    """int8 has no CUDA kernels, so the engine must not request it on a GPU host."""
+    import sys
+    import types
+
+    from backend.processing.engines import onnx_asr_engine
+
+    captured: dict = {}
+    stub = types.ModuleType("onnx_asr")
+    stub.load_model = lambda onnx_id, **kw: captured.update(kw) or ModelStub()
+    monkeypatch.setitem(sys.modules, "onnx_asr", stub)
+
+    class Engine(onnx_asr_engine.OnnxAsrEngine):
+        name = "canary"
+        config_key = "canary_model"
+        default_model_id = "nemo-canary-1b-v2"
+        onnx_id_map: dict = {}
+
+    for gpu_present, expected in ((True, None), (False, "int8")):
+        monkeypatch.setattr(onnx_asr_engine, "gpu_is_present", lambda v=gpu_present: v)
+        engine = Engine()
+        engine._model_cache = {}
+        engine._get_model({})
+        assert captured["quantization"] == expected

--- a/backend/tests/test_stuck_processing_recovery.py
+++ b/backend/tests/test_stuck_processing_recovery.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import types
+
+from backend.models.recording import Recording, RecordingStatus
+from backend.worker.tasks import pipeline
+
+GPU_QUEUE = "gpu"
+
+
+class FakeSession:
+    """Minimal stand-in for the sync SQLModel session the sweep uses."""
+
+    def __init__(self, recordings: list[Recording]) -> None:
+        self._recordings = recordings
+        self.added: list[Recording] = []
+        self.commits = 0
+
+    def exec(self, _statement):
+        return types.SimpleNamespace(all=lambda: list(self._recordings))
+
+    def add(self, obj) -> None:
+        self.added.append(obj)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def processing(recording_id: int, task_id: str | None) -> Recording:
+    return Recording(
+        id=recording_id,
+        name=f"rec-{recording_id}",
+        status=RecordingStatus.PROCESSING,
+        celery_task_id=task_id,
+    )
+
+
+def test_reclaims_a_recording_whose_task_is_gone(monkeypatch):
+    # The production failure: the worker died mid-pipeline, so the recording sits in
+    # PROCESSING forever. The startup sweep ignored it and reprocess refuses it.
+    monkeypatch.setattr(pipeline, "_live_task_ids", lambda: {"some-other-task"})
+    session = FakeSession([processing(104, "dead-task")])
+
+    reclaimed = pipeline._reclaim_orphaned_processing(session)
+
+    assert [r.id for r in reclaimed] == [104]
+    assert reclaimed[0].status == RecordingStatus.QUEUED
+    assert session.commits == 1
+
+
+def test_leaves_a_recording_whose_task_is_still_running(monkeypatch):
+    monkeypatch.setattr(pipeline, "_live_task_ids", lambda: {"live-task"})
+    session = FakeSession([processing(104, "live-task")])
+
+    assert pipeline._reclaim_orphaned_processing(session) == []
+    assert session.commits == 0
+
+
+def test_reclaims_nothing_when_liveness_cannot_be_established(monkeypatch):
+    """A broker hiccup must not let one worker's restart steal another's live job."""
+    monkeypatch.setattr(pipeline, "_live_task_ids", lambda: None)
+    session = FakeSession([processing(104, "unknown")])
+
+    assert pipeline._reclaim_orphaned_processing(session) == []
+    assert session.commits == 0
+
+
+def test_unrecorded_task_id_is_reclaimable_when_nothing_is_running(monkeypatch):
+    """Recordings predating the task-id stamp still recover once the queue is idle."""
+    monkeypatch.setattr(pipeline, "_live_task_ids", lambda: set())
+    session = FakeSession([processing(104, None)])
+
+    assert [r.id for r in pipeline._reclaim_orphaned_processing(session)] == [104]
+
+
+def test_live_task_ids_reports_unknown_rather_than_empty(monkeypatch):
+    """inspect() returns None when no worker answers; that is not 'nothing running'."""
+
+    def inspect(**_kwargs):
+        return types.SimpleNamespace(active=lambda: None)
+
+    monkeypatch.setattr(pipeline, "_live_task_ids", pipeline._live_task_ids)
+    from backend import celery_app as celery_module
+
+    monkeypatch.setattr(
+        celery_module.celery_app, "control", types.SimpleNamespace(inspect=inspect)
+    )
+
+    assert pipeline._live_task_ids() is None
+
+
+def test_live_task_ids_flattens_every_worker(monkeypatch):
+    def inspect(**_kwargs):
+        return types.SimpleNamespace(
+            active=lambda: {
+                "celery@gpu": [{"id": "a"}, {"id": "b"}],
+                "celery@io": [{"id": "c"}],
+                "celery@cpu": [],
+            }
+        )
+
+    from backend import celery_app as celery_module
+
+    monkeypatch.setattr(
+        celery_module.celery_app, "control", types.SimpleNamespace(inspect=inspect)
+    )
+
+    assert pipeline._live_task_ids() == {"a", "b", "c"}
+
+
+def _sender(queues):
+    return types.SimpleNamespace(
+        app=types.SimpleNamespace(
+            amqp=types.SimpleNamespace(
+                queues=types.SimpleNamespace(consume_from=queues)
+            )
+        )
+    )
+
+
+def test_only_the_lane_running_the_task_sweeps():
+    # All three lanes import this module, so without the gate each pending recording
+    # would be dispatched once per lane.
+    assert pipeline._sweeps_recordings(_sender({GPU_QUEUE: object()}))
+    assert not pipeline._sweeps_recordings(_sender({"cpu": object(), "io": object()}))
+
+
+def test_sweeps_when_the_consumed_queues_cannot_be_read():
+    """Prefer a duplicate run over leaving recordings stranded."""
+    assert pipeline._sweeps_recordings(_sender(None))
+    assert pipeline._sweeps_recordings(types.SimpleNamespace(app=None))

--- a/backend/worker/tasks/pipeline.py
+++ b/backend/worker/tasks/pipeline.py
@@ -897,6 +897,10 @@ def process_recording_task(
 
     try:
         recording.status = RecordingStatus.PROCESSING
+        # Stamp the task actually doing the work, not just the one the API dispatched.
+        # The startup sweep uses this to tell a live run from one whose worker died,
+        # and the worker's own re-queue path never set it.
+        recording.celery_task_id = self.request.id
         recording.processing_progress = 20
         if (
             recording.processing_started_at is None
@@ -1099,17 +1103,110 @@ def process_recording_task(
             _release_pipeline_vram()
 
 
+def _live_task_ids() -> set[str] | None:
+    """Ids of tasks currently running on any worker.
+
+    Returns None when that cannot be established, which is deliberately different
+    from an empty set: callers must not treat "nobody answered" as "nothing is
+    running", or restarting one worker would reclaim another's live work.
+    """
+    from backend.celery_app import celery_app
+
+    try:
+        active = celery_app.control.inspect(timeout=5.0).active()
+    except Exception as e:  # noqa: BLE001 -- boundary: broker may be unreachable
+        logger.warning("Could not inspect active Celery tasks: %s", e)
+        return None
+
+    if active is None:
+        logger.warning("No Celery worker answered the active-task inspection.")
+        return None
+
+    return {
+        task["id"]
+        for tasks in active.values()
+        for task in tasks
+        if isinstance(task, dict) and task.get("id")
+    }
+
+
+def _reclaim_orphaned_processing(session) -> list[Recording]:
+    """Return recordings left in PROCESSING by a worker that died mid-pipeline.
+
+    A recording only leaves PROCESSING when its task finishes, so one whose task is
+    no longer running is stranded: the startup sweep used to ignore it and the
+    reprocess endpoint refuses to touch a PROCESSING recording, leaving no way back
+    short of editing the database. Reclaiming needs proof the task is gone, so this
+    returns nothing when liveness cannot be established.
+    """
+    stuck = session.exec(
+        select(Recording).where(Recording.status == RecordingStatus.PROCESSING)
+    ).all()
+    if not stuck:
+        return []
+
+    live = _live_task_ids()
+    if live is None:
+        logger.warning(
+            "%s recording(s) are PROCESSING but liveness is unknown; leaving them "
+            "alone rather than risk reclaiming a running job.",
+            len(stuck),
+        )
+        return []
+
+    orphaned = [r for r in stuck if r.celery_task_id not in live]
+    for recording in orphaned:
+        logger.warning(
+            "Recording %s was left PROCESSING by task %s, which is no longer "
+            "running. Re-queueing.",
+            recording.id,
+            recording.celery_task_id or "<unrecorded>",
+        )
+        recording.status = RecordingStatus.QUEUED
+        recording.processing_step = "Queued after an interrupted run..."
+        session.add(recording)
+    if orphaned:
+        session.commit()
+    return orphaned
+
+
+def _sweeps_recordings(sender) -> bool:
+    """Whether this worker should run the startup sweep.
+
+    Every lane imports this module, so all three would otherwise sweep on startup
+    and dispatch each pending recording once per lane. Only the lane that consumes
+    the queue process_recording_task routes to can actually run the work, so it
+    does the sweep. When the consumed queues cannot be read, sweep anyway: a
+    duplicate run wastes time, but skipping leaves recordings stranded.
+    """
+    from backend.celery_app import GPU_QUEUE
+
+    try:
+        consume_from = getattr(sender.app.amqp.queues, "consume_from", None)
+    except Exception:  # noqa: BLE001 -- boundary: internal Celery shape may change
+        consume_from = None
+
+    if not consume_from:
+        logger.warning("Could not read this worker's queues; sweeping regardless.")
+        return True
+    return GPU_QUEUE in set(consume_from)
+
+
 @worker_ready.connect
 def check_queued_recordings(sender, **kwargs):
     """
-    On worker startup, check for any recordings that are stuck in QUEUED state
-    and re-queue them.
+    On worker startup, re-queue recordings left QUEUED, and reclaim any left
+    PROCESSING by a worker that died mid-pipeline.
     """
+    if not _sweeps_recordings(sender):
+        return
+
     logger.info("Checking for pending QUEUED recordings...")
     session = get_sync_session()
     try:
         statement = select(Recording).where(Recording.status == RecordingStatus.QUEUED)
-        recordings = session.exec(statement).all()
+        recordings = list(session.exec(statement).all())
+        recordings.extend(_reclaim_orphaned_processing(session))
 
         if not recordings:
             logger.info("No pending recordings found.")

--- a/backend/worker/tasks/pipeline.py
+++ b/backend/worker/tasks/pipeline.py
@@ -718,6 +718,35 @@ def _finalize_transcript_and_notes(
     )
 
 
+def _release_asr_vram() -> None:
+    """Free the ASR models once transcription is done, before diarization runs.
+
+    Only on a GPU host, where VRAM is the contended resource. ONNX Runtime's arena
+    grows with the transcription window and never shrinks, so on a small card a
+    finished ASR session can leave diarization with nothing left to allocate. The
+    engines reload lazily on the next task.
+    """
+    from backend.processing.onnx_providers import gpu_is_present
+
+    if not gpu_is_present():
+        return
+
+    import gc
+
+    import torch
+
+    try:
+        from backend.processing.transcribe import release_model_cache
+
+        release_model_cache()
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        logger.info("Released ASR VRAM before diarization.")
+    except Exception as e:  # noqa: BLE001 -- boundary: VRAM release is best-effort
+        logger.error("Error releasing ASR VRAM: %s", e)
+
+
 def _release_pipeline_vram() -> None:
     """Best-effort release of cached ML models / VRAM after the task.
 
@@ -897,6 +926,9 @@ def process_recording_task(
         transcription_result = _run_final_asr_stage(
             ctx, recording, processed_audio_path, engine_override
         )
+
+        # Hand the card back before diarization asks for it.
+        _release_asr_vram()
 
         # --- Stage: diarization ---
         diarization_result = _run_final_diarization_stage(

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -85,6 +85,32 @@ RUN apt-get update && \
 RUN /usr/bin/python3 -m pip install --no-cache-dir --break-system-packages \
     --root-user-action=ignore --upgrade pillow==12.3.0 urllib3==2.7.0
 
+# Put the CUDA wheel libraries on the dynamic loader path. Despite the `cudnn9` tag,
+# this base ships CUDA and cuDNN only as nvidia-*-cu12 wheels under dist-packages,
+# with nothing in a system lib dir or the ldconfig cache. torch copes, because it
+# ctypes-preloads its own wheel libraries with RTLD_GLOBAL, but onnxruntime-gpu does
+# not: libonnxruntime_providers_cuda.so is linked against cuDNN 9's split
+# sub-libraries (libcudnn_adv, _ops, _cnn, _graph, _heuristic, _engines_*), which
+# torch never preloads, plus libcublasLt. Without this the loader cannot resolve
+# them, the CUDA execution provider is silently dropped, and Canary/Parakeet ASR and
+# text embeddings run on CPU while torch still reports CUDA as available.
+#
+# Register every wheel lib directory rather than just cuDNN's, so the CUDA provider
+# loads on its own merits instead of depending on torch being imported first. These
+# are CUDA runtime libraries only; the driver libraries still come from
+# /usr/local/nvidia/lib*, which LD_LIBRARY_PATH resolves ahead of the ldconfig cache.
+# Read paths from __path__ rather than __file__: the nvidia-*-cu12 wheels are PEP 420
+# namespace packages, whose __file__ is None. The greps assert the layout so a future
+# base bump fails the build here instead of degrading to CPU in production.
+RUN /usr/bin/python3 -c \
+      "import nvidia, os, glob; \
+       print('\n'.join(sorted(d for p in nvidia.__path__ \
+             for d in glob.glob(os.path.join(p, '*', 'lib')))))" \
+      > /etc/ld.so.conf.d/nvidia-cuda-wheels.conf && \
+    ldconfig && \
+    ldconfig -p | grep -q libcudnn_adv.so.9 && \
+    ldconfig -p | grep -q libcublasLt.so.12
+
 COPY --from=builder /opt/venv /opt/venv
 
 WORKDIR /app

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -265,7 +265,9 @@ The worker image installs Triton in its virtual environment so Whisper word-leve
 
 Text embedding (used during AI-generated meeting intelligence) uses the ONNX Runtime CUDA execution provider when available, with an automatic CPU fallback.
 
-The Parakeet and Canary ASR engines also use ONNX Runtime CUDA. Some ONNX graph operations are inherently CPU-pinned; the resulting memcpy overhead is expected and does not indicate a configuration problem.
+The Parakeet and Canary ASR engines also use ONNX Runtime CUDA. They load fp32 weights where a GPU is present and int8 weights where one is not. This is deliberate: int8 is a CPU optimisation, and ONNX Runtime has no CUDA kernels for most quantized operations, so an int8 graph is handed back to the CPU node by node even when the CUDA provider loads cleanly. On Canary 1B that difference is 1046 memcpy nodes and roughly real-time transcription against 66 nodes and a GPU-bound run. The fp32 weights need more VRAM (about 5.4 GB for Canary 1B), which is why the choice follows GPU presence rather than being fixed.
+
+A small number of memcpy nodes is normal, since some graph operations are inherently CPU-pinned. A count in the hundreds or thousands is not, and means the graph is not really running on the GPU.
 
 #### Diagnosing a silent CPU fallback
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -267,6 +267,34 @@ Text embedding (used during AI-generated meeting intelligence) uses the ONNX Run
 
 The Parakeet and Canary ASR engines also use ONNX Runtime CUDA. Some ONNX graph operations are inherently CPU-pinned; the resulting memcpy overhead is expected and does not indicate a configuration problem.
 
+#### Diagnosing a silent CPU fallback
+
+ONNX Runtime treats its provider list as a preference, not a contract. If the CUDA execution provider cannot be loaded, the session is built on CPU and reported as successful, so the only symptom is that transcription runs far slower while the host CPU saturates. `worker-gpu` pegging several cores with `nvidia-smi` showing 0% GPU utilisation is the signature.
+
+Note that PyTorch and ONNX Runtime resolve their CUDA libraries independently, so they can disagree. `torch.cuda.is_available()` returning `True`, VAD logging `Model loaded successfully on cuda`, and `nvidia-smi` working inside the container all confirm the container's GPU passthrough is intact. None of them say anything about ONNX Runtime.
+
+To check the real state:
+
+```bash
+docker compose logs worker-gpu | grep -i "execution provider"
+```
+
+The worker logs which provider each ONNX model actually got after loading. A warning naming `fell back to CPU` means the CUDA provider was dropped. The underlying cause is usually a missing shared library, logged nearby as:
+
+```
+Failed to load library libonnxruntime_providers_cuda.so with error: libcudnn_*.so.9: cannot open shared object file
+```
+
+`onnxruntime.get_available_providers()` is not a valid check here. It lists the providers the build was compiled with, so it reports `CUDAExecutionProvider` even on a host with no GPU.
+
+If a library is missing, confirm the loader can see cuDNN inside the container. The worker image registers the cuDNN wheel's directory with `ldconfig` at build time for exactly this reason:
+
+```bash
+docker compose exec worker-gpu ldconfig -p | grep libcudnn_adv
+```
+
+An empty result means the base image moved cuDNN and the image needs rebuilding against the corrected path.
+
 ## CPU-Only Deployment
 
 If you do not have a compatible NVIDIA GPU:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -269,6 +269,10 @@ The Parakeet and Canary ASR engines also use ONNX Runtime CUDA. They load fp32 w
 
 A small number of memcpy nodes is normal, since some graph operations are inherently CPU-pinned. A count in the hundreds or thousands is not, and means the graph is not really running on the GPU.
 
+The fp32 weights also constrain the transcription window. Attention activations grow with the square of the window length, so the ASR window is capped at 120 seconds on a GPU host against 240 on CPU (`GPU_MAX_CHUNK_DURATION_S`). On an 8 GB card the 240 second window overflows VRAM outright. If live capture and a transcription job contend for the same card, lower that value further.
+
+ONNX Runtime's memory arena grows to fit the largest window and never shrinks, so the ASR models are released after transcription and before diarization rather than at the end of the task. Without that release, a finished ASR session leaves diarization with no VRAM to allocate and it fails with a CUDA out-of-memory error while the transcript itself succeeds.
+
 #### Diagnosing a silent CPU fallback
 
 ONNX Runtime treats its provider list as a preference, not a contract. If the CUDA execution provider cannot be loaded, the session is built on CPU and reported as successful, so the only symptom is that transcription runs far slower while the host CPU saturates. `worker-gpu` pegging several cores with `nvidia-smi` showing 0% GPU utilisation is the signature.


### PR DESCRIPTION
## Description

Canary and Parakeet transcription had been running entirely on the CPU since the
PyTorch base image was bumped to 2.11.0 (521b21d, 2026-06-22). On the GPU worker
this saturated ~14 cores for the length of a meeting while the card sat idle.

Four defects, stacked so that each hid the next:

1. **The CUDA execution provider could not load.** The PyTorch 2.11 base ships CUDA
   and cuDNN only as `nvidia-*-cu12` wheels, absent from the ldconfig cache despite
   the `cudnn9` tag. `libonnxruntime_providers_cuda.so` could not resolve
   `libcudnn_adv.so.9`, so ONNX Runtime dropped the provider and built every session
   on CPU without error. torch was unaffected because it ctypes-preloads its own
   wheel libraries, which is why every conventional GPU check kept reporting healthy.
2. **`int8` defeats CUDA.** onnxruntime has no CUDA kernels for most quantized ops,
   so once the provider loaded it still handed the graph back to the CPU node by
   node: 1046 memcpy nodes on the Canary encoder.
3. **The fp32 window overflowed VRAM.** Attention activations grow with the square
   of the window, so the 240s window OOM'd an 8GB card outright.
4. **The ASR arena starved diarization.** ONNX Runtime's arena grows to fit the
   largest window and never shrinks, so a finished ASR session left diarization with
   nothing to allocate. The transcript succeeded and diarization returned no
   speakers.

Also fixes recordings being stranded in `PROCESSING`. A recording only leaves that
state when its task finishes, so a worker that died mid-pipeline left it there
permanently: the startup sweep looked only at `QUEUED`, and the reprocess endpoint
refuses a `PROCESSING` recording, leaving no way back short of editing the database.
This surfaced repeatedly while validating the above.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1172 passed)
- [x] Python quality: `python scripts/check.py` (lint, format, whitespace, filesize, heldpins, mypy, docs, alembic)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (320 passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Frontend is untouched by this branch; those checks were run to confirm no regression.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

`celery_task_id` already existed on `recordings`; this only starts populating it
from the worker as well as the API.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/DEPLOYMENT.md` gains a section on diagnosing a silent CPU fallback, why
`get_available_providers()` cannot serve as that check, the quantization choice, the
GPU window cap, and the VRAM handoff before diarization.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Validated on the deployment GPU (RTX 2080 SUPER, 8GB) against a real 40 minute
recording, not synthetic fixtures.

Before: ~223s per 224s window, ~1497% host CPU, 0-15% GPU, ending in CUDA OOM with
the recording marked `PROCESSED` but holding no final transcript and 0 speakers.

After: full pipeline in 352.7s. 23 ASR windows at 96% GPU and ~101% host CPU,
`Released ASR VRAM before diarization` dropping VRAM from 6748 MiB to 2908 MiB, then
diarization completing with 785 segments and 3 speakers. Reproduced identically on a
second run.

Provider verification was checked both ways: the previous image reports 10 of 10
sessions on CPU, the new one reports 10 of 10 on `CUDAExecutionProvider`, confirmed
with torch deliberately not imported so nothing masked a missing library.

Orphan recovery proved itself unprompted during validation. Rebuilding the worker
killed a run mid-flight and the next startup logged
`Recording 104 was left PROCESSING by task 388436ec-..., which is no longer running.
Re-queueing.` and recovered it with no manual intervention. Sweep gating verified in
the running stack: the sweep now fires on the gpu lane only, where previously all
three lanes ran it and dispatched each pending recording once per lane.

No capture, context-menu, or frontend changes, so no browser smoke testing applies.

## Notes for review

- VRAM peaks at ~6.7GB of 8GB during ASR. It fits, but a card shared with concurrent
  live capture will be tight; `GPU_MAX_CHUNK_DURATION_S` is the dial.
- `quantization=None` on a GPU host pulls the fp32 weights, so GPU deployments fetch
  a larger model on first use. int8 is retained for CPU-only hosts, where it remains
  the right choice.
- Orphan reclaim requires positive proof the task is gone via Celery inspect. When
  liveness cannot be established it reclaims nothing, so restarting one worker
  cannot take over another's live job.