### PR TITLE
feat(mcp): expose canonical transcript revisions and utterance deltas

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -13,10 +13,7 @@ on the grant. Every read tool works with ``mcp:read`` alone, so grants
 issued before the write scope existed keep functioning unchanged.
 """
 
-import functools
-import inspect
 import logging
-import time
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, Callable, Literal, Optional
@@ -34,10 +31,10 @@ from starlette.types import ASGIApp
 from backend.core.security import MCP_WRITE_SCOPE
 from backend.mcp_server.auth import (
     MCPAuthMiddleware,
-    current_mcp_user,
     get_current_mcp_scopes,
     get_current_mcp_user,
 )
+from backend.mcp_server.tool_logging import logged_tool
 from backend.utils.config_manager import get_trusted_web_origin
 
 logger = logging.getLogger(__name__)
@@ -51,7 +48,10 @@ MCP_SERVER_INSTRUCTIONS = (
     "set_speaker_name names a meeting's speaker and links it to a person, "
     "and append_meeting_notes adds to a meeting's user notes. Recording "
     "identifiers are the string `id` values returned by list_recordings; "
-    "person identifiers are the integer `id` values from list_people."
+    "person identifiers are the integer `id` values from list_people. "
+    "Read transcripts with get_transcript for prose, or "
+    "get_transcript_utterances for structured utterances with stable ids, "
+    "timestamps, and a revision cursor for incremental sync."
 )
 
 _PUBLIC_ORIGIN = get_trusted_web_origin().rstrip("/")
@@ -79,107 +79,11 @@ mcp = FastMCP(
 )
 
 
-# Argument names safe to log verbatim: identifiers, pagination, and enums —
-# never free text (note bodies, search queries) or PII (names, contact
-# details), which are summarised by length/count instead. This keeps the
-# MCP call log useful for debugging without recording meeting content, in
-# line with the logging redaction policy in docs/SECURITY.md.
-_LOGGABLE_ARG_NAMES = frozenset(
-    {
-        "recording_id",
-        "person_id",
-        "diarization_label",
-        "on_conflict",
-        "limit",
-        "skip",
-        "start_date",
-        "end_date",
-    }
-)
-
-
-def _summarise_args(arguments: dict[str, Any]) -> str:
-    parts: list[str] = []
-    for name, value in arguments.items():
-        if value is None:
-            continue
-        if name in _LOGGABLE_ARG_NAMES:
-            parts.append(f"{name}={value!r}")
-        elif isinstance(value, str):
-            parts.append(f"{name}=<str:{len(value)}>")
-        elif isinstance(value, (list, tuple, dict)):
-            parts.append(f"{name}=<{type(value).__name__}:{len(value)}>")
-        else:
-            parts.append(f"{name}=<{type(value).__name__}>")
-    return " ".join(parts) or "(no args)"
-
-
-def _summarise_result(result: Any) -> str:
-    if isinstance(result, (list, tuple, dict)):
-        return f"{type(result).__name__}:{len(result)}"
-    return type(result).__name__
-
-
-def _logged_tool(func: Callable) -> Callable:
-    """Wrap an MCP tool with structured call logging.
-
-    Emits one INFO line per successful call (tool, user, redacted args,
-    result shape, duration), a WARNING for a ToolError (an expected,
-    user-facing rejection), and an EXCEPTION for anything unexpected. The
-    signature is preserved via functools.wraps so FastMCP still builds the
-    tool's input schema from the original annotations.
-    """
-    signature = inspect.signature(func)
-
-    @functools.wraps(func)
-    async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        user = current_mcp_user.get()
-        user_id = getattr(user, "id", None)
-        try:
-            bound = signature.bind(*args, **kwargs)
-            bound.apply_defaults()
-            arg_summary = _summarise_args(bound.arguments)
-        except TypeError:
-            arg_summary = "<unbindable args>"
-        started = time.monotonic()
-        try:
-            result = await func(*args, **kwargs)
-        except ToolError as exc:
-            logger.warning(
-                "mcp tool %s rejected user=%s %s: %s",
-                func.__name__,
-                user_id,
-                arg_summary,
-                exc,
-            )
-            raise
-        except Exception:
-            logger.exception(
-                "mcp tool %s failed user=%s %s",
-                func.__name__,
-                user_id,
-                arg_summary,
-            )
-            raise
-        duration_ms = (time.monotonic() - started) * 1000
-        logger.info(
-            "mcp tool %s ok user=%s %s -> %s (%.0fms)",
-            func.__name__,
-            user_id,
-            arg_summary,
-            _summarise_result(result),
-            duration_ms,
-        )
-        return result
-
-    return wrapper
-
-
 def mcp_tool() -> Callable[[Callable], Callable]:
     """Register a coroutine as an MCP tool with call logging."""
 
     def decorator(func: Callable) -> Callable:
-        return mcp.tool()(_logged_tool(func))
+        return mcp.tool()(logged_tool(func))
 
     return decorator
 
@@ -210,13 +114,17 @@ def _require_write_scope(capability: str) -> None:
         )
 
 
-def _compact_recording(recording: Any) -> dict[str, Any]:
+def _compact_recording(
+    recording: Any,
+    transcript_revision: int = 0,
+) -> dict[str, Any]:
     """Compact a Recording ORM row for the MCP client.
 
-    Expects ``tags`` (with each ``RecordingTag.tag``) and ``speakers`` (with
-    each ``RecordingSpeaker.global_speaker``) eager-loaded: the web endpoint's
-    serializer strips both unless explicitly asked, so list_recordings loads
-    the ORM row itself rather than relying on that projection.
+    Expects ``tags`` (with each ``RecordingTag.tag``), ``speakers`` (with
+    each ``RecordingSpeaker.global_speaker``), and ``transcript``
+    eager-loaded: the web endpoint's serializer strips these unless
+    explicitly asked, so list_recordings loads the ORM row itself rather
+    than relying on that projection.
     """
     speakers = [
         speaker.local_name
@@ -231,14 +139,19 @@ def _compact_recording(recording: Any) -> dict[str, Any]:
         for recording_tag in recording.tags
         if recording_tag.tag is not None
     ]
+    transcript = recording.transcript
     return {
         "id": recording.public_id,
         "name": recording.name,
         "created_at": recording.created_at.isoformat(),
+        "updated_at": recording.updated_at.isoformat(),
         "duration_seconds": recording.duration_seconds,
         "status": str(recording.status.value)
         if hasattr(recording.status, "value")
         else str(recording.status),
+        "transcript_status": transcript.transcript_status if transcript else None,
+        "notes_status": transcript.notes_status if transcript else None,
+        "transcript_revision": transcript_revision,
         "tags": tags,
         "speakers": speakers,
         "is_archived": recording.is_archived,
@@ -261,6 +174,14 @@ async def list_recordings(
     Each result carries `is_archived` and `is_deleted` so their state is
     clear and the caller can filter them out when only active meetings matter.
 
+    Each result also reports processing state (`status`, `transcript_status`,
+    `notes_status`), `updated_at`, and the canonical `transcript_revision`
+    cursor, so a caller can tell that a recording has finished processing
+    (`status` PROCESSED and `notes_status` completed) or that its transcript
+    changed since last seen, without re-fetching transcripts. Pass a stored
+    `transcript_revision` to get_transcript_utterances to fetch only what
+    changed.
+
     Args:
         limit: Maximum number of recordings to return (1-100).
         skip: Number of recordings to skip, for pagination.
@@ -271,10 +192,13 @@ async def list_recordings(
         end_date: Only recordings created on or before this ISO 8601
             date/datetime.
     """
+    from sqlalchemy import func
+
     from backend.api.v1.endpoints.recordings.routes_query import (
         list_recordings as api_list_recordings,
     )
     from backend.core.db import async_session_maker
+    from backend.models.pipeline import TranscriptUtteranceEvent
     from backend.models.recording import Recording
     from backend.models.speaker import RecordingSpeaker
     from backend.models.tag import RecordingTag
@@ -321,12 +245,33 @@ async def list_recordings(
                 selectinload(Recording.speakers).selectinload(
                     RecordingSpeaker.global_speaker
                 ),
+                selectinload(Recording.transcript),
             )
         )
         by_public_id = {rec.public_id: rec for rec in orm_result.scalars()}
 
+        # One grouped aggregate for the whole page: the canonical revision
+        # cursor is max(event id) per recording, and a query per row would
+        # be an N+1 against the busiest table in the schema.
+        internal_ids = [rec.id for rec in by_public_id.values()]
+        revision_result = await db.execute(
+            select(
+                TranscriptUtteranceEvent.recording_id,
+                func.max(TranscriptUtteranceEvent.id),
+            )
+            .where(TranscriptUtteranceEvent.recording_id.in_(internal_ids))
+            .group_by(TranscriptUtteranceEvent.recording_id)
+        )
+        revisions = {
+            recording_id: int(revision)
+            for recording_id, revision in revision_result.all()
+        }
+
     return [
-        _compact_recording(by_public_id[public_id])
+        _compact_recording(
+            by_public_id[public_id],
+            transcript_revision=revisions.get(by_public_id[public_id].id, 0),
+        )
         for public_id in ordered_public_ids
         if public_id in by_public_id
     ]
@@ -379,6 +324,56 @@ async def get_transcript(recording_id: str) -> dict[str, Any]:
         "duration_seconds": recording.duration_seconds,
         "transcript": transcript_text,
     }
+
+
+@mcp_tool()
+async def get_transcript_utterances(
+    recording_id: str,
+    after_revision: Optional[int] = None,
+) -> dict[str, Any]:
+    """Get the canonical transcript as structured utterances with delta sync.
+
+    Where get_transcript returns formatted prose for reading, this returns
+    the same structured contract the web client synchronises on: stable
+    utterance ids, millisecond timestamps, per-utterance state, revision and
+    edit-provenance flags, the recording's speaker list, a recording-level
+    `revision` cursor, and `tombstones` (ids of utterances removed or
+    superseded since the supplied cursor).
+
+    Intended for tools that keep their own copy of a transcript in sync:
+    store the returned `revision`, and pass it back as `after_revision` on
+    the next call to receive only what changed (empty lists mean up to
+    date). Omit `after_revision` for a full snapshot, which always has empty
+    `tombstones`. The cursor is opaque and increases monotonically per
+    recording; it never resets, including across reprocessing, though
+    reprocessing may replace most utterance ids. The `speakers` list always
+    reflects current names, so speaker renames are visible even when no
+    utterance changed.
+
+    Args:
+        recording_id: The recording's string id from list_recordings.
+        after_revision: The last `revision` cursor already seen, from a
+            previous call or from list_recordings' `transcript_revision`.
+            Omit for a full snapshot.
+    """
+    from backend.api.v1.endpoints.transcripts.routes_utterances import (
+        get_transcript_utterances as api_get_transcript_utterances,
+    )
+    from backend.core.db import async_session_maker
+
+    user = get_current_mcp_user()
+    if after_revision is not None and after_revision < 0:
+        raise ToolError("after_revision must be a non-negative integer.")
+
+    async with async_session_maker() as db:
+        payload = await api_get_transcript_utterances(
+            recording_id,
+            after_revision=after_revision,
+            db=db,
+            current_user=user,
+        )
+
+    return payload.model_dump()
 
 
 @mcp_tool()

--- a/backend/mcp_server/tool_logging.py
+++ b/backend/mcp_server/tool_logging.py
@@ -1,0 +1,115 @@
+"""Structured call logging for MCP tools.
+
+Wraps every registered tool so each call emits one log line with the tool
+name, acting user, redacted argument summary, result shape, and duration.
+Redaction policy: identifiers and enums are logged verbatim, free text and
+PII are summarised by length or count only, in line with the logging
+redaction policy in docs/SECURITY.md.
+"""
+
+import functools
+import inspect
+import logging
+import time
+from typing import Any, Callable
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from backend.mcp_server.auth import current_mcp_user
+
+logger = logging.getLogger(__name__)
+
+# Argument names safe to log verbatim: identifiers, pagination, and enums —
+# never free text (note bodies, search queries) or PII (names, contact
+# details), which are summarised by length/count instead. This keeps the
+# MCP call log useful for debugging without recording meeting content.
+_LOGGABLE_ARG_NAMES = frozenset(
+    {
+        "recording_id",
+        "person_id",
+        "diarization_label",
+        "on_conflict",
+        "limit",
+        "skip",
+        "start_date",
+        "end_date",
+        "after_revision",
+    }
+)
+
+
+def _summarise_args(arguments: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for name, value in arguments.items():
+        if value is None:
+            continue
+        if name in _LOGGABLE_ARG_NAMES:
+            parts.append(f"{name}={value!r}")
+        elif isinstance(value, str):
+            parts.append(f"{name}=<str:{len(value)}>")
+        elif isinstance(value, (list, tuple, dict)):
+            parts.append(f"{name}=<{type(value).__name__}:{len(value)}>")
+        else:
+            parts.append(f"{name}=<{type(value).__name__}>")
+    return " ".join(parts) or "(no args)"
+
+
+def _summarise_result(result: Any) -> str:
+    if isinstance(result, (list, tuple, dict)):
+        return f"{type(result).__name__}:{len(result)}"
+    return type(result).__name__
+
+
+def logged_tool(func: Callable) -> Callable:
+    """Wrap an MCP tool with structured call logging.
+
+    Emits one INFO line per successful call (tool, user, redacted args,
+    result shape, duration), a WARNING for a ToolError (an expected,
+    user-facing rejection), and an EXCEPTION for anything unexpected. The
+    signature is preserved via functools.wraps so FastMCP still builds the
+    tool's input schema from the original annotations.
+    """
+    signature = inspect.signature(func)
+
+    @functools.wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        user = current_mcp_user.get()
+        user_id = getattr(user, "id", None)
+        try:
+            bound = signature.bind(*args, **kwargs)
+            bound.apply_defaults()
+            arg_summary = _summarise_args(bound.arguments)
+        except TypeError:
+            arg_summary = "<unbindable args>"
+        started = time.monotonic()
+        try:
+            result = await func(*args, **kwargs)
+        except ToolError as exc:
+            logger.warning(
+                "mcp tool %s rejected user=%s %s: %s",
+                func.__name__,
+                user_id,
+                arg_summary,
+                exc,
+            )
+            raise
+        except Exception:
+            logger.exception(
+                "mcp tool %s failed user=%s %s",
+                func.__name__,
+                user_id,
+                arg_summary,
+            )
+            raise
+        duration_ms = (time.monotonic() - started) * 1000
+        logger.info(
+            "mcp tool %s ok user=%s %s -> %s (%.0fms)",
+            func.__name__,
+            user_id,
+            arg_summary,
+            _summarise_result(result),
+            duration_ms,
+        )
+        return result
+
+    return wrapper

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -31,6 +31,7 @@ from backend.mcp_server.server import (
     get_documents,
     get_person,
     get_speakers,
+    get_transcript_utterances,
     import_people,
     list_people,
     list_recordings,
@@ -38,6 +39,11 @@ from backend.mcp_server.server import (
     set_speaker_name,
 )
 from backend.models.people_tag import PeopleTag, PeopleTagLink
+from backend.models.pipeline import (
+    TranscriptUtterance,
+    TranscriptUtteranceEvent,
+    TranscriptUtteranceState,
+)
 from backend.models.speaker import GlobalSpeaker
 from backend.models.transcript import Transcript
 from backend.models.user import User
@@ -250,6 +256,52 @@ SCHEMA_STATEMENTS = [
         updated_at DATETIME NOT NULL,
         recording_id INTEGER NOT NULL,
         tag_id INTEGER NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE transcript_utterances (
+        id INTEGER PRIMARY KEY,
+        created_at DATETIME NOT NULL,
+        updated_at DATETIME NOT NULL,
+        public_id VARCHAR(36) NOT NULL,
+        recording_id INTEGER NOT NULL,
+        sort_key VARCHAR(64) NOT NULL,
+        start_ms INTEGER NOT NULL,
+        end_ms INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        speaker_label VARCHAR(255),
+        recording_speaker_id INTEGER,
+        state VARCHAR(32) NOT NULL,
+        source_kind VARCHAR(255) NOT NULL,
+        processing_run_id INTEGER,
+        last_utterance_event_id INTEGER,
+        last_diarization_window_result_id INTEGER,
+        revision INTEGER NOT NULL,
+        overlap_group_id VARCHAR(64),
+        overlap_rank INTEGER NOT NULL,
+        manual_text_locked BOOLEAN NOT NULL,
+        manual_speaker_locked BOOLEAN NOT NULL,
+        speaker_assignment_source VARCHAR(32) NOT NULL,
+        speaker_assignment_authority VARCHAR(32) NOT NULL,
+        text_confidence FLOAT,
+        speaker_confidence FLOAT,
+        confidence_payload JSON
+    )
+    """,
+    """
+    CREATE TABLE transcript_utterance_events (
+        id INTEGER PRIMARY KEY,
+        created_at DATETIME NOT NULL,
+        updated_at DATETIME NOT NULL,
+        recording_id INTEGER NOT NULL,
+        utterance_id INTEGER NOT NULL,
+        processing_run_id INTEGER,
+        actor_user_id INTEGER,
+        event_type VARCHAR(64) NOT NULL,
+        source VARCHAR(64) NOT NULL,
+        old_values JSON,
+        new_values JSON,
+        resulting_revision INTEGER NOT NULL
     )
     """,
 ]
@@ -576,6 +628,210 @@ async def test_list_recordings_covers_archived_and_deleted(
     assert states["rec-active"] == (False, False)
     assert states["rec-archived"] == (True, False)
     assert states["rec-deleted"] == (False, True)
+
+
+async def seed_canonical_transcript(session_maker, *, recording_id: int = 1) -> None:
+    """A transcript with two active canonical utterances and one superseded.
+
+    Events 1 and 2 create u-1 and u-2; event 3 supersedes u-3, leaving the
+    recording's revision cursor at 3.
+    """
+    async with session_maker() as session:
+        session.add(
+            Transcript(
+                recording_id=recording_id,
+                segments=[],
+                notes_status="completed",
+                transcript_status="completed",
+            )
+        )
+        session.add_all(
+            [
+                TranscriptUtterance(
+                    id=1,
+                    public_id="u-1",
+                    recording_id=recording_id,
+                    sort_key="0001",
+                    start_ms=0,
+                    end_ms=1500,
+                    text="Hello everyone.",
+                    speaker_label="SPEAKER_00",
+                    recording_speaker_id=1,
+                    state=TranscriptUtteranceState.STABLE,
+                    source_kind="final",
+                ),
+                TranscriptUtterance(
+                    id=2,
+                    public_id="u-2",
+                    recording_id=recording_id,
+                    sort_key="0002",
+                    start_ms=1500,
+                    end_ms=4000,
+                    text="Morning.",
+                    speaker_label="SPEAKER_01",
+                    recording_speaker_id=2,
+                    state=TranscriptUtteranceState.STABLE,
+                    source_kind="final",
+                ),
+                TranscriptUtterance(
+                    id=3,
+                    public_id="u-3",
+                    recording_id=recording_id,
+                    sort_key="0003",
+                    start_ms=4000,
+                    end_ms=6000,
+                    text="Replaced line.",
+                    speaker_label="SPEAKER_01",
+                    recording_speaker_id=2,
+                    state=TranscriptUtteranceState.SUPERSEDED,
+                    source_kind="final",
+                ),
+            ]
+        )
+        session.add_all(
+            [
+                TranscriptUtteranceEvent(
+                    id=1,
+                    recording_id=recording_id,
+                    utterance_id=1,
+                    event_type="create",
+                ),
+                TranscriptUtteranceEvent(
+                    id=2,
+                    recording_id=recording_id,
+                    utterance_id=2,
+                    event_type="create",
+                ),
+                TranscriptUtteranceEvent(
+                    id=3,
+                    recording_id=recording_id,
+                    utterance_id=3,
+                    event_type="supersede",
+                ),
+            ]
+        )
+        await session.commit()
+
+
+@pytest.mark.anyio
+async def test_list_recordings_reports_sync_fields(
+    session_maker, test_user: User, mcp_context
+):
+    """A polling client must be able to see processing state and the
+    canonical revision cursor without fetching any transcript."""
+    bind_mcp_identity(test_user)
+    await seed_person(session_maker, person_id=11, name="Dana", user_id=test_user.id)
+    await seed_recording_with_speakers(session_maker, user_id=test_user.id)
+    await seed_canonical_transcript(session_maker)
+
+    recordings = await list_recordings()
+
+    assert len(recordings) == 1
+    recording = recordings[0]
+    assert recording["status"] == "PROCESSED"
+    assert recording["transcript_status"] == "completed"
+    assert recording["notes_status"] == "completed"
+    assert recording["transcript_revision"] == 3
+    assert recording["updated_at"] == TEST_TIMESTAMP.isoformat()
+
+
+@pytest.mark.anyio
+async def test_list_recordings_sync_fields_without_transcript(
+    session_maker, test_user: User, mcp_context
+):
+    """A recording with no transcript row reports null statuses and a zero
+    cursor rather than failing."""
+    bind_mcp_identity(test_user)
+    await seed_bare_recording(
+        session_maker,
+        recording_id=1,
+        public_id="rec-bare",
+        user_id=test_user.id,
+        state="active",
+    )
+
+    recordings = await list_recordings()
+
+    assert recordings[0]["transcript_status"] is None
+    assert recordings[0]["notes_status"] is None
+    assert recordings[0]["transcript_revision"] == 0
+
+
+@pytest.mark.anyio
+async def test_get_transcript_utterances_full_snapshot(
+    session_maker, test_user: User, mcp_context
+):
+    bind_mcp_identity(test_user)
+    await seed_person(session_maker, person_id=11, name="Dana", user_id=test_user.id)
+    public_id = await seed_recording_with_speakers(session_maker, user_id=test_user.id)
+    await seed_canonical_transcript(session_maker)
+
+    result = await get_transcript_utterances(public_id)
+
+    assert result["recording_id"] == public_id
+    assert result["revision"] == 3
+    # Only active utterances appear in a snapshot; the superseded one does not.
+    assert [u["id"] for u in result["utterances"]] == ["u-1", "u-2"]
+    first = result["utterances"][0]
+    assert first["start_ms"] == 0
+    assert first["end_ms"] == 1500
+    assert first["text"] == "Hello everyone."
+    assert first["state"] == "stable"
+    assert first["text_manually_edited"] is False
+    assert result["tombstones"] == []
+    assert {s["diarization_label"] for s in result["speakers"]} == {
+        "SPEAKER_00",
+        "SPEAKER_01",
+    }
+
+
+@pytest.mark.anyio
+async def test_get_transcript_utterances_delta_returns_tombstones(
+    session_maker, test_user: User, mcp_context
+):
+    bind_mcp_identity(test_user)
+    await seed_person(session_maker, person_id=11, name="Dana", user_id=test_user.id)
+    public_id = await seed_recording_with_speakers(session_maker, user_id=test_user.id)
+    await seed_canonical_transcript(session_maker)
+
+    result = await get_transcript_utterances(public_id, after_revision=2)
+
+    assert result["revision"] == 3
+    assert result["utterances"] == []
+    assert result["tombstones"] == ["u-3"]
+
+
+@pytest.mark.anyio
+async def test_get_transcript_utterances_current_cursor_is_empty_delta(
+    session_maker, test_user: User, mcp_context
+):
+    bind_mcp_identity(test_user)
+    await seed_person(session_maker, person_id=11, name="Dana", user_id=test_user.id)
+    public_id = await seed_recording_with_speakers(session_maker, user_id=test_user.id)
+    await seed_canonical_transcript(session_maker)
+
+    result = await get_transcript_utterances(public_id, after_revision=3)
+
+    assert result["revision"] == 3
+    assert result["utterances"] == []
+    assert result["tombstones"] == []
+
+
+@pytest.mark.anyio
+async def test_get_transcript_utterances_rejects_bad_cursor_and_foreign_recording(
+    session_maker, test_user: User, mcp_context
+):
+    bind_mcp_identity(test_user)
+    await seed_person(session_maker, person_id=11, name="Dana", user_id=999)
+    public_id = await seed_recording_with_speakers(session_maker, user_id=999)
+    await seed_canonical_transcript(session_maker)
+
+    with pytest.raises(ToolError):
+        await get_transcript_utterances(public_id, after_revision=-1)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_transcript_utterances(public_id)
+    assert exc_info.value.status_code == 404
 
 
 @pytest.mark.anyio
@@ -1049,7 +1305,7 @@ async def test_append_meeting_notes_rejects_empty_text_and_read_only(
 
 # --- tool-call logging -----------------------------------------------------
 
-MCP_LOGGER = "backend.mcp_server.server"
+MCP_LOGGER = "backend.mcp_server.tool_logging"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_oauth_mcp_connector.py
+++ b/backend/tests/test_oauth_mcp_connector.py
@@ -713,6 +713,7 @@ async def test_mcp_protocol_tools_list_end_to_end(
     assert tool_names == {
         "list_recordings",
         "get_transcript",
+        "get_transcript_utterances",
         "get_meeting_notes",
         "list_tags",
         "get_speakers",

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -41,8 +41,9 @@ Claude Code discovers the OAuth flow automatically and opens a browser window fo
 
 | Tool | Scope | Description |
 | --- | --- | --- |
-| `list_recordings` | `mcp:read` | List and search recordings with free-text and date filters; covers archived and soft-deleted meetings by default. |
-| `get_transcript` | `mcp:read` | Full speaker-attributed transcript of a recording. |
+| `list_recordings` | `mcp:read` | List and search recordings with free-text and date filters; covers archived and soft-deleted meetings by default. Each result reports processing state (`status`, `transcript_status`, `notes_status`), `updated_at`, and the canonical `transcript_revision` cursor. |
+| `get_transcript` | `mcp:read` | Full speaker-attributed transcript of a recording, formatted for reading. |
+| `get_transcript_utterances` | `mcp:read` | The canonical transcript as structured utterances: stable ids, millisecond timestamps, per-utterance state and edit provenance, and a revision cursor with tombstones for incremental sync. |
 | `get_meeting_notes` | `mcp:read` | AI-generated meeting notes plus your own manual notes. |
 | `get_documents` | `mcp:read` | The documents attached to a recording, with their extracted text. |
 | `get_speakers` | `mcp:read` | The speakers in a recording, with links to their People records. |
@@ -56,6 +57,10 @@ Claude Code discovers the OAuth flow automatically and opens a browser window fo
 All tools operate only on data owned by the account that authorised the connection. The write tools are additive: `import_people` fills in or updates a person's title, company, email, phone number, notes, and tags; `set_speaker_name` names a diarised speaker and links it to a matching person (importing the person first, if needed, lets it link rather than set a recording-local name); `append_meeting_notes` adds to your own meeting notes without altering the AI-generated notes. None of them delete data or modify voiceprints.
 
 Connections authorised before the write scope existed carry only the `mcp:read` scope: every read tool keeps working, and the write tools respond with an instruction to reconnect. Remove and re-add the connector to consent to the wider scope.
+
+### Keeping an External Copy in Sync
+
+`get_transcript_utterances` exists for tools that maintain their own copy of transcript data, such as a read-only sidecar or knowledge base, rather than for conversational assistants, which should prefer `get_transcript`. Poll `list_recordings` and compare each recording's `transcript_revision` (and `notes_status`) with the last value you stored, then call `get_transcript_utterances` with your stored cursor as `after_revision` to receive only changed utterances plus tombstones. A recording is fully processed once `status` is `PROCESSED` and `notes_status` is `completed`. Treat the cursor as opaque and the response fields as an additive contract: new fields may appear over time, and reprocessing a recording can replace most utterance ids while the cursor keeps increasing.
 
 ## Managing and Revoking Access
 


### PR DESCRIPTION
# Pull Request

## Description

Adds a `get_transcript_utterances` MCP tool exposing the canonical transcript contract that until now only the web client consumed: stable utterance ids, millisecond timestamps, per-utterance state, revision and edit-provenance flags, the recording's speaker list, a recording-level revision cursor, and tombstones for removed or superseded utterances. Passing the cursor back as `after_revision` returns only what changed since then, with an empty delta when the cursor is current.

`list_recordings` now also reports `transcript_status`, `notes_status`, `updated_at`, and the `transcript_revision` cursor, so a polling client can detect completed processing (`status` PROCESSED plus `notes_status` completed) and transcript changes without fetching any transcript. The cursor is computed with one grouped aggregate per result page rather than a query per recording.

The tool delegates to the same endpoint coroutine the REST API uses, so ownership checks and cursor semantics cannot drift from the web client. The response contract is additive-only: new fields may appear over time, and `docs/MCP.md` documents the polling flow, the PROCESSED-plus-completed readiness rule, and the fact that reprocessing can replace utterance ids while the cursor keeps increasing.

Mechanical consequence: the tool call-logging wrapper moved to `backend/mcp_server/tool_logging.py` to keep `server.py` under the 1000-line file-size gate. `after_revision` is logged verbatim as an identifier-class argument.

No new dependencies.

Fixes #189

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test`
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR (`docs/MCP.md`: tool table entries and a new "Keeping an External Copy in Sync" section).

## Security impact

- [x] No security-sensitive change. The tool requires the existing `mcp:read` scope, reuses the REST endpoint's `_get_owned_recording` ownership check, and returns no data the authorised user cannot already read. Log redaction policy is unchanged; the moved logging wrapper is verbatim apart from the new identifier-class argument.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Unit and end-to-end protocol tests cover the tool registration, full snapshot, delta with tombstones, up-to-date cursor, invalid cursor, foreign-recording rejection, and the new `list_recordings` fields against seeded canonical data. Not yet exercised from a live MCP client against a running deployment; planned as a post-merge smoke test alongside the next deploy.

## Screenshots (if relevant)

Not applicable.