### PR TITLE
fix(docker): align the API image's Python with the rest of the stack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,7 +98,24 @@ updates:
       docker-base-images:
         patterns:
           - "*"
-    # Held pin (see PR #43). Remove when torchaudio ships a 2.12.x release.
+    # Held pins (see PR #43). Remove an entry when its blocker clears.
     ignore:
+      # Remove when torchaudio ships a 2.12.x release.
       - dependency-name: "pytorch/pytorch"
         versions: [">=2.12.0"]
+      # The API image's Python minor is not independently choosable: it must match
+      # the worker image, which inherits 3.12 from the held PyTorch base, and the
+      # 3.12 that CI and mypy target. Without this hold Dependabot walked the API
+      # base from 3.12 to 3.14 unnoticed, leaving the interpreter serving every
+      # HTTP request the only one the test suite never ran on. Lift this only
+      # together with the PyTorch hold above, and move CI, mypy, the docs, and the
+      # worker in the same change. scripts/check_held_pins.py fails if they drift.
+      - dependency-name: "python"
+        versions: [">=3.13.0"]
+      # Node majors stay deliberate rather than automatic. The two Node bases are
+      # NOT interchangeable (see docker/Dockerfile.worker-io): the worker-io donor
+      # must be glibc to run inside the Ubuntu PyTorch base, while the frontend
+      # runs musl/Alpine standalone. A major bump changes the bundled npm and the
+      # Trivy surface of both, so it is reviewed by hand.
+      - dependency-name: "node"
+        versions: [">=27.0.0"]

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,6 +1,15 @@
 # --- Builder Stage ---
 # Pinned by digest for reproducible builds; Dependabot keeps the tag comment current.
-FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS builder
+#
+# The Python minor MUST stay 3.12, matching the worker image, CI, and the mypy
+# target. The worker's interpreter is not freely choosable: it comes from the
+# PyTorch base image, held at 2.11.x because torchaudio has published nothing
+# above it, and that image ships 3.12. Running the API on a different minor
+# means the interpreter serving every HTTP request is the one the test suite
+# never runs on. Both stages below must move together, or the venv is built on a
+# different interpreter than it executes on. scripts/check_held_pins.py enforces
+# this, and .github/dependabot.yml holds the base image at 3.12.
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -23,7 +32,8 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements/backend.txt
 
 # --- Runtime Stage ---
-FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS runtime
+# Must be the same image as the builder stage above; see the note there.
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/docker/Dockerfile.worker-io
+++ b/docker/Dockerfile.worker-io
@@ -13,10 +13,19 @@
 ARG WORKER_BASE_IMAGE=ghcr.io/valtora/nojoin-worker:latest
 
 # Node.js runtime, PINNED BY DIGEST (supply-chain hardening — replaces the
-# unpinned NodeSource curl|bash install). node:22-bookworm-slim is glibc 2.36,
-# which runs on the Ubuntu 24.04 base (glibc 2.39). Bump this digest to move Node
-# deliberately. The Anthropic CLI + Agent SDK are LLM SDKs and stay UNPINNED per
-# the repo policy (allow latest); only the Node runtime shipping them is pinned.
+# unpinned NodeSource curl|bash install). Bump this digest to move Node
+# deliberately; .github/dependabot.yml holds Node majors back for hand review.
+# The Anthropic CLI + Agent SDK are LLM SDKs and stay UNPINNED per the repo
+# policy (allow latest); only the Node runtime shipping them is pinned.
+#
+# The `-bookworm-slim` variant is load-bearing and NOT interchangeable with the
+# `-alpine` one that frontend/Dockerfile uses. This stage is only a donor: the
+# bare `node` binary is copied into the PyTorch base below, which is Ubuntu 24.04
+# (glibc 2.39). Debian bookworm builds against glibc 2.36, and glibc is forward
+# compatible, so that binary runs there. An Alpine build links against musl and
+# would find no loader in the Ubuntu base at all. The frontend image has the
+# opposite requirement — it runs Node standalone, so it takes the smaller Alpine
+# base. The two therefore stay different on purpose.
 FROM node:26-bookworm-slim@sha256:2d49d876e96237d76de412761cf05dbfe5aee325cc4406a4d41d5824c5bb8beb AS node
 
 FROM ${WORKER_BASE_IMAGE}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -555,7 +555,8 @@ The policy for a hold is therefore:
 
 1. **Record it in code, not just prose.** Add the hold to `HOLDS` in [scripts/check_held_pins.py](../scripts/check_held_pins.py) with the blocking package and the version that resolves the advisory. Add the matching `ignore:` entry to [dependabot.yml](../.github/dependabot.yml) to stop the pointless update pull requests.
 2. **Enforce that the stack moves together.** Every file declaring part of a matched stack must declare the same version. `python scripts/check_held_pins.py --offline` checks this, runs in CI and in `scripts/check.py`, and covers the requirements files and the worker base-image tag. It fails a bump applied to some declarations and not others.
-3. **Suppress the alerts automatically, not manually.** Add a custom **Dependabot rule** (repository *Settings > Code security > Dependabot rules > New rule*, free on public repositories) matching the held package. For the current hold, set *Target alerts* to `package:torch`, `ecosystem:pip`, and `severity:low` (the filters are ANDed), then tick **Dismiss alerts** and choose **Indefinitely**. The rule re-dismisses on every advisory revision and every new manifest, which is what makes the suppression durable. There is no REST API for these rules; they are configured in the web UI.
+3. **Enforce anything the hold transitively fixes.** A hold can constrain more than its own version string. The PyTorch hold also fixes the worker's **Python minor**, because the interpreter arrives with the base image rather than being chosen, so the API image, CI, mypy, and the documented prerequisite all have to match it. `EXPECTED_PYTHON` and `PYTHON_DECLARATIONS` in [check_held_pins.py](../scripts/check_held_pins.py) record that, and the same `--offline` run fails on any surface that drifts. This is not hypothetical: with no `ignore:` entry for the `python` base image, Dependabot walked the API image from 3.12 to 3.14 on its own, and for a while the interpreter serving every HTTP request was the only one the test suite never ran on. When a hold implies a constraint like this, encode the constraint too, not just the pin.
+4. **Suppress the alerts automatically, not manually.** Add a custom **Dependabot rule** (repository *Settings > Code security > Dependabot rules > New rule*, free on public repositories) matching the held package. For the current hold, set *Target alerts* to `package:torch`, `ecosystem:pip`, and `severity:low` (the filters are ANDed), then tick **Dismiss alerts** and choose **Indefinitely**. The rule re-dismisses on every advisory revision and every new manifest, which is what makes the suppression durable. There is no REST API for these rules; they are configured in the web UI.
 
    Three choices on that form are easy to get wrong:
 
@@ -566,7 +567,7 @@ The policy for a hold is therefore:
    Restricting the rule to `Low` is what keeps it honest: while the pin is held, no torch advisory of any severity can be fixed by upgrading, so auto-dismissing the local-only low tier costs nothing that could have been acted on, while moderate and above still surface for a human decision. `ecosystem:pip` is not redundant — an npm package named `torch` exists.
 
    *Open a pull request to resolve alerts* cannot be unticked, which is harmless here: the `ignore:` entry for the same package already stops that pull request being opened.
-4. **Dismiss the alerts that are already open.** Auto-triage rules apply going forward, so clear the backlog once:
+5. **Dismiss the alerts that are already open.** Auto-triage rules apply going forward, so clear the backlog once:
 
    ```bash
    gh api --method PATCH repos/Valtora/Nojoin/dependabot/alerts/<number> \
@@ -576,7 +577,7 @@ The policy for a hold is therefore:
    ```
 
    Valid reasons are `fix_started`, `inaccurate`, `no_bandwidth`, `not_used`, and `tolerable_risk`; the comment is capped at 280 characters. Prefer `tolerable_risk` over `not_used` unless you have confirmed that no transitive dependency reaches the vulnerable code path.
-5. **Watch for the hold clearing.** Because the alerts are now silenced, nothing would otherwise announce the day the pin can move. [held-pin-watch.yml](../.github/workflows/held-pin-watch.yml) runs `scripts/check_held_pins.py` monthly against PyPI and opens a single `held-pin` issue when the blocking package catches up. Lifting a hold means moving the whole stack, updating `HOLDS`, removing the `ignore:` entry, and **removing the auto-triage rule** so genuine advisories surface again.
+6. **Watch for the hold clearing.** Because the alerts are now silenced, nothing would otherwise announce the day the pin can move. [held-pin-watch.yml](../.github/workflows/held-pin-watch.yml) runs `scripts/check_held_pins.py` monthly against PyPI and opens a single `held-pin` issue when the blocking package catches up. Lifting a hold means moving the whole stack, updating `HOLDS`, removing the `ignore:` entry, and **removing the auto-triage rule** so genuine advisories surface again.
 
 A hold is a deliberate, dated, checked decision, not a silence. If a held advisory ever rises above the risk this repository is prepared to carry, the answer is to drop the blocking dependency, not to widen the hold.
 

--- a/scripts/check_held_pins.py
+++ b/scripts/check_held_pins.py
@@ -8,13 +8,20 @@ to be re-justified every time the advisory's affected range is revised. The
 policy, and the one-off dismissal procedure, are in
 docs/DEVELOPMENT.md#held-pins-and-unfixable-advisories.
 
-This script does the two things that keep the hold honest:
+This script does the three things that keep the hold honest:
 
 1. **Drift check (offline).** Every file that declares part of a matched stack
    must declare the same version. Nothing else enforces that today, so a bump
    applied to one requirements file and missed in another would install a
    mismatched, ABI-incompatible pair.
-2. **Release check (network).** Ask PyPI whether the blocking package has
+2. **Interpreter check (offline).** Every surface that runs ``backend/`` must
+   declare the same Python minor. This is a consequence of the torch hold rather
+   than a separate decision: the worker inherits its interpreter from the held
+   PyTorch base image, so the API image, CI, and mypy have to follow it. Left
+   unchecked, Dependabot walked the API base image from 3.12 to 3.14 on its own
+   and made the interpreter serving every HTTP request the only one the test
+   suite never ran on.
+3. **Release check (network).** Ask PyPI whether the blocking package has
    published a version that lets the pin move, so the hold is revisited when it
    can actually be lifted rather than on every alert.
 
@@ -93,6 +100,73 @@ HOLDS: tuple[Hold, ...] = (
 PIN_RE_TEMPLATE = r"^{package}==([^\s;#]+)"
 # FROM pytorch/pytorch:2.11.0-cuda12.6-cudnn9-runtime@sha256:...
 IMAGE_TAG_RE = re.compile(r"^FROM\s+pytorch/pytorch:([^\s@]+)", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class Declaration:
+    """A file that states the Python version, and how to read it back out."""
+
+    path: str
+    pattern: re.Pattern[str]
+    # What the declaration governs, for the failure message.
+    what: str
+    # How many matches the file must contain, when that count is itself load
+    # bearing. Dockerfile.api names the interpreter once per build stage, and is
+    # only aligned if *both* moved: a half-applied bump builds the venv on one
+    # interpreter and runs it on another, which can still appear to work.
+    expected_matches: int | None = None
+
+
+# The Python minor that every surface running backend/ must agree on.
+#
+# This is derived, not chosen. The worker's interpreter comes from the PyTorch
+# base image, which is held at 2.11.x because torchaudio has published nothing
+# above it (see the torch Hold above), and that image ships Python 3.12. The
+# worker's Python is therefore fixed until the torch hold lifts, and everything
+# else has to match it rather than the other way round.
+#
+# The worker image is the source of truth but cannot be checked statically: the
+# pytorch/pytorch tag encodes the torch version, not the Python one. So this
+# constant records what that base ships, verified by running `python -V` in the
+# built image, and the declarations below are checked against it. Moving it is a
+# deliberate act that should come with the same verification.
+EXPECTED_PYTHON = "3.12"
+
+PYTHON_DECLARATIONS: tuple[Declaration, ...] = (
+    Declaration(
+        path="docker/Dockerfile.api",
+        # FROM python:3.12-slim@sha256:...
+        pattern=re.compile(r"^FROM\s+python:(\d+\.\d+)", re.MULTILINE),
+        what="the API image base",
+        expected_matches=2,
+    ),
+    Declaration(
+        path="pyproject.toml",
+        # python_version = "3.12"  (mypy's target)
+        pattern=re.compile(r"^python_version\s*=\s*\"([^\"]+)\"", re.MULTILINE),
+        what="the mypy target",
+    ),
+    Declaration(
+        # Globbed rather than listed, so a new workflow is covered on the day it
+        # lands instead of whenever someone remembers to add it here. Both
+        # extensions, so a .yaml file does not escape the check.
+        path=".github/workflows/*.y*ml",
+        # python-version: "3.12"
+        pattern=re.compile(r"python-version:\s*\"([^\"]+)\"", re.MULTILINE),
+        what="the CI interpreter",
+    ),
+    Declaration(
+        path="CONTRIBUTING.md",
+        # - Python 3.12   (the contributor prerequisite bullet)
+        pattern=re.compile(r"^-\s+Python\s+(\d+\.\d+)", re.MULTILINE),
+        what="the documented prerequisite",
+    ),
+    Declaration(
+        path="docs/DEVELOPMENT.md",
+        pattern=re.compile(r"^-\s+Python\s+(\d+\.\d+)", re.MULTILINE),
+        what="the documented prerequisite",
+    ),
+)
 
 
 def parse_version(raw: str) -> tuple[int, ...] | None:
@@ -195,6 +269,120 @@ def check_drift(hold: Hold) -> list[str]:
     return problems
 
 
+def minor_of(raw: str) -> str:
+    """Reduce a version to its ``X.Y`` minor, so 3.12.13 and 3.12 compare equal.
+
+    Patch releases are free to differ: the API image and the worker will not ship
+    the same 3.12.z, and that is fine. The minor is what changes behaviour.
+    """
+    parts = raw.strip().split(".")
+    return ".".join(parts[:2])
+
+
+def resolve_paths(pattern: str) -> list[Path]:
+    """Expand a declaration path, which may be a glob, to concrete files."""
+    if "*" in pattern:
+        return sorted(REPO_ROOT.glob(pattern))
+    return [REPO_ROOT / pattern]
+
+
+def check_one_file(
+    declaration: Declaration, path: Path, globbed: bool
+) -> tuple[list[str], int]:
+    """Check a single file, returning its problems and how many pins it declared.
+
+    The match count is returned because a globbed declaration can only judge
+    coverage across the whole set: see ``check_declaration``.
+    """
+    problems: list[str] = []
+    relative = path.relative_to(REPO_ROOT).as_posix()
+
+    if not path.is_file():
+        return (
+            [f"python: {relative} is missing, so {declaration.what} is unchecked."],
+            0,
+        )
+
+    text = path.read_text(encoding="utf-8")
+    matches = list(declaration.pattern.finditer(text))
+
+    if not matches:
+        # For a named file, declaring nothing means the check silently stopped
+        # covering it. Across a glob it is ordinary, so it is judged by the caller.
+        if not globbed:
+            problems.append(
+                f"python: {relative} declares no Python version, so "
+                f"{declaration.what} is unchecked. The file's format probably "
+                f"changed and PYTHON_DECLARATIONS in {Path(__file__).name} needs "
+                f"updating."
+            )
+        return problems, 0
+
+    expected_count = declaration.expected_matches
+    if expected_count is not None and len(matches) != expected_count:
+        problems.append(
+            f"python: {relative} declares the Python version {len(matches)} "
+            f"time(s), expected {expected_count}. Every build stage must name the "
+            f"same interpreter, or the venv is built on one and run on another."
+        )
+
+    for match in matches:
+        if minor_of(match.group(1)) == EXPECTED_PYTHON:
+            continue
+        line = text.count("\n", 0, match.start()) + 1
+        problems.append(
+            f"python: {relative}:{line} sets {declaration.what} to "
+            f"{match.group(1)}, but every surface running backend/ must be on "
+            f"{EXPECTED_PYTHON} — the minor the held PyTorch base ships to the "
+            f"worker. Either align this back, or move the worker, CI, mypy, the "
+            f"docs and EXPECTED_PYTHON in {Path(__file__).name} together in one "
+            f"reviewed change."
+        )
+
+    return problems, len(matches)
+
+
+def check_declaration(declaration: Declaration) -> list[str]:
+    """Check every file one declaration resolves to."""
+    # A globbed declaration sweeps a whole directory, where most files
+    # legitimately say nothing about Python (a workflow that never sets up an
+    # interpreter, say). So "declares nothing" is only a problem for a named file;
+    # across a glob the coverage assertion is that *some* file matched.
+    globbed = "*" in declaration.path
+    paths = resolve_paths(declaration.path)
+
+    if not paths:
+        return [
+            f"python: no file matched {declaration.path}, so {declaration.what} is "
+            f"unchecked. Either the path moved or the glob is wrong; the "
+            f"interpreter check is not covering what it claims to."
+        ]
+
+    problems: list[str] = []
+    total_matches = 0
+    for path in paths:
+        found, matched = check_one_file(declaration, path, globbed)
+        problems.extend(found)
+        total_matches += matched
+
+    if globbed and not total_matches:
+        problems.append(
+            f"python: no file under {declaration.path} declares a Python version, "
+            f"so {declaration.what} is unchecked. The format probably changed and "
+            f"PYTHON_DECLARATIONS in {Path(__file__).name} needs updating."
+        )
+    return problems
+
+
+def check_interpreter() -> list[str]:
+    """Return a problem per surface whose Python version is out of alignment."""
+    return [
+        problem
+        for declaration in PYTHON_DECLARATIONS
+        for problem in check_declaration(declaration)
+    ]
+
+
 def evaluate(hold: Hold) -> dict[str, object]:
     """Ask PyPI whether the blocker has released far enough to move the pin."""
     latest = latest_release(hold.blocker)
@@ -258,7 +446,10 @@ def render_text(
     for failure in failures:
         print(f"ERROR: could not check {failure}")
     if not problems:
-        print("Matched-stack pins agree with every recorded hold.")
+        print(
+            "Matched-stack pins agree with every recorded hold, and every "
+            f"surface running backend/ declares Python {EXPECTED_PYTHON}."
+        )
 
 
 def main() -> int:
@@ -274,6 +465,7 @@ def main() -> int:
     args = parser.parse_args()
 
     problems = [problem for hold in HOLDS for problem in check_drift(hold)]
+    problems += check_interpreter()
     results, failures = ((), []) if args.offline else check_releases(HOLDS)
     results = list(results)
     actionable = bool(problems or [r for r in results if r["status"] != "held"])


### PR DESCRIPTION
# Pull Request

## Description

The `nojoin-api` container ran **Python 3.14** while all three worker lanes, every CI job, mypy, and the documented prerequisite were on **3.12**. Nothing was broken by it, but the interpreter serving every HTTP request was the only one the test suite never ran on. Measured on the live deployment before the change:

| Surface | Before | After |
| --- | --- | --- |
| `nojoin-api` | 3.14.6 | **3.12.13** |
| `nojoin-worker-gpu` / `-cpu` / `-io` | 3.12.3 | 3.12.3 (unchanged) |
| CI (11 sites), mypy, docs | 3.12 | 3.12 (unchanged) |

The alignment goes **downward** because the worker's Python is not a free choice: it arrives with the PyTorch base image, held at 2.11.x because torchaudio has published nothing above it, and that image ships 3.12. Raising everything to 3.14 would require breaking that hold, which is outside this repository's control.

**Root cause.** The `docker` ecosystem block in `.github/dependabot.yml` held `pytorch/pytorch` but said nothing about `python`, so Dependabot walked the API base from 3.12 to 3.14 unreviewed and no gate noticed.

**What changed**

- `docker/Dockerfile.api` — both stages move to `python:3.12-slim`, pinned by digest. Both together: moving one alone builds the venv on one interpreter and runs it on another, which can still appear to work.
- `.github/dependabot.yml` — holds added for `python` (`>=3.13.0`) and `node` (`>=27.0.0`).
- `scripts/check_held_pins.py` — a third check alongside the existing drift and release checks. `EXPECTED_PYTHON` records the minor the held base ships; `PYTHON_DECLARATIONS` asserts the Dockerfile (both stages), the workflows, the mypy target, and both documented prerequisites all agree. Offline, so it gates every PR.
- `docker/Dockerfile.worker-io` — comment corrected. It still described `node:22` after Dependabot moved the tag to 26, and did not record why the two Node bases differ.
- `docs/DEVELOPMENT.md` — the held-pins policy gains the step this PR implements: encode what a hold *transitively* fixes, not just the pin.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 1176 passed
- [x] Python quality: `python scripts/check.py` — all nine checks pass, exit 0
- [ ] Frontend lint: not touched
- [ ] Frontend unit tests: not touched
- [ ] Frontend build: not touched
- [x] Docs validation: `python3 scripts/validate_docs.py` — 20 files
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — head `e1a7c93b8d24`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/DEVELOPMENT.md` "Held Pins and Unfixable Advisories" gains a step for constraints a hold transitively fixes. The stated prerequisite stays **Python 3.12** — after this change every container, CI job, and mypy target is 3.12, so the existing wording becomes accurate rather than aspirational and needed no edit.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

A base-image change alters the vulnerability surface, so the rebuilt image was scanned at the release gate's exact settings (`--severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore --exit-code 1`): **0 findings, exit code 0**. No `.trivyignore` entries were added or needed. `python:3.12-slim` is Debian 13 (trixie), the same distro generation as the 3.14 image it replaces, so there is no OS-package regression.

## Manual verification

**The interpreter was verified by building the image, not by reading the Dockerfile.**

```
$ docker run --rm --entrypoint python nojoin-api:py312-verify -c "import sys; print(sys.version)"
3.12.13 (main, Jul 14 2026, 02:09:00) [GCC 14.2.0]

$ docker run --rm --entrypoint /opt/venv/bin/python nojoin-api:py312-verify -V
Python 3.12.13                      # venv interpreter matches the runtime

$ docker run --rm --entrypoint sh nojoin-api:py312-verify -c 'ls -d /opt/venv/lib/python*'
/opt/venv/lib/python3.12            # proves which minor built the venv
```

Compiled dependencies import cleanly on 3.12 — `numpy 2.4.6`, `google-re2`, `reportlab 5.0.0`, `markdown_pdf` — which is the risk a lockfile read cannot cover.

**The guard was demonstrated against the bad cases, not just added.** Each was applied to a working tree, checked, and reverted:

| Injected fault | Result |
| --- | --- |
| Both stages walked back to 3.14 (the original bug) | caught, 2 drift lines, exit 1 |
| **Only the builder stage bumped** (the subtle one) | caught, exit 1 |
| A build stage deleted, leaving one `FROM` | caught by the count assertion: `declares the Python version 1 time(s), expected 2` |
| CI `python-version` moved to 3.13 | caught at every site, exit 1 |
| mypy `python_version` moved to 3.14 | caught, exit 1 |
| Docs prerequisite reworded so the regex stops matching | caught as *unchecked*, not silently passed |

The last row is the one that matters for durability: losing coverage fails loudly rather than turning into a green tick.

**On the two Node bases** — investigated for possible unification; they must stay different, and this is now recorded in the Dockerfile:

- `docker/Dockerfile.worker-io` uses `node:26-bookworm-slim` purely as a **donor stage** — the bare `node` binary is copied into the PyTorch base, which is **Ubuntu 24.04 / glibc 2.39**. Bookworm builds against glibc 2.36, and glibc is forward compatible, so it runs there. Verified: `ldd` shows `libc.so.6`.
- `frontend/Dockerfile` uses `node:26-alpine`, which links against **musl** (`/lib/ld-musl-x86_64.so.1`, verified). It runs Node standalone, so the smaller image is correct.

Unifying toward Alpine would break worker-io outright — a musl binary has no loader in the Ubuntu base. Unifying toward bookworm would be a pure size regression for the frontend. Both are held against unreviewed major bumps instead.

## Screenshots (if relevant)

Not applicable.
