### PR TITLE
fix(site): stop Quick Start steps breaking around inline code

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -562,10 +562,12 @@ samp {
   background: var(--surface-inset);
 }
 
+// The step's own sentence, which must stay a normal block. As a flex container
+// every inline <code> in it became a separate flex item: a step carrying two of
+// them laid out as columns rather than wrapping as prose, and the second one
+// overflowed the card. The badge is aligned against the first line below instead,
+// which is where that problem actually belongs.
 .markdown-body h2#quick-start + ol > li > p:first-of-type {
-  display: flex;
-  align-items: center;
-  min-height: 2.4rem;
   margin: 0;
 }
 
@@ -583,7 +585,12 @@ samp {
   content: counter(steps, decimal-leading-zero);
   position: absolute;
   left: 1rem;
-  top: 1rem;
+  // Centred on the first line of the step text rather than on the card, so a step
+  // that runs to several lines keeps its badge beside the opening line. Derived as
+  // the li's 1.15rem top padding, plus half a 1.7rem line box, less half the
+  // badge's own 2.4rem height. Written out rather than left as a calc() because
+  // Sass evaluates division inside calc() and this needs no runtime arithmetic.
+  top: 0.8rem;
   width: 2.4rem;
   height: 2.4rem;
   display: grid;


### PR DESCRIPTION
# Pull Request

## Description

Step 6 of Quick Start rendered as columns rather than prose on the home page, with its trailing `/setup` overflowing the card.

The step's first paragraph was a flex container, used only to centre a one-line step against its 2.4rem number badge. A flex container makes every inline child a flex item, so each inline `<code>` became an atomic column that could not wrap, while the text runs between them wrapped inside their own items.

Step 6 is the only step kramdown wraps in a `<p>`, and the only one carrying two code spans, which is why it was the only one visibly broken. Steps 3 and 7 carry inline code and a link respectively but have no paragraph wrapper, so the rule never reached them.

The fix drops the flex and aligns the badge against the first text line instead, which is where the alignment problem belongs. That also makes step 6 sit level with the steps that were never wrapped, rather than 1.2rem lower for reasons no reader could see.

The badge offset is written out rather than left as a `calc()`, since Sass evaluates division inside `calc()` and the arithmetic is static.

No dependencies added.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [ ] Backend tests: `source .venv/bin/activate && pytest`
- [ ] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [ ] Docs validation: `python3 scripts/validate_docs.py`
- [ ] Alembic validation: `python3 scripts/validate_alembic.py`

The change is one Jekyll stylesheet at the repository root. It is not part of the Next.js app, so none of the frontend gates cover it, and no Python or migration source is touched.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

The README source is correct as written and renders correctly on GitHub itself. Only the Pages stylesheet was at fault.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

The rendered markup was read from the live site rather than assumed, which is what identified the trigger:

- Step 6 is `<li><p>Unlock the wizard with your <code>FIRST_RUN_PASSWORD</code> ... <code>/setup</code>.</p></li>`, the only match for `li > p:first-of-type` in the list.
- Steps 3 and 7 place their content directly in the `<li>` with no `<p>`, so they were never affected and are unchanged by this.
- Steps 1, 2, 4 and 5 wrap their sentence in a `<p>` followed by a code fence. Their first line still begins at the list item's 1.15rem top padding, so the new badge offset aligns them identically.

No local Jekyll toolchain is installed and installing one to compile a six line stylesheet change was not proportionate, so the render itself is confirmed on Pages after merge.

## Screenshots (if relevant)

Reported from the live site at nojoin.co.uk, Quick Start step 6.
