### PR TITLE
feat(mcp): page get_transcript_utterances responses

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -330,6 +330,8 @@ async def get_transcript(recording_id: str) -> dict[str, Any]:
 async def get_transcript_utterances(
     recording_id: str,
     after_revision: Optional[int] = None,
+    limit: int = 100,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """Get the canonical transcript as structured utterances with delta sync.
 
@@ -350,11 +352,20 @@ async def get_transcript_utterances(
     reflects current names, so speaker renames are visible even when no
     utterance changed.
 
+    Long transcripts are paged: `utterances` holds at most `limit` entries
+    starting at `offset`, `total_utterances` is the full match count, and
+    `next_offset` is the offset of the next page, or null when this page is
+    the last. `tombstones` and `speakers` are complete on every page. Pages
+    are consistent only within one `revision`: if `revision` differs between
+    pages, the transcript changed mid-read, so restart from offset 0.
+
     Args:
         recording_id: The recording's string id from list_recordings.
         after_revision: The last `revision` cursor already seen, from a
             previous call or from list_recordings' `transcript_revision`.
             Omit for a full snapshot.
+        limit: Maximum utterances per page (1-500, default 100).
+        offset: Number of matching utterances to skip, for pagination.
     """
     from backend.api.v1.endpoints.transcripts.routes_utterances import (
         get_transcript_utterances as api_get_transcript_utterances,
@@ -364,6 +375,8 @@ async def get_transcript_utterances(
     user = get_current_mcp_user()
     if after_revision is not None and after_revision < 0:
         raise ToolError("after_revision must be a non-negative integer.")
+    limit = max(1, min(int(limit), 500))
+    offset = max(0, int(offset))
 
     async with async_session_maker() as db:
         payload = await api_get_transcript_utterances(
@@ -373,7 +386,13 @@ async def get_transcript_utterances(
             current_user=user,
         )
 
-    return payload.model_dump()
+    result = payload.model_dump()
+    utterances = result["utterances"]
+    page_end = offset + limit
+    result["utterances"] = utterances[offset:page_end]
+    result["total_utterances"] = len(utterances)
+    result["next_offset"] = page_end if page_end < len(utterances) else None
+    return result
 
 
 @mcp_tool()

--- a/backend/mcp_server/tool_logging.py
+++ b/backend/mcp_server/tool_logging.py
@@ -31,6 +31,7 @@ _LOGGABLE_ARG_NAMES = frozenset(
         "on_conflict",
         "limit",
         "skip",
+        "offset",
         "start_date",
         "end_date",
         "after_revision",

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -779,10 +779,45 @@ async def test_get_transcript_utterances_full_snapshot(
     assert first["state"] == "stable"
     assert first["text_manually_edited"] is False
     assert result["tombstones"] == []
+    assert result["total_utterances"] == 2
+    assert result["next_offset"] is None
     assert {s["diarization_label"] for s in result["speakers"]} == {
         "SPEAKER_00",
         "SPEAKER_01",
     }
+
+
+@pytest.mark.anyio
+async def test_get_transcript_utterances_pages_with_limit_and_offset(
+    session_maker, test_user: User, mcp_context
+):
+    """Long transcripts page: each page slices utterances only, while the
+    revision, tombstones, and speakers stay complete on every page."""
+    bind_mcp_identity(test_user)
+    await seed_person(session_maker, person_id=11, name="Dana", user_id=test_user.id)
+    public_id = await seed_recording_with_speakers(session_maker, user_id=test_user.id)
+    await seed_canonical_transcript(session_maker)
+
+    first_page = await get_transcript_utterances(public_id, limit=1)
+    assert [u["id"] for u in first_page["utterances"]] == ["u-1"]
+    assert first_page["total_utterances"] == 2
+    assert first_page["next_offset"] == 1
+    assert first_page["revision"] == 3
+    assert len(first_page["speakers"]) == 2
+
+    second_page = await get_transcript_utterances(
+        public_id, limit=1, offset=first_page["next_offset"]
+    )
+    assert [u["id"] for u in second_page["utterances"]] == ["u-2"]
+    assert second_page["next_offset"] is None
+    assert second_page["revision"] == 3
+    assert len(second_page["speakers"]) == 2
+
+    # Out-of-range offset yields an empty page, not an error.
+    past_end = await get_transcript_utterances(public_id, offset=10)
+    assert past_end["utterances"] == []
+    assert past_end["total_utterances"] == 2
+    assert past_end["next_offset"] is None
 
 
 @pytest.mark.anyio

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -62,6 +62,8 @@ Connections authorised before the write scope existed carry only the `mcp:read` 
 
 `get_transcript_utterances` exists for tools that maintain their own copy of transcript data, such as a read-only sidecar or knowledge base, rather than for conversational assistants, which should prefer `get_transcript`. Poll `list_recordings` and compare each recording's `transcript_revision` (and `notes_status`) with the last value you stored, then call `get_transcript_utterances` with your stored cursor as `after_revision` to receive only changed utterances plus tombstones. A recording is fully processed once `status` is `PROCESSED` and `notes_status` is `completed`. Treat the cursor as opaque and the response fields as an additive contract: new fields may appear over time, and reprocessing a recording can replace most utterance ids while the cursor keeps increasing.
 
+Responses are paged, because a full snapshot of a long meeting easily exceeds an assistant's tool-output budget: `utterances` carries at most `limit` entries (1-500, default 100) starting at `offset`, `total_utterances` is the full count, and `next_offset` is the next page's offset, or null on the last page. `tombstones` and `speakers` are complete on every page. Pages are only consistent within a single `revision`: if `revision` changes between pages, the transcript moved mid-read, so restart from offset 0. Deltas are usually a single page; the calls that need paging are the first snapshot and the delta after a reprocess.
+
 ## Managing and Revoking Access
 
 - **Settings → Integrations → Connected apps** lists every active connection with its scope, creation time, and last use, and offers per-connection revocation.


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #190 from live smoke testing: a full snapshot of a one-hour meeting (359 utterances) serialised to roughly 236k characters and exceeded the assistant's tool-output budget. The unpaged shape would have done the same on every first sync of a long meeting, and on the mass delta after a reprocess.

`get_transcript_utterances` now pages the `utterances` array with `limit` (1-500, default 100) and `offset`, reporting `total_utterances` and `next_offset` (null on the last page). `tombstones` and `speakers` remain complete on every page, so tombstone application and speaker-rename visibility are unaffected by paging. Pages are consistent only within a single `revision`: the documented client rule is to restart from offset 0 if the cursor moves between pages, which is the same reconciliation discipline a delta consumer already needs. Deltas are typically a single page; paging matters for the first snapshot and post-reprocess deltas.

`docs/MCP.md` documents the paging contract, and `offset` joins the identifier-class arguments logged verbatim. Additive only: existing fields and semantics are unchanged, so nothing built against #190's shape breaks.

Refs #189

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

No frontend files are touched; frontend checks were not rerun for this branch.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR (`docs/MCP.md`: paging contract in the external-sync section).

## Security impact

- [x] No security-sensitive change. Paging slices the already-authorised response; ownership checks and scopes are unchanged.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

The pre-paging tool was smoke-tested live from Claude Desktop against a real deployment (snapshot, delta, and up-to-date cursor all correct), which is where the oversized payload was observed. Paging itself is covered by unit tests (page boundaries, next_offset, out-of-range offset, speakers and revision on every page); a live re-test of a paged first sync is pending the next deploy.

## Screenshots (if relevant)

Not applicable.