### PR TITLE
fix(chat): constrain tag-widened retrieval to the caller's recordings

### DIFF
--- a/backend/api/v1/endpoints/transcripts/routes_chat.py
+++ b/backend/api/v1/endpoints/transcripts/routes_chat.py
@@ -91,6 +91,23 @@ async def clear_chat_history(
     return {"status": "success"}
 
 
+def _tag_context_recording_ids(tag_ids: list[int], user_id: int):
+    """Recording ids allowed to widen chat retrieval by tag.
+
+    Tag ids arrive from the client, so the widening must stay inside the
+    caller's own recordings: without the ownership join, any tag id would
+    pull other users' context chunks into the retrieval pool.
+    """
+    return (
+        select(RecordingTag.recording_id)
+        .join(Recording, Recording.id == RecordingTag.recording_id)
+        .where(
+            RecordingTag.tag_id.in_(tag_ids),
+            Recording.user_id == user_id,
+        )
+    )
+
+
 @router.post("/{recording_id}/chat")
 async def chat_with_meeting(
     recording_id: str,
@@ -164,9 +181,7 @@ async def chat_with_meeting(
         # 2. Build Query Condition
         if request.tag_ids:
             # Identify relevant recordings from tags
-            subquery = select(RecordingTag.recording_id).where(
-                RecordingTag.tag_id.in_(request.tag_ids)
-            )
+            subquery = _tag_context_recording_ids(request.tag_ids, current_user.id)
             condition = (ContextChunk.recording_id.in_(subquery)) | (
                 ContextChunk.recording_id == recording.id
             )

--- a/backend/tests/test_chat_tag_context_ownership.py
+++ b/backend/tests/test_chat_tag_context_ownership.py
@@ -1,0 +1,143 @@
+"""Ownership regression test for tag-widened chat retrieval.
+
+The chat endpoint widens RAG retrieval to recordings carrying the tag ids
+the client supplies. Those ids are caller-controlled, so the widening query
+must be constrained to the caller's own recordings; before the ownership
+join was added, any tag id (including another user's) pulled that user's
+recordings into the retrieval pool. The pgvector search itself cannot run
+on SQLite, so this exercises the widening subquery directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.api.v1.endpoints.transcripts.routes_chat import (
+    _tag_context_recording_ids,
+)
+
+# Register every ORM model so mappers configure via the recording/user FKs.
+from backend.models import registry  # noqa: F401
+
+_SCHEMA = """
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY, created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL,
+    username VARCHAR NOT NULL, hashed_password VARCHAR NOT NULL, is_active BOOLEAN NOT NULL,
+    is_superuser BOOLEAN NOT NULL, force_password_change BOOLEAN NOT NULL, role VARCHAR NOT NULL,
+    token_version INTEGER NOT NULL, settings JSON, has_seen_demo_recording BOOLEAN NOT NULL,
+    has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
+    invitation_id INTEGER
+);
+CREATE TABLE recordings (
+    max_speakers INTEGER,
+    id INTEGER PRIMARY KEY, created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL,
+    name VARCHAR(255) NOT NULL, public_id VARCHAR(36) NOT NULL, meeting_uid VARCHAR(36) NOT NULL,
+    audio_path VARCHAR(1024) NOT NULL, proxy_path VARCHAR(1024), celery_task_id VARCHAR(255),
+    duration_seconds FLOAT, file_size_bytes INTEGER, status VARCHAR(32) NOT NULL,
+    client_status VARCHAR(32), upload_progress INTEGER NOT NULL, processing_progress INTEGER NOT NULL,
+    processing_step VARCHAR(255), processing_started_at TIMESTAMP, processing_completed_at TIMESTAMP,
+    pipeline_generation VARCHAR(32) DEFAULT 'unified', is_archived BOOLEAN NOT NULL,
+    is_deleted BOOLEAN NOT NULL, last_activity_at TIMESTAMP, user_id INTEGER, calendar_event_id INTEGER
+);
+CREATE TABLE tags (
+    id INTEGER PRIMARY KEY, created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL,
+    name VARCHAR(255) NOT NULL, color VARCHAR(64), user_id INTEGER, parent_id INTEGER
+);
+CREATE TABLE recording_tags (
+    id INTEGER PRIMARY KEY, created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL,
+    recording_id INTEGER NOT NULL, tag_id INTEGER NOT NULL
+);
+"""
+
+_NOW = "2026-08-01 00:00:00"
+
+
+async def _make_session_maker():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        for statement in _SCHEMA.split(";"):
+            if statement.strip():
+                await conn.execute(text(statement))
+        for user_id, username in ((1, "owner"), (2, "other")):
+            await conn.execute(
+                text(
+                    "INSERT INTO users (id, created_at, updated_at, username, "
+                    "hashed_password, is_active, is_superuser, force_password_change, "
+                    "role, token_version, settings, has_seen_demo_recording) "
+                    "VALUES (:id, :n, :n, :username, 'x', 1, 0, 0, 'user', 0, '{}', 0)"
+                ),
+                {"id": user_id, "n": _NOW, "username": username},
+            )
+        for rec_id, user_id in ((1, 1), (2, 1), (3, 2)):
+            await conn.execute(
+                text(
+                    "INSERT INTO recordings (id, created_at, updated_at, name, "
+                    "public_id, meeting_uid, audio_path, status, upload_progress, "
+                    "processing_progress, is_archived, is_deleted, user_id) "
+                    "VALUES (:id, :n, :n, :name, :pid, :uid, :path, 'PROCESSED', "
+                    "100, 100, 0, 0, :user_id)"
+                ),
+                {
+                    "id": rec_id,
+                    "n": _NOW,
+                    "name": f"Rec {rec_id}",
+                    "pid": f"p{rec_id}",
+                    "uid": f"m{rec_id}",
+                    "path": f"/a{rec_id}.wav",
+                    "user_id": user_id,
+                },
+            )
+        for tag_id, user_id in ((1, 1), (2, 2)):
+            await conn.execute(
+                text(
+                    "INSERT INTO tags (id, created_at, updated_at, name, user_id) "
+                    "VALUES (:id, :n, :n, :name, :user_id)"
+                ),
+                {"id": tag_id, "n": _NOW, "name": f"Tag {tag_id}", "user_id": user_id},
+            )
+        # User 1's tag on recordings 1 and 2; user 2's tag on recording 3.
+        for link_id, rec_id, tag_id in ((1, 1, 1), (2, 2, 1), (3, 3, 2)):
+            await conn.execute(
+                text(
+                    "INSERT INTO recording_tags (id, created_at, updated_at, "
+                    "recording_id, tag_id) VALUES (:id, :n, :n, :rec, :tag)"
+                ),
+                {"id": link_id, "n": _NOW, "rec": rec_id, "tag": tag_id},
+            )
+    return engine, sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+def test_own_tags_widen_to_own_recordings_only():
+    async def _run():
+        engine, maker = await _make_session_maker()
+        async with maker() as session:
+            result = await session.execute(_tag_context_recording_ids([1], 1))
+            assert sorted(result.scalars().all()) == [1, 2]
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_foreign_tag_ids_widen_to_nothing():
+    async def _run():
+        engine, maker = await _make_session_maker()
+        async with maker() as session:
+            # User 1 supplies user 2's tag id: recording 3 must not appear.
+            result = await session.execute(_tag_context_recording_ids([2], 1))
+            assert result.scalars().all() == []
+
+            # Both ids at once still only reach user 1's own recordings.
+            result = await session.execute(_tag_context_recording_ids([1, 2], 1))
+            assert sorted(result.scalars().all()) == [1, 2]
+        await engine.dispose()
+
+    asyncio.run(_run())


### PR DESCRIPTION
# Pull Request

## Description

The tag-scoped cross-meeting chat feature widens vector retrieval to recordings carrying the tag ids supplied in the chat request. That widening subquery had no ownership constraint: on a multi-user instance, a caller could pass another user's tag id and pull that user's transcript and document chunks into their own chat context. The single-recording path was unaffected (it goes through the owned-recording check); only the tag-widened pool leaked.

The widening subquery now joins recordings and filters on the calling user's id, so client-supplied tag ids can only ever reach the caller's own recordings. The subquery is extracted into a named helper (`_tag_context_recording_ids`) with a direct regression test covering both directions: own tags still widen to own recordings, and foreign tag ids widen to nothing. The pgvector search itself cannot execute against the SQLite test database, which is why the test exercises the widening query rather than the full endpoint.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test`
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required. The fix restores the documented per-user ownership boundary rather than changing any documented behaviour.
- [ ] Updated the relevant guide(s) in the same PR.

## Security impact

- [ ] No security-sensitive change.
- [x] Touches auth, tokens, encryption, capture ownership, or exposure. This closes a cross-user data exposure in tag-widened chat retrieval. `docs/SECURITY.md` boundaries are preserved and now enforced on this path; no boundary described there changed, so no doc update is needed.

## Manual verification

Regression tests cover the widening query directly against a seeded two-user database. Not separately smoke-tested in a browser: the only behavioural change for a legitimate single-user flow is none (own tags return the same recording set), and the multi-user leak requires a second account to reproduce, which the test covers.

## Screenshots (if relevant)

Not applicable.