### PR TITLE
fix(capture): make stop reachable and bounded for a paused capture

### DIFF
--- a/backend/api/v1/endpoints/recordings/helpers.py
+++ b/backend/api/v1/endpoints/recordings/helpers.py
@@ -741,13 +741,13 @@ def _ensure_recording_accepts_status_updates(recording: Recording) -> None:
 
 
 def _ensure_recording_can_finalize_upload(recording: Recording) -> None:
-    if recording.status == RecordingStatus.PAUSED:
-        raise HTTPException(
-            status_code=409,
-            detail="Recording is paused. Resume or discard it before finalizing.",
-        )
-
-    if recording.status != RecordingStatus.UPLOADING:
+    # PAUSED is accepted so a capture whose browser runtime is gone can still be
+    # finalized (issue #166). Requiring a resume first meant the client had to
+    # re-acquire the share picker, and a stale pause/stop ordering could skip the
+    # resume entirely and leave the recording stranded. Tail truncation stays
+    # guarded downstream: finalize still refuses missing sequences and pending
+    # transcodes with a retryable 409, and uploads are accepted while paused.
+    if recording.status not in {RecordingStatus.UPLOADING, RecordingStatus.PAUSED}:
         raise HTTPException(
             status_code=409,
             detail=UPLOAD_CLOSED_DETAIL,

--- a/backend/api/v1/endpoints/recordings/routes_capture.py
+++ b/backend/api/v1/endpoints/recordings/routes_capture.py
@@ -37,6 +37,78 @@ from .router import router
 logger = logging.getLogger(__name__)
 
 
+def _capture_wall_span_seconds(recording: Recording) -> float | None:
+    """Wall-clock seconds between the capture starting and its last activity."""
+    started_at = recording.created_at
+    last_activity_at = recording.last_activity_at
+    if started_at is None or last_activity_at is None:
+        return None
+
+    try:
+        span = (last_activity_at - started_at).total_seconds()
+    except TypeError:
+        # Mixed naive/aware timestamps from an older row; not worth failing over.
+        return None
+
+    return span if span > 0 else None
+
+
+def _record_finalize_capture_metrics(
+    recording: Recording,
+    *,
+    chunk_rows,
+    duration_seconds,
+    finalized_from_paused: bool,
+) -> None:
+    """Emit the finalize-time capture diagnostics.
+
+    ``capture_coverage`` compares the audio actually stored against the wall-clock
+    span of the session. A browser tab that the OS or the browser suspends stops
+    feeding its MediaRecorder without surfacing any error, so a healthy-looking
+    recording can be missing large stretches of a meeting (issue #166). Coverage
+    is the only server-side signal that this happened.
+    """
+    try:
+        if finalized_from_paused:
+            recordings_module.record_pipeline_metric(
+                stage="recording_finalized_from_paused",
+                recording_id=recording.id,
+                payload={"public_id": recording.public_id},
+                log=logger,
+            )
+
+        captured_ms = sum(int(row.duration_ms or 0) for row in chunk_rows)
+        wall_span_seconds = _capture_wall_span_seconds(recording)
+        payload = {
+            "public_id": recording.public_id,
+            "chunk_count": len(chunk_rows),
+            "captured_seconds": round(captured_ms / 1000.0, 2),
+            "final_duration_seconds": (
+                round(float(duration_seconds), 2) if duration_seconds else None
+            ),
+            "wall_span_seconds": (
+                round(wall_span_seconds, 2) if wall_span_seconds else None
+            ),
+            "coverage_ratio": (
+                round((captured_ms / 1000.0) / wall_span_seconds, 4)
+                if wall_span_seconds
+                else None
+            ),
+        }
+        recordings_module.record_pipeline_metric(
+            stage="capture_coverage",
+            recording_id=recording.id,
+            payload=payload,
+            log=logger,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to record finalize capture metrics for recording %s: %s",
+            recording.id,
+            exc,
+        )
+
+
 def _serialize_capture_track(track_payload):
     if track_payload is None:
         return None
@@ -449,7 +521,10 @@ async def finalize_upload(
     recording.file_size_bytes = file_stats.st_size
     recording.duration_seconds = duration_seconds
 
-    if recording.status != RecordingStatus.UPLOADING:
+    # Re-read above picked up any pause committed while segments were being
+    # concatenated. PAUSED finalizes just like UPLOADING (issue #166); only a
+    # genuinely closed recording is refused here.
+    if recording.status not in {RecordingStatus.UPLOADING, RecordingStatus.PAUSED}:
         db.add(recording)
         await db.commit()
         await db.refresh(recording)
@@ -457,6 +532,8 @@ async def finalize_upload(
             status_code=409,
             detail=recordings_module.UPLOAD_CLOSED_DETAIL,
         )
+
+    finalized_from_paused = recording.status == RecordingStatus.PAUSED
 
     recording.status = RecordingStatus.QUEUED
     recording.client_status = ClientStatus.IDLE
@@ -466,6 +543,13 @@ async def finalize_upload(
     db.add(recording)
     await db.commit()
     await db.refresh(recording)
+
+    _record_finalize_capture_metrics(
+        recording,
+        chunk_rows=chunk_rows,
+        duration_seconds=duration_seconds,
+        finalized_from_paused=finalized_from_paused,
+    )
 
     task = await dispatch_task(
         "backend.worker.tasks.process_recording_task", args=[recording.id]

--- a/backend/tests/test_recording_pause_resume.py
+++ b/backend/tests/test_recording_pause_resume.py
@@ -562,6 +562,183 @@ async def test_session_init_pause_resume_finalize_round_trip(
 
 
 @pytest.mark.anyio
+async def test_finalize_accepts_paused_recording_without_resuming(
+    client: AsyncClient,
+    monkeypatch,
+) -> None:
+    """A paused capture finalizes directly, no resume round trip (issue #166).
+
+    When the browser runtime is gone the client cannot resume without
+    re-prompting the share picker, so requiring UPLOADING here left the
+    recording stranded in PAUSED with no route to processing.
+    """
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    metrics: list[dict] = []
+    monkeypatch.setattr(
+        recordings_module,
+        "record_pipeline_metric",
+        lambda **kwargs: metrics.append(kwargs) or {},
+    )
+
+    set_session_cookie(client)
+
+    init_response = await client.post(
+        "/api/v1/recordings/init",
+        params={"name": "Abandoned meeting"},
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    assert init_response.status_code == 200
+    recording_id = init_response.json()["id"]
+
+    segment_response = await client.post(
+        f"/api/v1/recordings/{recording_id}/segment",
+        params={"sequence": 0},
+        headers={"Origin": TRUSTED_ORIGIN},
+        files={"file": ("0.wav", make_wav_bytes(), "audio/wav")},
+    )
+    assert segment_response.status_code == 200
+
+    pause_response = await client.post(
+        f"/api/v1/recordings/{recording_id}/pause",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    assert pause_response.status_code == 200
+    assert pause_response.json()["status"] == "PAUSED"
+
+    finalize_response = await client.post(
+        f"/api/v1/recordings/{recording_id}/finalize",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+
+    assert finalize_response.status_code == 200
+    assert finalize_response.json()["status"] == "QUEUED"
+    assert finalize_response.json()["client_status"] == "IDLE"
+
+    stages = [metric["stage"] for metric in metrics]
+    assert "recording_finalized_from_paused" in stages
+    assert "capture_coverage" in stages
+
+
+@pytest.mark.anyio
+async def test_finalize_emits_capture_coverage_metric(
+    client: AsyncClient,
+    monkeypatch,
+) -> None:
+    """Coverage is the only server-side signal that a suspended tab lost audio."""
+    from backend.api.v1.endpoints import recordings as recordings_module
+
+    metrics: list[dict] = []
+    monkeypatch.setattr(
+        recordings_module,
+        "record_pipeline_metric",
+        lambda **kwargs: metrics.append(kwargs) or {},
+    )
+
+    set_session_cookie(client)
+
+    init_response = await client.post(
+        "/api/v1/recordings/init",
+        params={"name": "Coverage meeting"},
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    recording_id = init_response.json()["id"]
+
+    for sequence in (0, 1):
+        segment_response = await client.post(
+            f"/api/v1/recordings/{recording_id}/segment",
+            params={"sequence": sequence},
+            headers={"Origin": TRUSTED_ORIGIN},
+            files={"file": (f"{sequence}.wav", make_wav_bytes(), "audio/wav")},
+        )
+        assert segment_response.status_code == 200
+
+    finalize_response = await client.post(
+        f"/api/v1/recordings/{recording_id}/finalize",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    assert finalize_response.status_code == 200
+
+    coverage = next(
+        metric for metric in metrics if metric["stage"] == "capture_coverage"
+    )
+    payload = coverage["payload"]
+    assert payload["chunk_count"] == 2
+    assert payload["captured_seconds"] > 0
+    # A recording that finalized straight through was never paused.
+    assert "recording_finalized_from_paused" not in [
+        metric["stage"] for metric in metrics
+    ]
+
+
+@pytest.mark.anyio
+async def test_finalize_rejects_paused_recording_with_a_sequence_gap(
+    client: AsyncClient,
+) -> None:
+    """Accepting PAUSED must not weaken the completeness gates."""
+    set_session_cookie(client)
+
+    init_response = await client.post(
+        "/api/v1/recordings/init",
+        params={"name": "Gappy meeting"},
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    recording_id = init_response.json()["id"]
+
+    # Sequence 1 never arrives, so the recording is not safe to concatenate.
+    for sequence in (0, 2):
+        segment_response = await client.post(
+            f"/api/v1/recordings/{recording_id}/segment",
+            params={"sequence": sequence},
+            headers={"Origin": TRUSTED_ORIGIN},
+            files={"file": (f"{sequence}.wav", make_wav_bytes(), "audio/wav")},
+        )
+        assert segment_response.status_code == 200
+
+    pause_response = await client.post(
+        f"/api/v1/recordings/{recording_id}/pause",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+    assert pause_response.status_code == 200
+
+    finalize_response = await client.post(
+        f"/api/v1/recordings/{recording_id}/finalize",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+
+    assert finalize_response.status_code == 409
+    assert finalize_response.json()["detail"] == (
+        "Recording upload is still in progress; finalize after all segment "
+        "uploads complete."
+    )
+
+
+@pytest.mark.anyio
+async def test_finalize_still_rejects_a_closed_recording(
+    client: AsyncClient,
+    test_session_maker: sessionmaker,
+) -> None:
+    set_session_cookie(client)
+    public_id = "processed-recording-public-id"
+    await insert_recording(
+        test_session_maker,
+        recording_id=2002,
+        public_id=public_id,
+        status="PROCESSED",
+    )
+
+    finalize_response = await client.post(
+        f"/api/v1/recordings/{public_id}/finalize",
+        headers={"Origin": TRUSTED_ORIGIN},
+    )
+
+    assert finalize_response.status_code == 409
+    assert finalize_response.json()["detail"] == (
+        "Recording is no longer accepting capture uploads"
+    )
+
+
+@pytest.mark.anyio
 async def test_init_rejects_existing_paused_recording(
     client: AsyncClient,
     test_session_maker: sessionmaker,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,9 @@ The browser capture stack is responsible for:
 - Recording short WebM/Opus, Ogg/Opus, or MP4 audio slices and uploading them with session-cookie authentication.
 - Preserving the browser-live source layout after worker transcode as 16 kHz, two-channel WAV: channel 0 is shared/system audio when available and channel 1 is microphone audio.
 - Exposing analyser output to the live waveform UI.
-- Moving recordings to `PAUSED` on real tab unload (pagehide/beforeunload) only, then requiring resume or discard before another capture starts. In-app page navigation does not pause capture.
+- Moving recordings to `PAUSED` on real tab unload (pagehide/beforeunload) only, then requiring resume, stop-and-process, or discard before another capture starts. In-app page navigation does not pause capture.
+- Bounding every stage of the stop sequence and reporting which stage it is on, so a stalled recorder or uploader degrades to a retryable finalize rather than leaving the recording unfinishable.
+- Comparing stored audio against elapsed recording time and warning when they diverge. A tab suspended by the browser or the operating system stops feeding the recorder without raising an error, so coverage is the only signal that audio is being lost.
 
 ## Recording Flow
 
@@ -75,10 +77,10 @@ The browser capture stack is responsible for:
 4. On desktop, the browser asks for shared tab/window/screen audio and microphone access, mixes those streams, and records short audio slices. On mobile Chrome, the browser asks for microphone access only and records microphone-only slices.
 5. The browser uploads segments to `/recordings/{id}/segment?sequence=N` with monotonically increasing 0-based sequence numbers.
 6. The worker transcodes each browser segment to 16 kHz, two-channel WAV and dispatches the live transcription lane. Channel 0 is shared/system audio when available and channel 1 is microphone audio.
-7. Finalisation concatenates the completed WAV segments, queues backend processing, and triggers proxy generation.
+7. Finalisation concatenates the completed WAV segments, queues backend processing, and triggers proxy generation. It accepts an `UPLOADING` or a `PAUSED` recording, so a capture whose browser runtime is gone can still be finalised from its uploaded segments without resuming first; missing sequences and pending transcodes are still refused with a retryable 409.
 8. The web client shows a live capture or processing status workspace while the job runs.
 
-If the user refreshes, closes, or navigates away from the Nojoin tab while recording (actual tab unload, not in-app navigation), the browser stops capture, drops only the in-memory tail, and asks the backend to mark the recording `PAUSED`. Uploaded segments remain available. On the next app load, Nojoin blocks new capture behind a mandatory resume-or-discard modal.
+If the user refreshes, closes, or navigates away from the Nojoin tab while recording (actual tab unload, not in-app navigation), the browser stops capture, drops only the in-memory tail, and asks the backend to mark the recording `PAUSED`. Uploaded segments remain available. On the next app load, Nojoin blocks new capture behind a mandatory modal offering resume, stop-and-process, or discard. Stop does not require a live browser runtime, so a recording in this state always has a route to processing.
 
 Switching focus to another browser tab, window, or application does not pause capture. Navigating between pages within the Nojoin app also does not pause capture. Only a real Nojoin tab unload (pagehide/beforeunload) invokes the guarded pause path.
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -110,7 +110,7 @@ Chrome on Android and iOS can start recording from the same **Start Meeting** bu
 
 - **Pause** keeps uploaded segments and stops new segment capture until you resume.
 - **Resume** reopens the browser share picker and continues with the next 0-based segment sequence.
-- **Stop** finalizes the recording after all uploaded segments finish transcoding, then queues final processing. The microphone and any shared tab or screen are released as soon as the recorded audio has been handed off, so the browser recording indicator disappears while Nojoin waits for the last segments to be processed; the meeting button shows the finalize progress during that wait.
+- **Stop** finalizes the recording after all uploaded segments finish transcoding, then queues final processing. The microphone and any shared tab or screen are released as soon as the recorded audio has been handed off, so the browser recording indicator disappears while Nojoin waits for the last segments to be processed; the meeting button names the current stage during that wait (stopping the recorder, uploading the last segments, releasing the microphone, finalizing). Stop works on a paused recording too, and does not need the original browser capture session to still be active.
 - **Discard** permanently removes a recording in one step. It works for any recording that has not finished: uploading, paused, queued, or processing. Discard revokes any running processing task, releases the capture lock, deletes the captured audio and derived files, and removes the meeting. Nojoin asks you to confirm first because this cannot be undone.
 
 Discard is available from the live recording controls, the floating recording badge, the resume-or-discard modal, and the recordings menu.
@@ -122,6 +122,8 @@ If you are recording in a shared-audio capture mode and click the browser's nati
 Refreshing or closing the Nojoin tab (actual tab unload) during a recording moves that recording to `PAUSED`. Nojoin keeps uploaded segments, drops only the in-memory tail, and shows a mandatory resume-or-discard modal the next time you open the app.
 
 Switching to another browser tab, changing the active window, using another application, or navigating between pages within the Nojoin app does not pause recording. The Nojoin tab only pauses automatically when it is actually unloaded. A floating recording badge remains visible at the top of the viewport on every page so you can always see the recording status and control it.
+
+Not pausing is not the same as being safe in the background. If the browser or the operating system suspends the Nojoin tab, browser capture stops receiving audio for as long as the suspension lasts, and that audio cannot be recovered afterwards. The recording is not paused and no error is raised, because nothing in a web page can prevent or undo being suspended. Nojoin detects the shortfall by comparing the audio it has stored against elapsed recording time, and shows a warning naming how much was captured. Keep the Nojoin tab open, keep the device awake, and do not rely on a background tab for a long meeting. See [Recorded audio is shorter than the meeting](#recorded-audio-is-shorter-than-the-meeting).
 
 ## Floating Recording Badge
 
@@ -138,9 +140,10 @@ Clicking the badge navigates directly to the recording detail page. The badge is
 Nojoin allows one active browser capture per user. If a paused recording exists, new capture and import entry points stay blocked until you choose one of the modal actions:
 
 - **Resume recording** to continue capture from the same recording.
+- **Stop and process** to finalize the audio already uploaded and queue processing, without recording any more. Use this when the meeting is over, or when the browser capture session was lost and you only want to keep what was captured. It does not reopen the share picker.
 - **Discard recording** to remove the partial upload and start fresh.
 
-Paused recordings are retained indefinitely. They are not cleaned up automatically.
+Paused recordings are retained indefinitely. They are not cleaned up automatically, and Nojoin never finalizes one on your behalf.
 
 ## Capture Settings
 
@@ -193,9 +196,24 @@ Use current Chrome and current macOS, then choose the meeting tab and enable the
 
 That is expected. Browsers do not let Nojoin silently recreate shared tab, window, screen, or microphone capture after a reload, close, or pause that released the previous tracks.
 
+### Recorded audio is shorter than the meeting
+
+The browser or the operating system suspended the Nojoin tab during capture. A suspended tab stops feeding audio to the recorder, so that stretch of the meeting was never recorded and cannot be recovered. The recording itself is intact and processes normally; it is only shorter than the elapsed time.
+
+Nojoin warns while this is happening, showing the captured duration next to the elapsed timer, and warns again when the recording is stopped. To avoid it:
+
+- Keep the Nojoin tab open, and prefer keeping it visible in its own window.
+- Prevent the device from sleeping for the length of the meeting. Closing a laptop lid or letting the machine enter standby suspends capture.
+- Exempt Nojoin from browser tab-suspension features. In Chrome, add the site to the exceptions under **Settings > Performance > Memory Saver**.
+- On mobile Chrome, keep Nojoin in the foreground and stop the phone locking.
+
+### Stop did not finish
+
+The meeting button names the stage it is on while stopping. If stopping fails, the recording returns to paused with an error rather than being left in an unusable state, and you can stop it again from the live controls, the floating badge, or the resume-or-discard modal. Stopping does not need the original capture session, so it still works after a reload or after the browser has released the shared audio and microphone tracks.
+
 ### Nojoin says a paused recording exists
 
-Use the resume-or-discard modal. Starting a second recording while a paused upload exists is intentionally blocked to avoid overlapping segment streams and accidental data loss.
+Use the modal. Resume to keep recording, **Stop and process** to keep what was already captured, or discard to remove the partial upload. Starting a second recording while a paused upload exists is intentionally blocked to avoid overlapping segment streams and accidental data loss.
 
 ### Unsupported browser notice appears
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -109,20 +109,22 @@ On mobile and narrow tablet layouts, Nojoin uses compact navigation with a menu 
 
 You can switch to another browser tab, window, or application while recording. Nojoin only pauses automatically when the Nojoin tab is refreshed, closed, or navigated away from the active recording.
 
+Keep the Nojoin tab open and the device awake for the length of the meeting. If the browser or the operating system suspends the tab, capture stops receiving audio for that period and it cannot be recovered afterwards, even though the recording is not paused. Nojoin warns you when the audio it has stored falls behind the elapsed recording time. See [Recorded audio is shorter than the meeting](CAPTURE.md#recorded-audio-is-shorter-than-the-meeting).
+
 While a recording is active, a floating badge appears at the top-centre of the viewport on every page. The badge shows the recording status, elapsed time, and pause, resume, and stop controls. Clicking the badge navigates to the recording detail page. You can control the recording from any page without navigating back to the recording workspace first.
 
 ### Pause, Resume, Stop, And Discard
 
 - **Pause** temporarily stops capture while preserving uploaded segments.
 - **Resume** opens the browser share picker again and continues the same recording.
-- **Stop** finalises the recording and starts processing.
+- **Stop** finalises the recording and starts processing. It names the stage it is working through, and it works on a paused recording as well as an active one.
 - **Discard** permanently removes an in-progress recording in one step. It stops capture, cancels any processing, deletes the captured audio, and removes the meeting. Nojoin asks you to confirm first because this cannot be undone.
 
 Discard is available from the live recording controls, the floating recording badge, the resume-or-discard modal, and the recordings menu, so you can abandon a recording from wherever you are.
 
-If the browser is closed, refreshed, or loses the active recording page during capture, Nojoin pauses the recording to protect already uploaded data. When you return, Nojoin requires you to resume or discard that recording before starting anything else.
+If the browser is closed, refreshed, or loses the active recording page during capture, Nojoin pauses the recording to protect already uploaded data. When you return, Nojoin requires you to deal with that recording before starting anything else, offering three choices: resume it, **Stop and process** to keep the audio already captured and start processing, or discard it. Stopping this way does not reopen the browser share picker, so it works even though the original capture session is gone.
 
-Paused recordings are retained indefinitely until you resume or discard them.
+Paused recordings are retained indefinitely until you resume, stop, or discard them.
 
 ### Live Transcription
 
@@ -321,7 +323,7 @@ Configure the secondary provider through environment variables prefixed with `SE
 - If live capture is unavailable, switch to Chrome on desktop for shared-audio recording or Chrome on Android/iOS for microphone-only recording.
 - If remote participants are missing, start again and enable shared audio in the browser picker.
 - If the microphone is missing, grant microphone permission and check **Settings > Recording**.
-- If Nojoin reports a paused recording, resume or discard it before starting another capture.
+- If Nojoin reports a paused recording, resume it, stop and process it, or discard it before starting another capture.
 - If processing fails, use **Retry Processing** or check the administrator logs.
 - If calendar sync fails, review provider setup in [CALENDAR.md](CALENDAR.md).
 

--- a/frontend/src/components/CaptureShell.tsx
+++ b/frontend/src/components/CaptureShell.tsx
@@ -17,8 +17,10 @@ interface CaptureShellProps {
 export default function CaptureShell({ children }: CaptureShellProps) {
   const router = useRouter();
   const { pausedRecording, hasPausedRecording } = usePausedRecordingGuard();
-  const { cancel, controller, resume, runtimeActive } = useCapture();
-  const [busyAction, setBusyAction] = useState<"resume" | "cancel" | null>(null);
+  const { cancel, controller, resume, runtimeActive, stop } = useCapture();
+  const [busyAction, setBusyAction] = useState<
+    "resume" | "cancel" | "stop" | null
+  >(null);
   const { addNotification } = useNotificationStore();
 
   const modalOpen = hasPausedRecording && !runtimeActive;
@@ -40,6 +42,33 @@ export default function CaptureShell({ children }: CaptureShellProps) {
           message: getErrorMessage(
             resumeError,
             "Failed to resume the paused recording.",
+          ),
+        });
+      }
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  // Finalizes straight from the uploaded segments; no share picker, because the
+  // browser runtime for this recording is already gone.
+  const handleStop = async () => {
+    if (!pausedRecording) {
+      return;
+    }
+
+    setBusyAction("stop");
+    try {
+      await stop();
+      router.push(`/recordings/${pausedRecording.id}`);
+
+        } catch (stopError: unknown) {
+      if (!controller.getState().error) {
+        addNotification({
+          type: "error",
+          message: getErrorMessage(
+            stopError,
+            "Failed to stop and process the paused recording.",
           ),
         });
       }
@@ -80,6 +109,7 @@ export default function CaptureShell({ children }: CaptureShellProps) {
         busyAction={busyAction}
         onResume={handleResume}
         onCancel={handleCancel}
+        onStop={handleStop}
       />
     </>
   );

--- a/frontend/src/components/LiveMeetingControls.tsx
+++ b/frontend/src/components/LiveMeetingControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pause, Play, Square, Trash2 } from "lucide-react";
+import { AlertTriangle, Pause, Play, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import SpeakerCapField from "@/components/SpeakerCapField";
@@ -35,6 +35,7 @@ export default function LiveMeetingControls({
   const {
     cancel,
     controller,
+    coverageWarning,
     elapsedSeconds,
     pause,
     recordingId,
@@ -46,7 +47,11 @@ export default function LiveMeetingControls({
 
   const { addNotification } = useNotificationStore();
   const isRecording = status === "recording";
-  const disabled = !runtimeActive || status === "finalizing";
+  // Pause and resume need live browser tracks. Stop and discard do not: a
+  // recording whose runtime was torn down must still be finishable, or it is
+  // stranded in PAUSED with no route to processing (issue #166).
+  const transportDisabled = !runtimeActive || status === "finalizing";
+  const stopDisabled = status === "finalizing" || !recordingId;
 
   // Diarization runs at stop time, so the cap stays editable for the whole
   // recording: whatever is set when capture ends is what gets applied.
@@ -79,7 +84,7 @@ export default function LiveMeetingControls({
     <SpeakerCapField
       value={maxSpeakers}
       onCommit={handleMaxSpeakersCommit}
-      disabled={disabled || !recordingId}
+      disabled={transportDisabled || !recordingId}
       size={size}
       layout="inline"
       liveHint
@@ -148,6 +153,26 @@ export default function LiveMeetingControls({
 
   const statusLabel = isRecording ? "Recording" : "Paused";
 
+  // The timer is wall clock, so it keeps counting while a suspended tab records
+  // nothing. This badge appears only when the two diverge, naming what was
+  // actually captured rather than quietly overstating the recording (issue #166).
+  const coverageBadge = coverageWarning ? (
+    <div
+      className="density-surface-panel flex items-start gap-2 border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-200"
+      role="status"
+    >
+      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>
+        <span className="font-semibold">
+          {formatTime(coverageWarning.capturedSeconds)} captured
+        </span>{" "}
+        of {formatTime(coverageWarning.elapsedSeconds)} elapsed. Audio is being
+        lost because this tab is being suspended. Keep the Nojoin tab open and
+        the device awake.
+      </span>
+    </div>
+  ) : null;
+
   if (size === "compact") {
     return (
       <div className="space-y-2">
@@ -167,7 +192,7 @@ export default function LiveMeetingControls({
             <button
               type="button"
               onClick={() => sendCommand("pause")}
-              disabled={disabled}
+              disabled={transportDisabled}
               className="rounded-xl border border-gray-300 bg-white p-2 text-gray-700 transition-colors hover:border-orange-300 hover:text-orange-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:border-orange-500/30 dark:hover:text-orange-300"
               title="Pause recording"
               aria-label="Pause recording"
@@ -178,7 +203,7 @@ export default function LiveMeetingControls({
             <button
               type="button"
               onClick={() => sendCommand("resume")}
-              disabled={disabled}
+              disabled={transportDisabled}
               className="rounded-xl border border-gray-300 bg-white p-2 text-gray-700 transition-colors hover:border-orange-300 hover:text-orange-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:border-orange-500/30 dark:hover:text-orange-300"
               title="Resume recording"
               aria-label="Resume recording"
@@ -189,7 +214,7 @@ export default function LiveMeetingControls({
           <button
             type="button"
             onClick={handleStop}
-            disabled={disabled}
+            disabled={stopDisabled}
             className="rounded-xl bg-red-600 p-2 text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
             title="Stop recording"
             aria-label="Stop recording"
@@ -199,7 +224,7 @@ export default function LiveMeetingControls({
           <button
             type="button"
             onClick={handleDiscard}
-            disabled={disabled}
+            disabled={stopDisabled}
             className="rounded-xl border border-red-200 bg-white p-2 text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/30 dark:bg-gray-950/60 dark:text-red-300 dark:hover:bg-red-500/10"
             title="Discard recording"
             aria-label="Discard recording"
@@ -207,6 +232,7 @@ export default function LiveMeetingControls({
             <Trash2 className="h-4 w-4" />
           </button>
         </div>
+        {coverageBadge}
         {speakerCapField}
       </div>
     );
@@ -233,7 +259,7 @@ export default function LiveMeetingControls({
           <button
             type="button"
             onClick={() => sendCommand("pause")}
-            disabled={disabled}
+            disabled={transportDisabled}
             className="density-control-lg inline-flex flex-1 items-center justify-center gap-2 rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm font-semibold text-gray-700 transition-colors hover:border-orange-300 hover:text-orange-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:border-orange-500/30 dark:hover:text-orange-300"
             title="Pause recording"
           >
@@ -244,7 +270,7 @@ export default function LiveMeetingControls({
           <button
             type="button"
             onClick={() => sendCommand("resume")}
-            disabled={disabled}
+            disabled={transportDisabled}
             className="density-control-lg inline-flex flex-1 items-center justify-center gap-2 rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm font-semibold text-gray-700 transition-colors hover:border-orange-300 hover:text-orange-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:border-orange-500/30 dark:hover:text-orange-300"
             title="Resume recording"
           >
@@ -256,7 +282,7 @@ export default function LiveMeetingControls({
         <button
           type="button"
           onClick={handleStop}
-          disabled={disabled}
+          disabled={stopDisabled}
           className="density-control-lg inline-flex flex-1 items-center justify-center gap-2 rounded-2xl bg-red-600 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
           title="Stop recording"
         >
@@ -267,7 +293,7 @@ export default function LiveMeetingControls({
         <button
           type="button"
           onClick={handleDiscard}
-          disabled={disabled}
+          disabled={stopDisabled}
           className="density-control-lg inline-flex flex-1 items-center justify-center gap-2 rounded-2xl border border-red-200 bg-white px-4 py-3 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/30 dark:bg-gray-950/60 dark:text-red-300 dark:hover:bg-red-500/10"
           title="Discard recording"
         >
@@ -276,6 +302,7 @@ export default function LiveMeetingControls({
         </button>
       </div>
 
+      {coverageBadge}
       {speakerCapField}
     </div>
   );

--- a/frontend/src/components/MeetingControls.tsx
+++ b/frontend/src/components/MeetingControls.tsx
@@ -36,6 +36,7 @@ export default function MeetingControls({
     runtimeActive,
     start,
     status,
+    stopStage,
     support,
   } = useCapture();
 
@@ -47,6 +48,17 @@ export default function MeetingControls({
   const isBusy = status === "starting" || status === "finalizing";
   const unsupported = !support.supported;
   const microphoneOnly = support.supported && support.mode === "microphone_only";
+
+  // Naming the stage keeps a slow stop legible instead of looking hung.
+  const stopStageLabel = !stopStage
+    ? null
+    : stopStage === "stopping-recorder"
+      ? "stopping the recorder"
+      : stopStage === "flushing-uploads"
+        ? "uploading the last segments"
+        : stopStage === "releasing-media"
+          ? "releasing the microphone"
+          : "finalizing";
 
   const meetingSurfaceState: MeetingSurfaceState = !backend
     ? {
@@ -78,7 +90,9 @@ export default function MeetingControls({
                   status === "finalizing"
                     ? finalizeRetry
                       ? `Finalizing meeting (waiting ${finalizeRetry.attempt}/${finalizeRetry.maxAttempts})...`
-                      : "Finalizing meeting..."
+                      : stopStageLabel
+                        ? `Ending meeting (${stopStageLabel})...`
+                        : "Finalizing meeting..."
                     : "Starting meeting...",
                 buttonMode: "wait",
                 buttonDisabled: true,
@@ -86,7 +100,9 @@ export default function MeetingControls({
                   status === "finalizing"
                     ? finalizeRetry
                       ? `Nojoin is waiting for the last uploaded segments to be processed (attempt ${finalizeRetry.attempt} of ${finalizeRetry.maxAttempts}).`
-                      : "Nojoin is finalizing the current meeting recording."
+                      : stopStageLabel
+                        ? `Nojoin is ${stopStageLabel} before queueing processing.`
+                        : "Nojoin is finalizing the current meeting recording."
                     : "Nojoin is preparing browser capture.",
               }
           : {

--- a/frontend/src/components/RecordingFloatingBadge.tsx
+++ b/frontend/src/components/RecordingFloatingBadge.tsx
@@ -38,7 +38,10 @@ export default function RecordingFloatingBadge() {
   const isRecording = status === "recording";
   const show =
     runtimeActive && (status === "recording" || status === "paused");
-  const disabled = !runtimeActive || status === "finalizing";
+  // Kept in step with LiveMeetingControls: pause and resume need live browser
+  // tracks, stop and discard do not (issue #166).
+  const transportDisabled = !runtimeActive || status === "finalizing";
+  const stopDisabled = status === "finalizing" || !recordingId;
 
   const isRecordingDetailPage =
     recordingId && pathname === `/recordings/${recordingId}`;
@@ -125,7 +128,7 @@ export default function RecordingFloatingBadge() {
           <button
             type="button"
             onClick={() => sendCommand("pause")}
-            disabled={disabled}
+            disabled={transportDisabled}
             className="rounded-lg p-1.5 text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-red-500/10 dark:hover:text-red-300"
             title="Pause recording"
             aria-label="Pause recording"
@@ -136,7 +139,7 @@ export default function RecordingFloatingBadge() {
           <button
             type="button"
             onClick={() => sendCommand("resume")}
-            disabled={disabled}
+            disabled={transportDisabled}
             className="rounded-lg p-1.5 text-gray-600 transition-colors hover:bg-green-50 hover:text-green-700 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-green-500/10 dark:hover:text-green-300"
             title="Resume recording"
             aria-label="Resume recording"
@@ -148,7 +151,7 @@ export default function RecordingFloatingBadge() {
         <button
           type="button"
           onClick={() => sendCommand("stop")}
-          disabled={disabled}
+          disabled={stopDisabled}
           className="rounded-lg bg-red-600 p-1.5 text-white transition-colors hover:bg-red-700 disabled:opacity-50"
           title="Stop recording"
           aria-label="Stop recording"
@@ -159,7 +162,7 @@ export default function RecordingFloatingBadge() {
         <button
           type="button"
           onClick={handleDiscard}
-          disabled={disabled}
+          disabled={stopDisabled}
           className="rounded-lg p-1.5 text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-red-500/10 dark:hover:text-red-300"
           title="Discard recording"
           aria-label="Discard recording"

--- a/frontend/src/components/ResumeRecordingModal.tsx
+++ b/frontend/src/components/ResumeRecordingModal.tsx
@@ -2,16 +2,17 @@
 
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Loader2, PauseCircle } from "lucide-react";
+import { Loader2, PauseCircle, Square } from "lucide-react";
 
 import type { Recording } from "@/types";
 
 interface ResumeRecordingModalProps {
   isOpen: boolean;
   recording: Recording | null;
-  busyAction?: "resume" | "cancel" | null;
+  busyAction?: "resume" | "cancel" | "stop" | null;
   onResume: () => void;
   onCancel: () => void;
+  onStop: () => void;
 }
 
 export default function ResumeRecordingModal({
@@ -20,6 +21,7 @@ export default function ResumeRecordingModal({
   busyAction = null,
   onResume,
   onCancel,
+  onStop,
 }: ResumeRecordingModalProps) {
   const [mounted, setMounted] = useState(false);
 
@@ -44,14 +46,15 @@ export default function ResumeRecordingModal({
               Recording paused
             </p>
             <h2 className="mt-2 text-xl font-semibold text-gray-950 dark:text-white">
-              Resume or discard before starting anything new
+              Choose what to do before starting anything new
             </h2>
           </div>
         </div>
 
         <p className="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">
           Nojoin found a paused recording for your account. Resume it to keep
-          recording, or discard it to clear the capture lock.
+          recording, stop it to process the audio captured so far, or discard it
+          to clear the capture lock.
         </p>
 
         <div className="mt-4 rounded-2xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-950 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-100">
@@ -68,6 +71,24 @@ export default function ResumeRecordingModal({
           >
             {busyAction === "cancel" ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
             Discard recording
+          </button>
+          {/*
+            Stopping from here finalizes the uploaded segments without
+            re-acquiring the share picker. Without it, a recording whose browser
+            runtime was torn down could only be resumed or destroyed (issue #166).
+          */}
+          <button
+            type="button"
+            onClick={onStop}
+            disabled={busyAction !== null}
+            className="inline-flex items-center justify-center gap-2 rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm font-semibold text-gray-700 transition-colors hover:border-orange-300 hover:text-orange-700 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-orange-500/30 dark:hover:text-orange-300"
+          >
+            {busyAction === "stop" ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Square className="h-4 w-4 fill-current" />
+            )}
+            Stop and process
           </button>
           <button
             type="button"

--- a/frontend/src/lib/capture/CaptureProvider.tsx
+++ b/frontend/src/lib/capture/CaptureProvider.tsx
@@ -99,5 +99,7 @@ export function useCapture() {
     support: state.support,
     settings: state.settings,
     finalizeRetry: state.finalizeRetry,
+    stopStage: state.stopStage,
+    coverageWarning: state.coverageWarning,
   };
 }

--- a/frontend/src/lib/capture/controller.test.ts
+++ b/frontend/src/lib/capture/controller.test.ts
@@ -11,6 +11,7 @@ const apiMocks = vi.hoisted(() => ({
   getPausedRecordings: vi.fn(),
   initRecording: vi.fn(),
   reportRecordingCaptureSources: vi.fn(),
+  resumeRecordingCapture: vi.fn(),
 }));
 
 const featureDetectMocks = vi.hoisted(() => ({
@@ -29,7 +30,7 @@ vi.mock("@/lib/api", () => ({
   isActiveRecordingConflictDetail: vi.fn(() => false),
   pauseRecordingCapture: apiMocks.pauseRecordingCapture,
   reportRecordingCaptureSources: apiMocks.reportRecordingCaptureSources,
-  resumeRecordingCapture: vi.fn(),
+  resumeRecordingCapture: apiMocks.resumeRecordingCapture,
 }));
 
 vi.mock("./featureDetect", () => ({
@@ -144,6 +145,12 @@ describe("capture controller", () => {
     apiMocks.initRecording.mockReset();
     apiMocks.reportRecordingCaptureSources.mockReset();
     apiMocks.reportRecordingCaptureSources.mockResolvedValue(undefined);
+    apiMocks.resumeRecordingCapture.mockReset();
+    apiMocks.resumeRecordingCapture.mockResolvedValue({
+      recording_id: "rec-1",
+      status: "UPLOADING",
+      last_sequence: 0,
+    });
     apiMocks.getPausedRecordings.mockResolvedValue([]);
     featureDetectMocks.detectCaptureSupport.mockReset();
     featureDetectMocks.detectCaptureSupport.mockReturnValue({
@@ -633,5 +640,202 @@ describe("capture controller", () => {
     await controller.stop();
 
     expect(mockTrack.removeEventListener).toHaveBeenCalledWith("ended", expect.any(Function));
+  });
+
+  it("finalizes a paused recording whose runtime is gone, without resuming first", async () => {
+    // The guarded-exit case from issue #166: the runtime was disposed, so the
+    // only route to processing is finalizing the uploaded segments directly.
+    apiMocks.finalizeRecordingCapture.mockResolvedValue({
+      id: "rec-1",
+      status: "QUEUED",
+    });
+
+    const controller = new CaptureController() as any;
+    controller.state = {
+      ...controller.getState(),
+      status: "paused",
+      recordingId: "rec-1",
+      lastSequence: 41,
+    };
+    controller.runtime = null;
+
+    await expect(controller.stop()).resolves.toEqual({
+      id: "rec-1",
+      status: "QUEUED",
+    });
+
+    expect(apiMocks.finalizeRecordingCapture).toHaveBeenCalledWith("rec-1");
+    // Resuming would re-prompt the browser share picker for nothing, and the
+    // ordering race around it was what stranded the recording.
+    expect(apiMocks.resumeRecordingCapture).not.toHaveBeenCalled();
+    expect(controller.getState().status).toBe("idle");
+  });
+
+  it("finalizes a paused recording identified only by the server", async () => {
+    // A fresh tab has no sessionStorage context, so the id has to be passed in.
+    apiMocks.finalizeRecordingCapture.mockResolvedValue({
+      id: "rec-9",
+      status: "QUEUED",
+    });
+
+    const controller = new CaptureController();
+
+    await expect(controller.stop("rec-9")).resolves.toEqual({
+      id: "rec-9",
+      status: "QUEUED",
+    });
+    expect(apiMocks.finalizeRecordingCapture).toHaveBeenCalledWith("rec-9");
+  });
+
+  it("never leaves the controller stuck in finalizing when stop fails", async () => {
+    // "finalizing" disables every transport control, so settling there bricked
+    // the UI with no way back to Stop, Resume, or Discard.
+    apiMocks.finalizeRecordingCapture.mockRejectedValue(
+      buildConflictError("Recording is no longer accepting capture uploads"),
+    );
+
+    const controller = new CaptureController() as any;
+    controller.state = {
+      ...controller.getState(),
+      status: "recording",
+      recordingId: "rec-1",
+    };
+    controller.runtime = null;
+
+    await expect(controller.stop()).rejects.toThrow(
+      "Recording is no longer accepting capture uploads",
+    );
+
+    const state = controller.getState();
+    expect(state.status).toBe("paused");
+    expect(state.stopStage).toBeNull();
+    expect(state.recordingId).toBe("rec-1");
+  });
+
+  it("reports each stop stage in order", async () => {
+    const sources = {
+      mode: "microphone_only",
+      displayStream: null,
+      microphoneStream: {} as MediaStream,
+      captureReport: {
+        mode: "microphone_only",
+        requested_microphone_device_id: null,
+        requested_microphone_label: null,
+        available_microphones: [],
+        browser_microphone_track: null,
+        browser_display_audio_track: null,
+        browser_display_video_track: null,
+        shared_audio_available: false,
+        notes: [],
+      },
+      release: vi.fn(),
+    };
+
+    pickSourceMocks.pickCaptureSource.mockResolvedValue(sources);
+    apiMocks.initRecording.mockResolvedValue({ id: "rec-1", name: "Test meeting" });
+    apiMocks.finalizeRecordingCapture.mockResolvedValue({
+      id: "rec-1",
+      status: "QUEUED",
+    });
+
+    const controller = new CaptureController();
+    await controller.start("Test meeting");
+
+    const stages: (string | null)[] = [];
+    controller.subscribe((state) => {
+      if (state.stopStage && stages[stages.length - 1] !== state.stopStage) {
+        stages.push(state.stopStage);
+      }
+    });
+
+    await controller.stop();
+
+    expect(stages).toEqual([
+      "stopping-recorder",
+      "flushing-uploads",
+      "releasing-media",
+      "finalizing",
+    ]);
+    expect(controller.getState().stopStage).toBeNull();
+  });
+
+  it("still finalizes when the uploader cannot drain", async () => {
+    // Bounded, not fatal: the server refuses an incomplete upload with a
+    // retryable 409, which beats hanging forever without calling finalize.
+    const sources = {
+      mode: "microphone_only",
+      displayStream: null,
+      microphoneStream: {} as MediaStream,
+      captureReport: {
+        mode: "microphone_only",
+        requested_microphone_device_id: null,
+        requested_microphone_label: null,
+        available_microphones: [],
+        browser_microphone_track: null,
+        browser_display_audio_track: null,
+        browser_display_video_track: null,
+        shared_audio_available: false,
+        notes: [],
+      },
+      release: vi.fn(),
+    };
+
+    pickSourceMocks.pickCaptureSource.mockResolvedValue(sources);
+    apiMocks.initRecording.mockResolvedValue({ id: "rec-1", name: "Test meeting" });
+    apiMocks.finalizeRecordingCapture.mockResolvedValue({
+      id: "rec-1",
+      status: "QUEUED",
+    });
+
+    const controller = new CaptureController() as any;
+    await controller.start("Test meeting");
+    controller.runtime.uploader.waitForIdle = vi.fn(async () => {
+      throw new Error("segment 12 never uploaded");
+    });
+
+    await expect(controller.stop()).resolves.toEqual({
+      id: "rec-1",
+      status: "QUEUED",
+    });
+    expect(apiMocks.finalizeRecordingCapture).toHaveBeenCalledWith("rec-1");
+  });
+
+  it("warns when captured audio falls behind elapsed recording time", async () => {
+    // Measured at ~52% coverage across a 20s tab freeze; the wall-clock timer
+    // keeps counting while nothing is being recorded.
+    const controller = new CaptureController() as any;
+    controller.state = {
+      ...controller.getState(),
+      status: "recording",
+      recordingId: "rec-1",
+      lastSequence: 1_266,
+      elapsedSeconds: 5_455,
+    };
+
+    controller.evaluateCoverage();
+
+    const warning = controller.getState().coverageWarning;
+    expect(warning).not.toBeNull();
+    expect(warning.capturedSeconds).toBe(2_534);
+    expect(warning.missingSeconds).toBe(2_921);
+    expect(notificationMocks.addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" }),
+    );
+  });
+
+  it("stays quiet when captured audio only trails by upload latency", async () => {
+    const controller = new CaptureController() as any;
+    controller.state = {
+      ...controller.getState(),
+      status: "recording",
+      recordingId: "rec-1",
+      lastSequence: 299,
+      elapsedSeconds: 604,
+    };
+
+    controller.evaluateCoverage();
+
+    expect(controller.getState().coverageWarning).toBeNull();
+    expect(notificationMocks.addNotification).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/capture/controller.ts
+++ b/frontend/src/lib/capture/controller.ts
@@ -17,7 +17,11 @@ import { detectCaptureSupport } from "./featureDetect";
 import { CaptureLifecycle, sendPauseBeacon } from "./lifecycle";
 import { createCaptureMixer, type CaptureMixer } from "./mixer";
 import { pickCaptureSource, PickSourceError, type PickedCaptureSources } from "./pickSource";
-import { createBrowserRecorder, type BrowserRecorder } from "./recorder";
+import {
+  createBrowserRecorder,
+  type BrowserRecorder,
+  type RecorderStallInfo,
+} from "./recorder";
 import {
   buildCaptureSourceReportPayload,
   logCaptureSourceReport,
@@ -27,8 +31,10 @@ import {
 import {
   clearPausedCaptureContext,
   DEFAULT_CAPTURE_LEVELS,
+  type CaptureCoverageWarning,
   type CaptureSettings,
   type CaptureState,
+  type CaptureStopStage,
   type StartCaptureResponse,
   type StartCaptureResult,
   readCaptureSettings,
@@ -77,6 +83,46 @@ const wait = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+
+/** Bound on each pre-finalize stop stage, so none of them can hang finalize. */
+const RECORDER_STOP_TIMEOUT_MS = 8_000;
+
+const UPLOAD_FLUSH_TIMEOUT_MS = 60_000;
+
+/**
+ * Coverage thresholds for the suspended-tab warning. Both must be exceeded, so
+ * the ordinary couple of seconds of trailing segment latency stays quiet.
+ */
+const COVERAGE_WARNING_MIN_MISSING_SECONDS = 60;
+
+const COVERAGE_WARNING_MIN_RATIO = 0.1;
+
+const COVERAGE_WARNING_INTERVAL_MS = 5 * 60_000;
+
+const withStageTimeout = async <T>(
+  stage: CaptureStopStage,
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T | null> => {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const expired = Symbol("expired");
+  const timeout = new Promise<typeof expired>((resolve) => {
+    timeoutId = setTimeout(() => resolve(expired), timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([operation, timeout]);
+    if (result === expired) {
+      console.warn(`[capture] stop stage "${stage}" timed out after ${timeoutMs}ms`);
+      return null;
+    }
+    return result;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
 
 const formatCaptureError = (error: unknown) => {
   if (error instanceof PickSourceError) {
@@ -138,6 +184,8 @@ export class CaptureController {
 
   private elapsedTimerStartedAt = 0;
 
+  private lastCoverageNotifiedAt = 0;
+
   constructor() {
     const pausedContext = readPausedCaptureContext();
     this.state = {
@@ -152,12 +200,15 @@ export class CaptureController {
       runtimeActive: false,
       settings: readCaptureSettings(),
       finalizeRetry: null,
+      stopStage: null,
+      coverageWarning: null,
     };
 
     this.lifecycle = new CaptureLifecycle({
       getRecordingId: () => this.state.recordingId,
       shouldGuardExit: () => Boolean(this.runtime),
       onGuardedExit: (request) => this.handleGuardedExit(request),
+      onPageResume: () => this.handlePageResume(),
     });
   }
 
@@ -262,10 +313,13 @@ export class CaptureController {
       throw error;
     }
 
+    this.lastCoverageNotifiedAt = 0;
     this.setState({
       recordingId: initResponse.id,
       lastSequence: -1,
       elapsedSeconds: 0,
+      coverageWarning: null,
+      stopStage: null,
     });
 
     let sources: PickedCaptureSources | null = null;
@@ -391,7 +445,14 @@ export class CaptureController {
       throw new Error("No paused recording is available to resume.");
     }
 
-    if (this.runtime && this.state.status === "paused") {
+    // Reusing the existing tracks is only valid while they are still live. After
+    // a failed stop the runtime survives with its media released, and resuming
+    // onto those dead tracks would record silence.
+    if (
+      this.runtime &&
+      !this.runtime.mediaReleased &&
+      this.state.status === "paused"
+    ) {
       const response = await resumeRecordingCapture(targetRecordingId);
       // A stalled uploader (for example after a network outage) still holds
       // the queued segments; recovering it retries them before new audio.
@@ -500,31 +561,68 @@ export class CaptureController {
     }
   };
 
-  stop = async (): Promise<Recording> => {
-    if (!this.state.recordingId) {
+  /**
+   * Stops capture and queues final processing.
+   *
+   * Valid whether or not a browser runtime is still attached: a recording whose
+   * runtime was torn down (tab reload, guarded exit) is finalized from its
+   * uploaded segments alone. The server accepts finalize for a PAUSED recording,
+   * so no resume round trip is needed first, which also removes the ordering
+   * race that could skip the resume and strand the recording (issue #166).
+   *
+   * Every pre-finalize stage is bounded. A stage that times out is logged and
+   * skipped rather than awaited forever: the server decides whether the segments
+   * are complete, and a retryable 409 beats an infinite hang with no finalize.
+   */
+  stop = async (recordingId?: RecordingId): Promise<Recording> => {
+    // An explicit id matters when the runtime is gone and this tab never held
+    // the capture: the paused recording is then known only from the server.
+    const targetRecordingId =
+      recordingId ?? this.state.recordingId ?? this.state.pausedRecording?.id;
+    if (!targetRecordingId) {
       throw new Error("No active recording is available to finalize.");
     }
 
-    const recordingId = this.state.recordingId;
-    const wasPaused = this.state.status === "paused";
+    const hadRuntime = Boolean(this.runtime);
     this.setState({ status: "finalizing", error: null, finalizeRetry: null });
-    if (wasPaused) {
-      await resumeRecordingCapture(recordingId);
-    }
 
     try {
-      if (this.runtime) {
-        await this.runtime.recorder.stop({ emitTail: true });
-        this.runtime.uploader.recover();
-        await this.runtime.uploader.waitForIdle();
+      const runtime = this.runtime;
+      if (runtime) {
+        this.setStopStage("stopping-recorder");
+        await withStageTimeout(
+          "stopping-recorder",
+          runtime.recorder.stop({ emitTail: true }),
+          RECORDER_STOP_TIMEOUT_MS,
+        );
+
+        this.setStopStage("flushing-uploads");
+        runtime.uploader.recover();
+        try {
+          await runtime.uploader.waitForIdle({
+            timeoutMs: UPLOAD_FLUSH_TIMEOUT_MS,
+          });
+        } catch (flushError: unknown) {
+          // Keep going: finalize refuses an incomplete upload with a retryable
+          // 409, which is a far better outcome than never calling it.
+          console.warn(
+            "[capture] stop stage \"flushing-uploads\" did not drain cleanly",
+            flushError,
+          );
+        }
+
+        this.setStopStage("releasing-media");
         // Every recorded segment is queued server-side at this point, so stop
         // the microphone/tab capture now instead of keeping the tracks (and
         // the browser recording indicator) live through the finalize retries.
         await this.releaseRuntimeMedia();
       }
-      const recording = await this.finalizeRecordingWhenReady(recordingId);
+
+      this.setStopStage("finalizing");
+      const recording = await this.finalizeRecordingWhenReady(targetRecordingId);
       clearPausedCaptureContext();
       await this.disposeRuntime();
+      this.reportCoverageOnStop(recording);
       this.setState({
         status: "idle",
         error: null,
@@ -535,6 +633,7 @@ export class CaptureController {
         runtimeActive: false,
         levels: DEFAULT_CAPTURE_LEVELS,
         finalizeRetry: null,
+        stopStage: null,
       });
       await this.refreshPausedRecording().catch(() => {});
       this.lifecycle.updateRecordingId(null);
@@ -542,9 +641,62 @@ export class CaptureController {
 
     } catch (error: unknown) {
       const message = formatCaptureError(error);
-      this.setState({ status: "error", error: message, finalizeRetry: null });
+      console.error(
+        `[capture] stop failed during stage "${this.state.stopStage}"`,
+        error,
+      );
+      // Never leave the controller in "finalizing": every transport control is
+      // disabled in that state, which previously bricked the UI with no way back.
+      // Settling on "paused" matches the server and keeps stop retryable.
+      await this.settleAfterFailedStop(targetRecordingId, hadRuntime, message);
       throw new Error(message);
     }
+  };
+
+  /**
+   * Returns the controller to a state the user can act from after a failed stop.
+   *
+   * The media tracks are released either way: the recorded audio is already
+   * server-side, and holding the microphone open through a failure just leaves
+   * the browser recording indicator lit with no way to clear it.
+   */
+  private settleAfterFailedStop = async (
+    recordingId: RecordingId,
+    hadRuntime: boolean,
+    message: string,
+  ) => {
+    try {
+      await this.releaseRuntimeMedia();
+    } catch (releaseError: unknown) {
+      console.warn("[capture] failed to release media after a failed stop", releaseError);
+    }
+
+    if (hadRuntime) {
+      writePausedCaptureContext({
+        recordingId,
+        lastSequence: this.state.lastSequence,
+        persistedAt: Date.now(),
+      });
+    }
+
+    // The runtime object is kept even though its media is gone, so a retried
+    // stop can still flush whatever the uploader is holding. runtimeActive goes
+    // false so the transport controls disable and resume re-acquires sources.
+    this.setState({
+      status: "paused",
+      error: message,
+      recordingId,
+      finalizeRetry: null,
+      stopStage: null,
+      runtimeActive: false,
+      levels: DEFAULT_CAPTURE_LEVELS,
+    });
+    await this.refreshPausedRecording().catch(() => {});
+  };
+
+  private setStopStage = (stage: CaptureStopStage) => {
+    console.info(`[capture] stop stage: ${stage}`);
+    this.setState({ stopStage: stage });
   };
 
   cancel = async (recordingId?: RecordingId) => {
@@ -570,6 +722,8 @@ export class CaptureController {
       pausedRecording: null,
       runtimeActive: false,
       levels: DEFAULT_CAPTURE_LEVELS,
+      coverageWarning: null,
+      stopStage: null,
     });
     this.lifecycle.updateRecordingId(null);
     await this.refreshPausedRecording().catch(() => {});
@@ -602,6 +756,7 @@ export class CaptureController {
             sequenceToElapsedSeconds(sequence),
           ),
         });
+        this.evaluateCoverage();
       },
       onStalled: async (error) => {
         await this.handleUploaderStalled(options.recordingId, error);
@@ -626,6 +781,9 @@ export class CaptureController {
       },
       onError: (error) => {
         this.setState({ status: "error", error: error.message });
+      },
+      onStall: (info) => {
+        this.handleRecorderStall(info);
       },
     });
 
@@ -729,6 +887,94 @@ export class CaptureController {
         error: formatCaptureError(pauseError),
       });
     }
+  };
+
+  /**
+   * Compares captured audio against wall-clock recording time.
+   *
+   * When the browser or the OS suspends the tab, the MediaRecorder stops
+   * receiving audio while the recorder still reports "recording" and the elapsed
+   * timer keeps counting. Measured at ~52% coverage across a 20s freeze, so the
+   * shortfall is real data loss and the only client-side signal is this gap.
+   */
+  private evaluateCoverage = () => {
+    if (this.state.status !== "recording") {
+      return;
+    }
+
+    const capturedSeconds = sequenceToElapsedSeconds(this.state.lastSequence);
+    const elapsedSeconds = this.state.elapsedSeconds;
+    const missingSeconds = Math.max(0, elapsedSeconds - capturedSeconds);
+    if (
+      elapsedSeconds <= 0 ||
+      missingSeconds < COVERAGE_WARNING_MIN_MISSING_SECONDS ||
+      missingSeconds / elapsedSeconds < COVERAGE_WARNING_MIN_RATIO
+    ) {
+      return;
+    }
+
+    const warning: CaptureCoverageWarning = {
+      capturedSeconds,
+      elapsedSeconds,
+      missingSeconds,
+    };
+    this.setState({ coverageWarning: warning });
+
+    const now = Date.now();
+    if (now - this.lastCoverageNotifiedAt < COVERAGE_WARNING_INTERVAL_MS) {
+      return;
+    }
+
+    this.lastCoverageNotifiedAt = now;
+    const missingMinutes = Math.round(missingSeconds / 60);
+    console.warn("[capture] captured audio is behind elapsed time", warning);
+    useNotificationStore.getState().addNotification({
+      type: "warning",
+      message:
+        `Nojoin has captured ${Math.round(capturedSeconds / 60)} of ` +
+        `${Math.round(elapsedSeconds / 60)} minutes. Around ${missingMinutes} ` +
+        "minutes are missing, which usually means this tab was suspended by the " +
+        "browser or the device slept. Keep the Nojoin tab open and the device awake.",
+    });
+  };
+
+  private reportCoverageOnStop = (recording: Recording) => {
+    const warning = this.state.coverageWarning;
+    if (!warning) {
+      return;
+    }
+
+    console.warn(
+      "[capture] recording finalized with missing audio",
+      recording.id,
+      warning,
+    );
+    useNotificationStore.getState().addNotification({
+      type: "warning",
+      message:
+        `This recording captured ${Math.round(warning.capturedSeconds / 60)} of ` +
+        `${Math.round(warning.elapsedSeconds / 60)} minutes of the session. The ` +
+        "missing audio was not recorded because the tab or device was suspended.",
+    });
+  };
+
+  private handlePageResume = () => {
+    if (!this.runtime) {
+      return;
+    }
+
+    // Advisory: the watchdog in the recorder is what actually restarts the
+    // segment chain. This only records that a thaw happened.
+    console.warn("[capture] page resumed from a frozen state during capture");
+    this.evaluateCoverage();
+  };
+
+  private handleRecorderStall = (info: RecorderStallInfo) => {
+    console.warn(
+      "[capture] recorder stalled; restarting the segment chain",
+      info,
+    );
+    this.evaluateCoverage();
   };
 
   private finalizeRecordingWhenReady = async (recordingId: RecordingId) => {

--- a/frontend/src/lib/capture/lifecycle.ts
+++ b/frontend/src/lib/capture/lifecycle.ts
@@ -7,7 +7,15 @@ export interface CaptureLifecycleOptions {
   getRecordingId: () => RecordingId | null;
   shouldGuardExit: () => boolean;
   onGuardedExit: (request: GuardedExitRequest) => void | Promise<void>;
+  /**
+   * Fired when the page is thawed after the browser froze it. Advisory only:
+   * a frozen tab suspends timers and stops feeding the MediaRecorder, and this
+   * event is not reliably dispatched on every Chromium build, so capture
+   * liveness must not depend on it (issue #166).
+   */
+  onPageResume?: () => void;
   windowRef?: Window;
+  documentRef?: Document;
 }
 
 export class CaptureLifecycle {
@@ -17,7 +25,11 @@ export class CaptureLifecycle {
 
   private readonly onGuardedExit: CaptureLifecycleOptions["onGuardedExit"];
 
+  private readonly onPageResume?: CaptureLifecycleOptions["onPageResume"];
+
   private readonly windowRef: Window;
+
+  private readonly documentRef?: Document;
 
   private activeRecordingId: RecordingId | null = null;
 
@@ -31,7 +43,11 @@ export class CaptureLifecycle {
     this.getRecordingId = options.getRecordingId;
     this.shouldGuardExit = options.shouldGuardExit;
     this.onGuardedExit = options.onGuardedExit;
+    this.onPageResume = options.onPageResume;
     this.windowRef = options.windowRef ?? window;
+    this.documentRef =
+      options.documentRef ??
+      (typeof document === "undefined" ? undefined : document);
   }
 
   attach(initialRouteSignature: string) {
@@ -43,6 +59,7 @@ export class CaptureLifecycle {
     this.attached = true;
     this.windowRef.addEventListener("pagehide", this.handlePageHide);
     this.windowRef.addEventListener("beforeunload", this.handleBeforeUnload);
+    this.documentRef?.addEventListener("resume", this.handlePageResume);
   }
 
   detach() {
@@ -53,6 +70,7 @@ export class CaptureLifecycle {
     this.attached = false;
     this.windowRef.removeEventListener("pagehide", this.handlePageHide);
     this.windowRef.removeEventListener("beforeunload", this.handleBeforeUnload);
+    this.documentRef?.removeEventListener("resume", this.handlePageResume);
   }
 
   updateRecordingId(recordingId: RecordingId | null) {
@@ -81,6 +99,12 @@ export class CaptureLifecycle {
 
   private readonly handleBeforeUnload = () => {
     this.triggerGuardedExit("beforeunload", true);
+  };
+
+  // A thaw is not an exit: capture should carry on, but the gap it leaves in the
+  // audio needs reporting.
+  private readonly handlePageResume = () => {
+    this.onPageResume?.();
   };
 
   private triggerGuardedExit(

--- a/frontend/src/lib/capture/recorder.test.ts
+++ b/frontend/src/lib/capture/recorder.test.ts
@@ -126,4 +126,158 @@ describe("browser recorder", () => {
     expect(chunks).toHaveLength(1);
     expect(chunks[0].blob.type).toBe("audio/mp4");
   });
+
+  it("resolves stop when the recorder never fires onstop", async () => {
+    // Awaiting onstop unconditionally wedged the shared operation queue, so
+    // stop() never reached finalize and every later control hung behind it.
+    vi.useFakeTimers();
+
+    class SilentMediaRecorder extends FakeMediaRecorder {
+      stop() {
+        this.state = "inactive";
+        this.ondataavailable?.({
+          data: new Blob(["buffered"], { type: this.mimeType }),
+        } as BlobEvent);
+        // Deliberately never calls onstop.
+      }
+    }
+
+    const chunks: { sequence: number; blob: Blob }[] = [];
+    const recorder = createBrowserRecorder({
+      stream: {} as MediaStream,
+      mediaRecorderCtor: SilentMediaRecorder as unknown as typeof MediaRecorder,
+      stopTimeoutMs: 1_000,
+      onChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+
+    recorder.start();
+    const stopPromise = recorder.stop({ emitTail: true });
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(stopPromise).resolves.toBeUndefined();
+    // The buffered audio is kept rather than discarded with the wedged segment.
+    expect(chunks).toHaveLength(1);
+    expect(recorder.state).toBe("inactive");
+  });
+
+  it("does not let a wedged segment block a later stop", async () => {
+    vi.useFakeTimers();
+
+    class SilentMediaRecorder extends FakeMediaRecorder {
+      stop() {
+        this.state = "inactive";
+      }
+    }
+
+    const recorder = createBrowserRecorder({
+      stream: {} as MediaStream,
+      mediaRecorderCtor: SilentMediaRecorder as unknown as typeof MediaRecorder,
+      timesliceMs: 500,
+      stopTimeoutMs: 1_000,
+      onChunk: () => {},
+    });
+
+    recorder.start(500);
+    // Let a roll wedge on the missing onstop first.
+    await vi.advanceTimersByTimeAsync(600);
+
+    const stopPromise = recorder.stop({ emitTail: false });
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await expect(stopPromise).resolves.toBeUndefined();
+  });
+
+  it("reports a stall when no audio reaches disk while recording", async () => {
+    // The failure mode has no error attached: the recorder reports "recording"
+    // with an active segment while producing nothing, so silence over several
+    // timeslices is the only signal available.
+    vi.useFakeTimers();
+
+    class SilentDataMediaRecorder extends FakeMediaRecorder {
+      stop() {
+        // Ends cleanly but hands back no audio, as a dead source track does.
+        this.state = "inactive";
+        this.onstop?.();
+      }
+    }
+
+    const stalls: { sinceLastChunkMs: number; abandonedSegment: boolean }[] = [];
+    const chunks: { sequence: number; blob: Blob }[] = [];
+    const recorder = createBrowserRecorder({
+      stream: {} as MediaStream,
+      mediaRecorderCtor: SilentDataMediaRecorder as unknown as typeof MediaRecorder,
+      timesliceMs: 2_000,
+      stallTimeoutMs: 6_000,
+      onStall: (info) => stalls.push(info),
+      onChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+
+    recorder.start(2_000);
+    const segmentsAtStart = SilentDataMediaRecorder.instances.length;
+
+    await vi.advanceTimersByTimeAsync(9_000);
+
+    expect(chunks).toEqual([]);
+    expect(stalls.length).toBeGreaterThanOrEqual(1);
+    expect(stalls[0].abandonedSegment).toBe(false);
+    // The chain keeps rolling rather than dying silently.
+    expect(SilentDataMediaRecorder.instances.length).toBeGreaterThan(
+      segmentsAtStart,
+    );
+    expect(recorder.state).toBe("recording");
+
+    await recorder.stop({ emitTail: false });
+  });
+
+  it("does not report a stall while a healthy recorder keeps emitting", async () => {
+    vi.useFakeTimers();
+
+    const stalls: unknown[] = [];
+    const chunks: { sequence: number; blob: Blob }[] = [];
+    const recorder = createBrowserRecorder({
+      stream: {} as MediaStream,
+      mediaRecorderCtor: FakeMediaRecorder as unknown as typeof MediaRecorder,
+      timesliceMs: 2_000,
+      stallTimeoutMs: 6_000,
+      onStall: (info) => stalls.push(info),
+      onChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+
+    recorder.start(2_000);
+    await vi.advanceTimersByTimeAsync(9_000);
+
+    expect(chunks.length).toBeGreaterThanOrEqual(4);
+    expect(stalls).toEqual([]);
+
+    await recorder.stop({ emitTail: false });
+  });
+
+  it("does not report a stall for a paused recorder", async () => {
+    vi.useFakeTimers();
+
+    const stalls: unknown[] = [];
+    const recorder = createBrowserRecorder({
+      stream: {} as MediaStream,
+      mediaRecorderCtor: FakeMediaRecorder as unknown as typeof MediaRecorder,
+      timesliceMs: 2_000,
+      stallTimeoutMs: 6_000,
+      onStall: (info) => stalls.push(info),
+      onChunk: () => {},
+    });
+
+    recorder.start(2_000);
+    await recorder.pause();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(stalls).toEqual([]);
+
+    await recorder.stop({ emitTail: false });
+  });
 });

--- a/frontend/src/lib/capture/recorder.ts
+++ b/frontend/src/lib/capture/recorder.ts
@@ -3,13 +3,24 @@ export interface RecordedChunk {
   blob: Blob;
 }
 
+export interface RecorderStallInfo {
+  /** Milliseconds since the recorder last emitted a segment. */
+  sinceLastChunkMs: number;
+  /** True when the stalled segment had to be abandoned without an onstop. */
+  abandonedSegment: boolean;
+}
+
 export interface CreateBrowserRecorderOptions {
   stream: MediaStream;
   startSequence?: number;
   onChunk: (chunk: RecordedChunk) => void | Promise<void>;
   onError?: (error: Error) => void;
+  onStall?: (info: RecorderStallInfo) => void;
   mediaRecorderCtor?: typeof MediaRecorder;
   timesliceMs?: number;
+  stopTimeoutMs?: number;
+  stallTimeoutMs?: number;
+  now?: () => number;
 }
 
 const DEFAULT_MIME_TYPE = "audio/webm;codecs=opus";
@@ -22,6 +33,23 @@ const RECORDER_MIME_TYPE_CANDIDATES = [
   "audio/mp4",
 ];
 const DEFAULT_AUDIO_BITS_PER_SECOND = 160_000;
+
+/**
+ * How long to wait for MediaRecorder.onstop before abandoning the segment.
+ *
+ * stopActiveSegment used to await onstop unconditionally. Because every
+ * pause/stop/roll goes through one serial operation queue, a MediaRecorder that
+ * never fired onstop wedged the queue permanently and stop() could not reach
+ * finalize (issue #166).
+ */
+const DEFAULT_STOP_TIMEOUT_MS = 5_000;
+
+/** Multiple of the timeslice after which a silent recorder is treated as stalled. */
+const STALL_TIMESLICE_MULTIPLE = 3;
+
+const MIN_STALL_TIMEOUT_MS = 6_000;
+
+const STALL_CHECK_INTERVAL_MS = 2_000;
 
 const resolveRecorderMimeType = (mediaRecorderCtor: typeof MediaRecorder) => {
   return (
@@ -53,7 +81,15 @@ export class BrowserRecorder {
 
   private onError?: CreateBrowserRecorderOptions["onError"];
 
+  private onStall?: CreateBrowserRecorderOptions["onStall"];
+
   private timesliceMs: number;
+
+  private readonly stopTimeoutMs: number;
+
+  private readonly stallTimeoutMs?: number;
+
+  private readonly now: () => number;
 
   private activeSegment: ActiveSegment | null = null;
 
@@ -63,6 +99,10 @@ export class BrowserRecorder {
 
   private stopPromise: Promise<void> | null = null;
 
+  private lastChunkAt = 0;
+
+  private stallTimerId: ReturnType<typeof setInterval> | null = null;
+
   constructor(options: CreateBrowserRecorderOptions) {
     this.mediaRecorderCtor = options.mediaRecorderCtor ?? MediaRecorder;
     this.mimeType = resolveRecorderMimeType(this.mediaRecorderCtor);
@@ -70,18 +110,36 @@ export class BrowserRecorder {
     this.nextSequence = options.startSequence ?? 0;
     this.onChunk = options.onChunk;
     this.onError = options.onError;
+    this.onStall = options.onStall;
     this.timesliceMs = options.timesliceMs ?? 2_000;
+    this.stopTimeoutMs = options.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
+    this.stallTimeoutMs = options.stallTimeoutMs;
+    this.now = options.now ?? (() => Date.now());
   }
 
   get state() {
     return this.stateValue;
   }
 
+  /** Timestamp of the most recent emitted segment, for coverage tracking. */
+  get lastChunkEmittedAt() {
+    return this.lastChunkAt;
+  }
+
+  private get resolvedStallTimeoutMs() {
+    return (
+      this.stallTimeoutMs ??
+      Math.max(this.timesliceMs * STALL_TIMESLICE_MULTIPLE, MIN_STALL_TIMEOUT_MS)
+    );
+  }
+
   start(timesliceMs = 2_000) {
     if (this.stateValue === "inactive") {
       this.timesliceMs = timesliceMs;
       this.stateValue = "recording";
+      this.lastChunkAt = this.now();
       this.beginSegment();
+      this.startStallWatchdog();
     }
   }
 
@@ -99,6 +157,7 @@ export class BrowserRecorder {
       return;
     }
 
+    this.stopStallWatchdog();
     await this.enqueueOperation(async () => {
       if (this.stateValue !== "recording") {
         return;
@@ -118,7 +177,11 @@ export class BrowserRecorder {
         }
 
         this.stateValue = "recording";
+        // Reset the stall marker: the paused interval is not a stall, and a
+        // stale marker would trip the watchdog on the first tick after resume.
+        this.lastChunkAt = this.now();
         this.beginSegment();
+        this.startStallWatchdog();
       });
     }
   }
@@ -130,6 +193,7 @@ export class BrowserRecorder {
 
     if (!this.stopPromise) {
       const emitTail = options.emitTail !== false;
+      this.stopStallWatchdog();
       this.stopPromise = this.enqueueOperation(async () => {
         this.stateValue = "inactive";
         const blob = await this.stopActiveSegment();
@@ -232,7 +296,73 @@ export class BrowserRecorder {
       }
     }
 
-    return segment.stopPromise;
+    // Never await onstop unconditionally: a recorder that never fires it would
+    // wedge the shared operation queue and every later pause/stop with it. On
+    // expiry, keep whatever the segment did buffer rather than losing it.
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const abandoned = Symbol("abandoned");
+    const timeout = new Promise<typeof abandoned>((resolve) => {
+      timeoutId = setTimeout(() => resolve(abandoned), this.stopTimeoutMs);
+    });
+
+    try {
+      const result = await Promise.race([segment.stopPromise, timeout]);
+      if (result !== abandoned) {
+        return result;
+      }
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+
+    this.onStall?.({
+      sinceLastChunkMs: this.now() - this.lastChunkAt,
+      abandonedSegment: true,
+    });
+
+    const type = segment.recorder.mimeType || this.mimeType || DEFAULT_MIME_TYPE;
+    return segment.chunks.length > 0
+      ? new Blob(segment.chunks, { type })
+      : null;
+  }
+
+  private startStallWatchdog() {
+    this.stopStallWatchdog();
+    this.stallTimerId = setInterval(() => {
+      this.checkForStall();
+    }, STALL_CHECK_INTERVAL_MS);
+  }
+
+  private stopStallWatchdog() {
+    if (this.stallTimerId) {
+      clearInterval(this.stallTimerId);
+      this.stallTimerId = null;
+    }
+  }
+
+  /**
+   * Restarts the segment chain when it has gone quiet while still recording.
+   *
+   * A suspended tab (OS sleep, browser tab freezing) stops both the roll timer
+   * and the MediaRecorder's audio feed, and neither surfaces an error: state
+   * stays "recording" with an active segment while nothing reaches disk. Rolling
+   * the segment restarts the chain and makes the gap visible (issue #166).
+   */
+  private checkForStall() {
+    if (this.stateValue !== "recording") {
+      return;
+    }
+
+    const sinceLastChunkMs = this.now() - this.lastChunkAt;
+    if (sinceLastChunkMs < this.resolvedStallTimeoutMs) {
+      return;
+    }
+
+    // Move the marker first so a slow restart does not retrigger every tick.
+    this.lastChunkAt = this.now();
+    this.onStall?.({ sinceLastChunkMs, abandonedSegment: false });
+    void this.rollSegment();
   }
 
   private emitChunk(blob: Blob | null) {
@@ -242,6 +372,7 @@ export class BrowserRecorder {
 
     const sequence = this.nextSequence;
     this.nextSequence += 1;
+    this.lastChunkAt = this.now();
     void Promise.resolve(this.onChunk({ sequence, blob })).catch((error) => {
       this.onError?.(
         error instanceof Error

--- a/frontend/src/lib/capture/shared.ts
+++ b/frontend/src/lib/capture/shared.ts
@@ -48,6 +48,28 @@ export interface FinalizeRetryProgress {
   maxAttempts: number;
 }
 
+/**
+ * Stage the stop sequence has reached. Surfaced so a slow or failed stop names
+ * the step it is on instead of looking hung (issue #166).
+ */
+export type CaptureStopStage =
+  | "stopping-recorder"
+  | "flushing-uploads"
+  | "releasing-media"
+  | "finalizing";
+
+/**
+ * Divergence between wall-clock recording time and the audio actually captured.
+ *
+ * A suspended tab stops feeding the MediaRecorder without raising an error, so
+ * this is the only client-side signal that audio is being lost.
+ */
+export interface CaptureCoverageWarning {
+  capturedSeconds: number;
+  elapsedSeconds: number;
+  missingSeconds: number;
+}
+
 export interface CaptureState {
   status: CaptureStatus;
   support: CaptureSupport;
@@ -60,6 +82,8 @@ export interface CaptureState {
   runtimeActive: boolean;
   settings: CaptureSettings;
   finalizeRetry: FinalizeRetryProgress | null;
+  stopStage: CaptureStopStage | null;
+  coverageWarning: CaptureCoverageWarning | null;
 }
 
 export interface StartCaptureResult {

--- a/frontend/src/lib/capture/uploader.test.ts
+++ b/frontend/src/lib/capture/uploader.test.ts
@@ -112,4 +112,69 @@ describe("capture uploader", () => {
 
     expect(uploader.recover()).toBe(false);
   });
+
+  it("gives up waiting when a queued sequence can never arrive", async () => {
+    // A gap means the segment for nextExpectedSequence was dropped, so waiting
+    // is futile. An unbounded wait here stopped stop() ever calling finalize.
+    let clock = 0;
+    const wait = vi.fn(async (ms: number) => {
+      clock += ms;
+    });
+
+    const uploader = createSegmentUploader({
+      recordingId: 7,
+      uploadSegment: vi.fn(async () => {}),
+      wait,
+      now: () => clock,
+    });
+
+    uploader.enqueue(3, new Blob(["out of order"]));
+
+    await expect(
+      uploader.waitForIdle({ timeoutMs: 500 }),
+    ).rejects.toMatchObject({
+      name: "UploaderTimeoutError",
+      expectedSequence: 0,
+      pendingSequences: [3],
+    });
+  });
+
+  it("yields to macrotasks rather than starving the event loop on a gap", async () => {
+    // The gap branch previously awaited Promise.resolve(), a microtask, which
+    // starved timers and network callbacks and locked up the tab.
+    let clock = 0;
+    const wait = vi.fn(async (ms: number) => {
+      clock += ms;
+    });
+
+    const uploader = createSegmentUploader({
+      recordingId: 7,
+      uploadSegment: vi.fn(async () => {}),
+      wait,
+      now: () => clock,
+    });
+
+    uploader.enqueue(2, new Blob(["out of order"]));
+
+    await expect(uploader.waitForIdle({ timeoutMs: 200 })).rejects.toThrow();
+
+    expect(wait).toHaveBeenCalled();
+    expect(wait.mock.calls.every(([ms]) => ms > 0)).toBe(true);
+  });
+
+  it("still drains cleanly within its deadline", async () => {
+    const uploaded: number[] = [];
+    const uploader = createSegmentUploader({
+      recordingId: 7,
+      uploadSegment: vi.fn(async () => {}),
+      onUploaded: (sequence) => uploaded.push(sequence),
+    });
+
+    uploader.enqueue(0, new Blob(["first"]));
+    uploader.enqueue(1, new Blob(["second"]));
+
+    await uploader.waitForIdle({ timeoutMs: 5_000 });
+
+    expect(uploaded).toEqual([0, 1]);
+  });
 });

--- a/frontend/src/lib/capture/uploader.ts
+++ b/frontend/src/lib/capture/uploader.ts
@@ -3,6 +3,30 @@ import { uploadRecordingSegment } from "@/lib/api";
 
 const DEFAULT_RETRY_DELAYS_MS = [500, 1_000, 2_000, 4_000, 8_000];
 
+/**
+ * How long a queued-sequence gap is tolerated before waitForIdle gives up. The
+ * recorder emits sequences in order, so a gap means a segment was dropped and
+ * waiting for it can never succeed.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+
+const GAP_POLL_INTERVAL_MS = 50;
+
+export class UploaderTimeoutError extends Error {
+  readonly pendingSequences: number[];
+
+  readonly expectedSequence: number;
+
+  constructor(expectedSequence: number, pendingSequences: number[]) {
+    super(
+      `Timed out waiting for recording segment ${expectedSequence} to upload.`,
+    );
+    this.name = "UploaderTimeoutError";
+    this.expectedSequence = expectedSequence;
+    this.pendingSequences = pendingSequences;
+  }
+}
+
 export interface SegmentUploaderOptions {
   recordingId: RecordingId;
   initialSequence?: number;
@@ -11,6 +35,7 @@ export interface SegmentUploaderOptions {
   onStalled?: (error: Error) => void | Promise<void>;
   retryDelaysMs?: number[];
   wait?: (ms: number) => Promise<void>;
+  now?: () => number;
 }
 
 export class SegmentUploader {
@@ -25,6 +50,8 @@ export class SegmentUploader {
   private readonly retryDelaysMs: number[];
 
   private readonly wait: (ms: number) => Promise<void>;
+
+  private readonly now: () => number;
 
   private readonly pending = new Map<number, Blob>();
 
@@ -45,6 +72,7 @@ export class SegmentUploader {
     this.onStalled = options.onStalled;
     this.retryDelaysMs = options.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
     this.wait = options.wait ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.now = options.now ?? (() => Date.now());
     this.nextExpectedSequence = options.initialSequence ?? 0;
   }
 
@@ -75,7 +103,18 @@ export class SegmentUploader {
     return true;
   }
 
-  async waitForIdle() {
+  /**
+   * Resolves once every queued segment has uploaded.
+   *
+   * Bounded on purpose: stop() awaits this before finalizing, and an unbounded
+   * wait here meant a stalled queue silently prevented finalize from ever being
+   * called (issue #166). On expiry the caller gets an UploaderTimeoutError and
+   * can decide, rather than hanging.
+   */
+  async waitForIdle(options: { timeoutMs?: number } = {}) {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+    const deadline = this.now() + timeoutMs;
+
     while (true) {
       if (this.stalledError) {
         throw this.stalledError;
@@ -87,7 +126,17 @@ export class SegmentUploader {
         }
 
         if (!this.pending.has(this.nextExpectedSequence)) {
-          await Promise.resolve();
+          if (this.now() >= deadline) {
+            throw new UploaderTimeoutError(
+              this.nextExpectedSequence,
+              [...this.pending.keys()].sort((a, b) => a - b),
+            );
+          }
+
+          // A real macrotask yield. Spinning on a microtask here starved the
+          // event loop instead of yielding, locking up the tab rather than
+          // merely waiting.
+          await this.wait(GAP_POLL_INTERVAL_MS);
           continue;
         }
 
@@ -96,6 +145,13 @@ export class SegmentUploader {
       }
 
       await this.drainPromise.catch(() => {});
+
+      if (this.now() >= deadline && !this.closed && this.pending.size > 0) {
+        throw new UploaderTimeoutError(
+          this.nextExpectedSequence,
+          [...this.pending.keys()].sort((a, b) => a - b),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes two browser-capture defects. The first is the reported one: a capture left
in `PAUSED` with no live browser runtime had no route to processing at all.
`handleGuardedExit` pauses on tab unload and disposes the runtime, after which
Stop was disabled in both control surfaces, the blocking modal offered only
Resume (which re-prompts the share picker) or Discard (which destroys the audio),
finalize rejected `PAUSED` outright, and nothing reaps a paused row. Clicking
Stop emitted no HTTP request, which is exactly what the reporter's access log
shows.

Three defects in the stop path made the same failure reachable independently.
`resumeRecordingCapture` sat outside `stop()`'s try/catch, so a throw left
`status` at `"finalizing"` - a state in which all three surfaces disable every
control, with no way back. `wasPaused` was read before `pause()` committed its
transition, so Pause-then-Stop skipped the resume and guaranteed a 409. And two
awaits were unbounded: `stopActiveSegment` waited on `MediaRecorder.onstop`
through one serial queue, so a recorder that never fired it wedged every later
pause and stop, and `waitForIdle` looped with no deadline, spinning on a
microtask that starves the event loop rather than yielding to it.

The second defect is the duration gap the reporter flagged as possibly
unrelated. It is the same class of bug, and the obvious hypothesis is wrong.
Measured against real Chromium over CDP, the per-2s-segment recorder is not
lossy: 59.4s captured in 60.0s of wall clock (99%), against 60.0s for a single
recorder with `start(2000)`, at 0.3ms per `stop()`-to-`onstop` and 0.1ms to
construct and start the replacement. Mean blob duration 1.98s, matching the
reported chunks exactly at 126,278 bytes each, which is precisely
16 kHz x 2ch x 16-bit. Every stored chunk was healthy; there were simply too few
for the elapsed time.

Driving the page to Chrome's `frozen` lifecycle state reproduced it: coverage
fell from 99% to 52.4% across a 20s freeze, against the report's ~46%. Timers
suspend so the roll chain stalls, and the MediaRecorder also stops receiving
audio, so a blob spanning a 21,819ms cycle still decoded to about 2s. That audio
is gone rather than deferred. Nothing could observe it: the recorder reported
`"recording"` with an active segment, the AudioContext reported `"running"`, and
no `pagehide` fired - only `visibilitychange`, which the lifecycle ignores by
design. The elapsed timer is pure wall clock, so the UI showed 91 minutes for 42
minutes of audio.

Accordingly the recorder is deliberately **not** rewritten. The fix is liveness
detection plus a reachable, bounded stop.

Server side, finalize now accepts `PAUSED` alongside `UPLOADING` and promotes it
to `QUEUED` in the transaction that writes the audio path. This was chosen over
a parallel recovery route or a query flag because it lets the client drop the
resume round trip entirely, which deletes the `wasPaused` race at its root
rather than working around it. The completeness gates are unchanged: uploads are
still accepted while paused so a late tail survives, and missing sequences and
pending transcodes are still refused with a retryable 409 that the client
retries for up to ~61s. Two pipeline metrics (`recording_finalized_from_paused`,
`capture_coverage`) make this class of report a single query instead of a CDP
investigation; they are metrics rather than columns so no hand-written test DDL
has to change.

Four accepted limits, called out rather than solved:

- A suspended tab still loses its audio. Nothing in a page can prevent being
  suspended; the watchdog restarts the chain on thaw and coverage reports the
  gap, but the interval is unrecoverable. The docs now say so instead of
  implying background tabs are safe.
- The `freeze`/`resume` listeners are advisory. This Chromium build dispatched
  neither when driven to `frozen`, so liveness rests on measured coverage and
  does not depend on those events firing.
- There is still no reaper. A capture abandoned entirely stays `PAUSED`
  indefinitely, as the docs already document. Auto-finalizing a meeting nobody
  stopped is a policy question, not a bug fix.
- The wall-clock timer stays primary, with a divergence badge. A captured-only
  timer is more honest but stalls with no explanation during a suspension, which
  reads as a broken app rather than an incomplete recording.

No new dependencies.

Fixes #166

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1176 passed)
- [x] Python quality: `python scripts/check.py` (OK: lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests)
- [x] Frontend lint: `cd frontend && npm run lint` (clean)
- [x] Frontend unit tests: `cd frontend && npm run test` (335 passed, 15 new)
- [x] Frontend build: `cd frontend && npm run build` (compiled successfully)
- [x] Docs validation: `python3 scripts/validate_docs.py` (31 files)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (head e1a7c93b8d24)

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/CAPTURE.md` gains the stop-and-process action, a suspended-tab warning
against the existing "switching tabs does not pause recording" text, and two
troubleshooting entries. `docs/ARCHITECTURE.md` and `docs/USAGE.md` follow the
lifecycle and finalize-contract change.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

Finalize's ownership check (`_get_owned_recording`) and its session
authentication are untouched. The relaxed guard widens which *statuses* may
finalize, never which user may.

## Manual verification

Done: browser smoke test of start, pause, resume, and stop/finalize on a real
capture. Passed.

Automated: 15 new tests, including the previously uncovered stop-with-no-runtime
path, the wedged-`onstop` case, the `waitForIdle` deadline and its
macrotask-yield behaviour, the recorder stall watchdog, and finalize accepting
`PAUSED` while still refusing a sequence gap.

**Draft because the capture checklist is not fully covered.** Still pending, and
the first two are the point of the PR:

- Stop and process from the resume modal after a forced `pagehide` (reload the
  tab mid-recording, reopen Nojoin, finalize without re-picking sources).
- Freeze the tab mid-recording via `chrome://discards` or Memory Saver, thaw
  after a minute, and confirm the coverage badge appears, the chain resumes, and
  Stop still finalizes.
- Discard from the live controls, the floating badge, and the modal.
- Selected-microphone behaviour and unsupported-browser messaging.
- Native **Stop sharing** from the Chrome sharing bar still auto-finalizes.

Recording context menus were not touched, so `RecordingCard.tsx` and
`Sidebar.tsx` need no change. `LiveMeetingControls.tsx` and
`RecordingFloatingBadge.tsx` were kept in sync with each other, which is the
equivalent constraint for the capture transport controls.
