### PR TITLE
fix(mcp): stamp grant usage so Connected Apps stops showing Never

### DIFF
--- a/backend/api/services/oauth_service.py
+++ b/backend/api/services/oauth_service.py
@@ -25,6 +25,7 @@ from datetime import timedelta
 from typing import Any, Optional
 from urllib.parse import urlparse
 
+from sqlalchemy import or_, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -292,7 +293,9 @@ def _verify_pkce(code_challenge: str, code_verifier: str) -> bool:
     return secrets.compare_digest(computed, code_challenge)
 
 
-def _build_access_token(user: User, *, client_id: str, scope: str) -> tuple[str, int]:
+def _build_access_token(
+    user: User, *, client_id: str, scope: str, grant_id: str
+) -> tuple[str, int]:
     expires_in = security.MCP_TOKEN_EXPIRE_MINUTES * 60
     token = security.create_access_token(
         user.username,
@@ -304,6 +307,9 @@ def _build_access_token(user: User, *, client_id: str, scope: str) -> tuple[str,
             # Custom claim (not "aud": python-jose rejects tokens carrying
             # "aud" unless every decode call passes an audience option).
             "res": mcp_resource_url(),
+            # Lets the MCP endpoint attribute a request to its consent grant
+            # so Connected Apps can show when the grant was actually used.
+            "grant_id": grant_id,
         },
     )
     return token, expires_in
@@ -380,10 +386,11 @@ async def exchange_authorization_code(
     record.used_at = utc_now()
     user = await _load_user(db, record.user_id)
 
+    grant_id = uuid.uuid4().hex
     refresh_token = await _issue_refresh_token(
         db,
         RefreshGrant(
-            grant_id=uuid.uuid4().hex,
+            grant_id=grant_id,
             client_id=client_id,
             user_id=user.id,
             scope=record.scope,
@@ -394,7 +401,7 @@ async def exchange_authorization_code(
     await db.commit()
 
     access_token, expires_in = _build_access_token(
-        user, client_id=client_id, scope=record.scope
+        user, client_id=client_id, scope=record.scope, grant_id=grant_id
     )
     return {
         "access_token": access_token,
@@ -455,7 +462,7 @@ async def refresh_access_token(
     await db.commit()
 
     access_token, expires_in = _build_access_token(
-        user, client_id=client_id, scope=record.scope
+        user, client_id=client_id, scope=record.scope, grant_id=record.grant_id
     )
     return {
         "access_token": access_token,
@@ -477,6 +484,40 @@ async def revoke_grant(db: AsyncSession, *, grant_id: str) -> int:
             revoked += 1
     await db.commit()
     return revoked
+
+
+# One write per grant per interval keeps the usage stamp off the hot path:
+# a busy assistant makes many tool calls per minute, and per-request writes
+# to the busiest auth table would buy no extra precision the UI can show.
+GRANT_LAST_USED_THROTTLE_SECONDS = 60
+
+
+async def touch_grant_last_used(db: AsyncSession, grant_id: str) -> None:
+    """Record connector usage on the grant's active refresh-token row.
+
+    Rotation stamps last_used_at only on rows it simultaneously revokes, so
+    without this the Connected Apps view can never show a last-used time:
+    the value only ever exists on rows its query excludes. Stamping the
+    active row on authenticated /mcp requests makes "last used" mean what
+    it says — the last actual tool traffic, not the last token rotation.
+    """
+    now = utc_now()
+    threshold = (now - timedelta(seconds=GRANT_LAST_USED_THROTTLE_SECONDS)).replace(
+        tzinfo=None
+    )
+    await db.execute(
+        update(OAuthRefreshToken)
+        .where(
+            OAuthRefreshToken.grant_id == grant_id,
+            OAuthRefreshToken.revoked_at.is_(None),  # type: ignore[union-attr]
+            or_(
+                OAuthRefreshToken.last_used_at.is_(None),  # type: ignore[union-attr]
+                OAuthRefreshToken.last_used_at < threshold,
+            ),
+        )
+        .values(last_used_at=now)
+    )
+    await db.commit()
 
 
 async def list_active_grants(db: AsyncSession, *, user_id: int) -> list[dict[str, Any]]:

--- a/backend/mcp_server/auth.py
+++ b/backend/mcp_server/auth.py
@@ -242,7 +242,10 @@ class MCPAuthMiddleware:
         # Imported lazily so importing this module never drags the DB layer
         # into contexts (tests, tooling) that only need the contextvar.
         from backend.api.deps import get_authenticated_token_details
-        from backend.api.services.oauth_service import mcp_resource_url
+        from backend.api.services.oauth_service import (
+            mcp_resource_url,
+            touch_grant_last_used,
+        )
         from backend.core.db import async_session_maker
 
         try:
@@ -279,6 +282,17 @@ class MCPAuthMiddleware:
         granted_scopes = frozenset(
             item for item in (token_scopes or []) if isinstance(item, str)
         )
+
+        # Best-effort usage stamp for the Connected Apps view, throttled in
+        # the service. Tokens issued before the grant_id claim existed skip
+        # it, and no failure here may cost the request itself.
+        grant_id = payload.get("grant_id")
+        if isinstance(grant_id, str) and grant_id:
+            try:
+                async with async_session_maker() as db:
+                    await touch_grant_last_used(db, grant_id)
+            except Exception:  # noqa: BLE001 - usage telemetry must never 500
+                logger.warning("Failed to record MCP grant usage.", exc_info=True)
 
         context_token = current_mcp_user.set(user)
         scopes_token = current_mcp_scopes.set(granted_scopes)

--- a/backend/tests/test_oauth_mcp_connector.py
+++ b/backend/tests/test_oauth_mcp_connector.py
@@ -358,6 +358,9 @@ async def test_full_authorization_code_flow(
     assert payload["sub"] == test_user.username
     assert payload["res"] == f"{TEST_ORIGIN}/mcp"
     assert payload["tv"] == test_user.token_version
+    # The access token names its consent grant so /mcp requests can stamp
+    # the grant's last-used time for the Connected Apps view.
+    assert payload["grant_id"]
 
     # Codes are single-use.
     replay = await client.post(
@@ -656,6 +659,93 @@ async def test_mcp_token_dies_on_token_version_bump(
             "/", json={}, headers={"Authorization": f"Bearer {token}"}
         )
     assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_authenticated_requests_stamp_grant_last_used(
+    monkeypatch, fixed_origin, isolated_keyring, session_maker, test_user: User
+):
+    """An authenticated /mcp request stamps the grant's active refresh row.
+
+    Rotation only ever writes last_used_at onto rows it simultaneously
+    revokes, which the Connected Apps query excludes, so without this stamp
+    the view shows "Never" forever. The stamp is throttled, and tokens
+    issued before the grant_id claim existed skip it without failing.
+    """
+    from datetime import timedelta
+
+    import backend.core.db as core_db
+    from backend.models.oauth import OAuthClient, OAuthRefreshToken
+    from backend.utils.time import utc_now
+
+    monkeypatch.setattr(core_db, "async_session_maker", session_maker)
+
+    async with session_maker() as session:
+        session.add(
+            OAuthClient(client_id="abc", client_name="Codex", redirect_uris="[]")
+        )
+        session.add(
+            OAuthRefreshToken(
+                token_hash="h1",
+                grant_id="grant-1",
+                client_id="abc",
+                user_id=test_user.id,
+                scope="mcp:read mcp:write",
+                resource=f"{TEST_ORIGIN}/mcp",
+                expires_at=utc_now() + timedelta(days=1),
+            )
+        )
+        await session.commit()
+
+    def make_token(extra_claims: dict) -> str:
+        return security.create_access_token(
+            test_user.username,
+            token_type=security.MCP_TOKEN_TYPE,
+            scopes=[security.MCP_READ_SCOPE],
+            token_version=test_user.token_version,
+            extra_claims={"client_id": "abc", "res": f"{TEST_ORIGIN}/mcp"}
+            | extra_claims,
+        )
+
+    token = make_token({"grant_id": "grant-1"})
+    legacy_token = make_token({})
+
+    async def read_stamp():
+        async with session_maker() as session:
+            row = await session.get(OAuthRefreshToken, "h1")
+            return row.last_used_at
+
+    transport = ASGITransport(app=_build_mcp_test_app({}))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        first = await c.post("/", json={}, headers={"Authorization": f"Bearer {token}"})
+        assert first.status_code == 200
+        stamped = await read_stamp()
+        assert stamped is not None
+
+        # Within the throttle window a second request leaves the stamp alone.
+        second = await c.post(
+            "/", json={}, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert second.status_code == 200
+        assert await read_stamp() == stamped
+
+        # Outside the window (throttle forced to zero) the stamp advances.
+        monkeypatch.setattr(oauth_service, "GRANT_LAST_USED_THROTTLE_SECONDS", 0)
+        third = await c.post("/", json={}, headers={"Authorization": f"Bearer {token}"})
+        assert third.status_code == 200
+        assert await read_stamp() >= stamped
+
+        # Tokens issued before the claim existed still authenticate.
+        legacy = await c.post(
+            "/", json={}, headers={"Authorization": f"Bearer {legacy_token}"}
+        )
+        assert legacy.status_code == 200
+
+    # The Connected Apps listing now surfaces the usage.
+    async with session_maker() as session:
+        grants = await oauth_service.list_active_grants(session, user_id=test_user.id)
+    assert [g["grant_id"] for g in grants] == ["grant-1"]
+    assert grants[0]["last_used_at"] is not None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

The Connected Apps section reported "Last used Never" for connectors with heavy real traffic (observed live with both Claude and Codex). Root cause: `list_active_grants` aggregates `last_used_at` over the grant's **non-revoked** refresh-token rows, but rotation stamps `last_used_at` on the row it revokes in the same motion — so the only rows ever carrying a value are exactly the rows the query excludes. Tool calls authenticate with access tokens, which never touched these rows at all. The view was structurally incapable of showing anything but "Never".

Fix, per the fuller of the two remedies discussed: make "last used" mean actual connector traffic.

- MCP access tokens now carry a `grant_id` claim (both issuance paths: authorization-code exchange and refresh).
- The `/mcp` bearer middleware stamps the grant's active refresh-token row on authenticated requests via a new `touch_grant_last_used` service helper: a single conditional UPDATE, throttled to one write per grant per minute, best-effort (failure logs a warning and never fails the request).
- No schema change and no migration — the stamp reuses the existing `last_used_at` column on the active row, which the Connected Apps query already reads, so the listing and frontend need no changes.
- Backwards compatible: tokens issued before the claim existed authenticate unchanged and skip the stamp; they gain the claim at their next refresh (within the access-token lifetime), after which the view populates.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1316 passed, via `scripts/check.py`)
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: not run — no frontend change (CI runs it)
- [ ] Frontend unit tests: not run — no frontend change (CI runs it)
- [ ] Frontend build: not run — no frontend change (CI runs it)
- [x] Docs validation: `python3 scripts/validate_docs.py` (via `scripts/check.py`)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (via `scripts/check.py`)

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required (no documented behaviour changes; the Connected Apps view now does what it already claimed).
- [ ] Updated the relevant guide(s) in the same PR.

## Security impact

- [x] No security-sensitive change: the claim is additive metadata inside an already-signed token, the stamp is a best-effort write after full authentication, and no authorisation decision reads it.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Protocol-level test covers the full behaviour (stamp on authenticated request, throttle holds within the window and advances outside it, legacy tokens without the claim still authenticate, and the Connected Apps listing surfaces the stamp). Live verification after deploy: make a tool call from Claude or Codex, wait for the client's next token refresh if the grant predates this change, and confirm the Connected Apps row shows a recent "Last used".

## Screenshots (if relevant)

None.
