### PR TITLE
fix(worker): request the CUDA ONNX provider only when a GPU is present

### DIFF
--- a/backend/processing/engines/onnx_asr_engine.py
+++ b/backend/processing/engines/onnx_asr_engine.py
@@ -234,13 +234,25 @@ class OnnxAsrEngine(TranscriptionEngine):
         if onnx_id not in self._model_cache:
             import onnx_asr
 
-            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+            on_gpu = gpu_is_present()
+            # Ask for CUDA only where a GPU is actually attached. Requesting it
+            # without one does not degrade gracefully: onnxruntime-gpu loads its
+            # CUDA provider library, finds no device, and takes the process down
+            # with SIGSEGV. That is a native fault rather than an exception, so no
+            # handler here can catch it and fall back.
+            #
+            # The GPU lane normally has a device, but the CPU-only deployment in
+            # docs/DEPLOYMENT.md drops the compose `deploy` block while keeping the
+            # same onnxruntime-gpu image, which is exactly the crashing shape.
+            providers = ["CPUExecutionProvider"]
+            if on_gpu:
+                providers.insert(0, "CUDAExecutionProvider")
             # int8 is a CPU optimisation and defeats CUDA: onnxruntime has no CUDA
             # kernels for most quantized ops, so it claims the session and then hands
             # nearly every node back to CPU, inserting a memcpy at each handoff (1046
             # of them for canary-1b). Load the fp32 weights where a GPU is present,
             # which cuts that to 66 and keeps the graph on the card.
-            quantization = None if gpu_is_present() else "int8"
+            quantization = None if on_gpu else "int8"
             logger.info(
                 f"Loading {self.name} model: {onnx_id} "
                 f"(quantization={quantization or 'none'})"

--- a/backend/tests/test_onnx_providers.py
+++ b/backend/tests/test_onnx_providers.py
@@ -184,6 +184,68 @@ def test_asr_engine_picks_fp32_on_gpu_and_int8_on_cpu(monkeypatch):
         assert captured["quantization"] == expected
 
 
+def test_asr_engine_requests_cuda_only_when_a_gpu_is_present(monkeypatch):
+    """Requesting CUDA with no device attached segfaults the process.
+
+    onnxruntime-gpu loads its CUDA provider library, finds no device, and dies with
+    SIGSEGV. A native fault cannot be caught, so this has to be prevented rather
+    than handled. The CPU-only deployment in docs/DEPLOYMENT.md runs the GPU lane
+    on this image with no device, which is that shape exactly.
+    """
+    import sys
+    import types
+
+    from backend.processing.engines import onnx_asr_engine
+
+    captured: dict = {}
+    stub = types.ModuleType("onnx_asr")
+    stub.load_model = lambda onnx_id, **kw: captured.update(kw) or ModelStub()
+    monkeypatch.setitem(sys.modules, "onnx_asr", stub)
+
+    class Engine(onnx_asr_engine.OnnxAsrEngine):
+        name = "canary"
+        config_key = "canary_model"
+        default_model_id = "nemo-canary-1b-v2"
+        onnx_id_map: dict = {}
+
+    monkeypatch.setattr(onnx_asr_engine, "gpu_is_present", lambda: False)
+    engine = Engine()
+    engine._model_cache = {}
+    engine._get_model({})
+    assert captured["providers"] == [CPU_PROVIDER]
+
+    monkeypatch.setattr(onnx_asr_engine, "gpu_is_present", lambda: True)
+    engine._model_cache = {}
+    engine._get_model({})
+    assert captured["providers"] == [CUDA_PROVIDER, CPU_PROVIDER]
+
+
+def test_text_embedding_requests_cuda_only_when_a_gpu_is_present(monkeypatch):
+    """Same native crash, on the lane that actually hit it in the field.
+
+    Text embedding runs on the io and parse lanes, neither of which compose grants
+    a GPU, so an unconditional CUDA request killed every indexing task there and
+    left context_chunks empty while the recording still read as processed.
+    """
+    import sys
+    import types
+
+    from backend.processing import text_embedding
+
+    captured: dict = {}
+    stub = types.ModuleType("fastembed")
+    stub.TextEmbedding = lambda **kw: captured.update(kw) or ModelStub()
+    monkeypatch.setitem(sys.modules, "fastembed", stub)
+
+    monkeypatch.setattr(text_embedding, "gpu_is_present", lambda: False)
+    text_embedding.TextEmbeddingService()
+    assert captured["providers"] == [CPU_PROVIDER]
+
+    monkeypatch.setattr(text_embedding, "gpu_is_present", lambda: True)
+    text_embedding.TextEmbeddingService()
+    assert captured["providers"] == [CUDA_PROVIDER, CPU_PROVIDER]
+
+
 def test_window_cap_tightens_on_gpu_and_respects_test_overrides(monkeypatch):
     """fp32 attention activations blow an 8GB card at the CPU-sized window."""
     from backend.processing.engines import onnx_asr_engine as e


### PR DESCRIPTION
## Description

`OnnxAsrEngine._get_model` asked onnxruntime for `CUDAExecutionProvider` unconditionally. Where no GPU is attached that does not degrade to CPU: onnxruntime-gpu loads its CUDA provider library, finds no device, and takes the process down with `SIGSEGV`. That is a native fault rather than a Python exception, so nothing downstream can catch it and fall back.

The GPU lane normally has a device, so this stayed latent. The exposed case is the CPU-only deployment documented in `docs/DEPLOYMENT.md`, which tells the operator to drop the compose `deploy` block while keeping the same onnxruntime-gpu image. That is the crashing shape exactly, and it would kill transcription on the Parakeet and Canary backends.

The fix gates the provider list on `gpu_is_present()`, the device-node probe already used a few lines below to pick quantisation, so both decisions now come from one call.

This is the sibling of the `TextEmbeddingService` crash reported in #183, which was fixed the same way in #177 and is on `main` but not in any tagged release. That report prompted a sweep of every remaining ONNX session site: `backend/preload_models.py` already pins `CPUExecutionProvider`, and document OCR is Tesseract-driven and deliberately ONNX-free, so the ASR engine was the last unguarded one.

No new dependencies.

Fixes # (issue)

Refs #183.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1282 passed)
- [x] Python quality: `python scripts/check.py` (lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests all OK)
- [ ] Frontend lint: not applicable, no frontend files changed
- [ ] Frontend unit tests: not applicable, no frontend files changed
- [ ] Frontend build: not applicable, no frontend files changed
- [x] Docs validation: `python3 scripts/validate_docs.py` (via `scripts/check.py`)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (via `scripts/check.py`)

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

The CPU-only deployment steps in `docs/DEPLOYMENT.md` are unchanged. This makes the documented path work as already described rather than altering it.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Not run on a CPU-only host. The crash is a native segfault, so it cannot be exercised from inside a test process, and this host has a GPU attached.

Verified instead by asserting the requested provider list at the loader boundary. Both new tests were confirmed to fail against the unfixed code and pass with it, so they are not passing vacuously:

- `test_asr_engine_requests_cuda_only_when_a_gpu_is_present`
- `test_text_embedding_requests_cuda_only_when_a_gpu_is_present` (regression cover for #183, which shipped in #177 without a test)

Worth a smoke test on a CPU-only deployment with Parakeet or Canary selected before release, confirming transcription completes rather than losing the worker child to `WorkerLostError`.
