### PR TITLE
fix(frontend): apply Geist to body text

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -90,9 +90,18 @@ setting. Use or extend the tokens instead.
 and exposed as `--font-geist-sans` and `--font-geist-mono`, which `@theme inline` maps to Tailwind's
 `--font-sans` and `--font-mono`.
 
-Body text does not currently use them. `globals.css` sets `body { font-family: Arial, Helvetica,
-sans-serif; }`, so Geist applies only where a `font-sans` or `font-mono` utility is used
-explicitly.
+Geist Sans is the body font, set once on `body` in `globals.css`, so it is inherited everywhere
+rather than applied per component. Geist Mono is applied where it is wanted, through the `font-mono`
+utility.
+
+The `--font-geist-sans` variable already resolves to `Geist, Geist Fallback`, where the fallback is
+Arial carrying `size-adjust` and ascent/descent overrides that Next generates to match Geist's
+metrics. That is what covers the window before the webfont resolves, and it is why the swap does not
+visibly reflow the page. The generic families after the variable are a last resort for the case
+where the font class is absent entirely.
+
+There is no need to add a `font-sans` class to reach the body font; an element only needs one when
+it is overriding something else back to the default.
 
 ## Accessibility
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -104,7 +104,11 @@ html[data-ui-density="compact"] {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  /* layout.tsx sets --font-geist-sans on this element, and it already resolves
+     to "Geist, Geist Fallback" -- the fallback being Arial with size-adjust and
+     metric overrides, so the swap when the webfont lands is near-invisible. The
+     var() default and the generics only matter if that class is ever absent. */
+  font-family: var(--font-geist-sans, Arial), Helvetica, sans-serif;
 }
 
 body.resize-dragging,


### PR DESCRIPTION
# Pull Request

## Description

Geist and Geist Mono are loaded in `layout.tsx` via `next/font/google`, their variables are applied to `<body>`, and `@theme inline` maps them to Tailwind's `--font-sans` and `--font-mono`. The wiring is complete. But `globals.css` still carried the `create-next-app` default:

```css
body { font-family: Arial, Helvetica, sans-serif; }
```

That override won everywhere, so Geist Sans reached only elements naming `font-sans` explicitly — **exactly one in the entire application**. Geist Sans was therefore downloaded on every page load and applied to almost nothing, while the interface rendered in Arial.

Geist Mono was never affected: its twenty call sites all use the `font-mono` utility, so it has been working as intended throughout.

The fix sets the body font to the variable, making the loaded font the inherited default, which is what the existing wiring already assumed.

### On the fallback chain

`--font-geist-sans` does not resolve to a bare `Geist`. It resolves to `Geist, Geist Fallback`, and Next generates that fallback as:

```css
@font-face{font-family:Geist Fallback;src:local(Arial);
  ascent-override:95.94%;descent-override:28.16%;
  line-gap-override:0.0%;size-adjust:104.76%}
```

That is Arial metrically adjusted to Geist, so it — not the trailing generics — is what covers the window before the webfont resolves, and it is why the swap should not visibly reflow the page.

Worth noting for review, because it is easy to get backwards: `var()` with no default invalidates the whole declaration when the variable is missing, rather than falling through to the next family in the list. A trailing `Arial` would not have protected against an absent font class. The default is therefore written inside `var()`, where it actually takes effect.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

Non-breaking in the code sense, but it changes the typeface of every page, so it is a visible change rather than an invisible one.

## Checks run

- [ ] Backend tests — not applicable, no backend files touched
- [ ] Python quality — not applicable
- [x] Frontend lint: `cd frontend && npm run lint` — clean
- [x] Frontend unit tests: `cd frontend && npm run test` — 335 passed in 52 files
- [x] Frontend build: `cd frontend && npm run build` — succeeded
- [x] Docs validation: `python3 scripts/validate_docs.py` — 20 files, no broken links
- [ ] Alembic validation — not applicable, no migrations touched

### Verified in the compiled output

The change was confirmed in the built CSS rather than assumed from the source:

```
body{...font-family:var(--font-geist-sans,Arial), Helvetica, sans-serif}
--font-geist-sans:"Geist", "Geist Fallback"
```

Both halves are present, so the variable resolves and the rule applies.

Also checked: nothing draws text to a canvas (`ctx.font` / `fillText` / `measureText` have no hits under `frontend/src`), and after this change no other `Arial` or `Helvetica` reference remains in the frontend, so nothing else depended on the old metrics. PDF and DOCX export render server-side and are untouched.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/DESIGN.md` documented the previous behaviour, having been written from the code last week. Its typography section is corrected here, including the account of which part of the stack covers the font-load window.

## Security impact

- [x] No security-sensitive change.

## Manual verification

**Visual confirmation is outstanding, which is why this is a draft.** No browser or headless tooling is available in this environment, so I verified the mechanism — the compiled rule, the variable's value, and the generated fallback's metric overrides — but I have not looked at a rendered page. Since this changes the typeface of every screen, someone should look before it merges.

Suggested pass, once running:

- Dashboard, recordings workspace, and a transcript view render in Geist rather than Arial.
- Monospace areas are unchanged, since `font-mono` was already resolving to Geist Mono.
- No obvious reflow or clipping in dense UI: the sidebar, settings tabs, and the compact density mode (`data-ui-density="compact"`) are the places where a metric change would show first.
- Both light and dark themes, as the change is theme-independent but the check is cheap.

Mark ready for review once that looks right; there is nothing else pending.
