### PR TITLE
feat(frontend): small-screen space control and collapsible panels

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -286,7 +286,12 @@ what forced five panels into one long scroll.
 **A panel that subdivides must query itself, not the window.** Meeting Edge splits into two lists
 side by side, and did so at the `xl` *viewport* breakpoint: at a 1280px window it subdivided a
 400px column and wrapped both lists to three words a line. Any `grid-cols` inside a panel that can
-land in a column belongs behind a container query on that panel.
+land in a column belongs behind a container query on that panel. Settings now complies wholesale:
+`SettingsBlock` and `SettingsCard` are containers, `SettingsRow` switches its label-beside-control
+layout on its own width, and every grid under `components/settings/` queries its block or card.
+The calendar provider credentials card is the cautionary tale: its two-provider grid engaged on
+the `lg` viewport inside a 768px-capped column, leaving the label side of every row about 24px at
+every window width — a layout that was unsatisfiable, not merely tight.
 
 **These are container queries against the workspace, not media queries against the viewport**, and
 that distinction is load-bearing. The nav rail is roughly 340px, resizable and collapsible, so the
@@ -336,6 +341,17 @@ a separate sequence, set with a container-query `order` override where the two d
 what keeps a phone opening on the record button while a desktop leads its middle column with the
 task list.
 
+### Collapsible surfaces
+
+Both rails and both meeting side panels collapse, and every collapse state persists in the
+navigation store (`navigation-storage`). The pattern is uniform: the collapse control lives in the
+surface's own header, a slim strip carries the re-open affordance when nothing else is left, and
+nothing auto-collapses — the user decides, the choice survives a reload, and mobile keeps its own
+layouts (drawer, full-width list, tabs) untouched. The meeting view's Speakers and Chat panels
+collapse independently; collapsing one gives the other the full column height, and collapsing both
+reduces the right column to an icon strip. The recordings rail collapses to the same strip width
+as the nav rail so the two align.
+
 ### Surface nesting
 
 The flat canon's two-level rule, as a fix pattern. When a surface turns out to be nested, it steps
@@ -379,6 +395,7 @@ tokens exclusively. Build a surface out of these rather than out of raw elements
 | `Input`, `Select` | Form fields. Both draw on the shared `fieldChrome` helper, so they cannot drift apart. `Select` is a native select, because the mobile pass wants the platform picker on a phone; see `color-scheme` below for what that costs. |
 | `Modal` | Every dialog. Wraps the Headless UI dialog, so the focus trap, scroll lock, Escape handling and portal come from a maintained implementation. Adds the plain scrim, the float surface and shadow, a token z-index, and the height cap and viewport gutter that stop a tall modal pushing its own actions below the fold on a phone. |
 | `Switch`, `Tooltip`, `ModernDatePicker`, `MultiSelect` | Pre-existing widgets, restyled onto tokens. |
+| `FitText` | A single line that must fit its container, meaning the meeting title. Steps the font from a designed size down to a readability floor, then wraps to two clamped lines. CSS cannot do this: `clamp()` tracks the container's size, never the text's own length. |
 
 ## Typography
 
@@ -397,6 +414,19 @@ font class is absent entirely.
 
 There is no need to add a `font-sans` class to reach the body font; an element only needs one when
 it is overriding something else back to the default.
+
+### The heading scale
+
+`density-heading-page` and `density-heading-section` carry the fluid heading sizes: a viewport
+clamp below the desktop breakpoint, and a second clamp under compact desktop density. Their
+font-size declarations live *outside* the cascade layers on purpose. Inside `@layer components`
+they lose to the `text-*` utilities on the same elements, because the utilities layer is declared
+after components and layer order beats selector specificity — which is exactly how the compact
+scaling originally shipped inert. Keep them unlayered, and keep each clamp's upper bound at the
+largest `text-*` size the class is paired with, so a clamp only ever steps a heading down.
+
+Where a heading must respond to its own content rather than to its container — the meeting title
+is the case — CSS cannot help, and the `FitText` primitive measures and fits instead.
 
 Lucide is the sole icon system.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -240,6 +240,13 @@ Processed recordings can include Markdown notes, AI-generated meeting notes, mee
 - **Documents** can be uploaded to support meeting context, meeting notes, and later search.
 - **Search** spans recordings, transcript text, notes, tags, and document content where available.
 
+On desktop, the Speakers and Chat panels sit in a resizable column to the right of the transcript
+and notes. Each collapses independently from the control in its header: collapsing one gives the
+other the full column height, and collapsing both reduces the column to a slim strip of icons that
+restores them. The recordings list can likewise be collapsed from the control beside its search
+box. All of these choices persist across visits, so a laptop can keep the full width for reading a
+transcript without giving the panels up for good.
+
 ### Attaching Documents
 
 Upload PDF, PowerPoint, Word, Excel, CSV, text, Markdown, or image files, up to 250 MB each. Documents can be attached at any point: from the Documents tab of a processed meeting, or from the Documents panel that appears below the live transcript while a meeting is still recording or processing.

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -110,9 +110,9 @@ export default function LoginPage() {
               </div>
               <input
                 id="login-username"
-                name="login-username"
+                name="username"
                 type="text"
-                autoComplete="section-login username"
+                autoComplete="username"
                 autoCapitalize="none"
                 autoCorrect="off"
                 spellCheck={false}
@@ -134,9 +134,9 @@ export default function LoginPage() {
               </div>
               <input
                 id="login-current-password"
-                name="login-current-password"
+                name="password"
                 type="password"
-                autoComplete="section-login current-password"
+                autoComplete="current-password"
                 aria-describedby={error ? "login-error" : undefined}
                 aria-invalid={Boolean(error)}
                 required

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -132,7 +132,7 @@ function RegisterForm() {
                 id="register-username"
                 name="register-username"
                 type="text"
-                autoComplete="section-register username"
+                autoComplete="username"
                 autoCapitalize="none"
                 autoCorrect="off"
                 spellCheck={false}
@@ -157,7 +157,7 @@ function RegisterForm() {
                 id="register-new-password"
                 name="register-new-password"
                 type="password"
-                autoComplete="section-register new-password"
+                autoComplete="new-password"
                 aria-describedby={error ? 'register-error' : undefined}
                 aria-invalid={Boolean(error)}
                 required
@@ -180,7 +180,7 @@ function RegisterForm() {
                 id="register-confirm-password"
                 name="register-confirm-password"
                 type="password"
-                autoComplete="section-register new-password"
+                autoComplete="new-password"
                 aria-describedby={error ? 'register-error' : undefined}
                 aria-invalid={Boolean(error)}
                 required

--- a/frontend/src/app/(dashboard)/people/page.tsx
+++ b/frontend/src/app/(dashboard)/people/page.tsx
@@ -296,7 +296,7 @@ export default function PeoplePage() {
             {/* Header Action */}
             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
               <div>
-                <h1 className="text-2xl font-bold text-foreground flex items-center gap-3">
+                <h1 className="density-heading-section text-2xl font-bold text-foreground flex items-center gap-3">
                   <Users className="w-8 h-8 text-action-text" />
                   People Library
                 </h1>

--- a/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingHeader.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingHeader.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { Edit2 } from "lucide-react";
+import { ArrowLeft, Edit2, MoreHorizontal } from "lucide-react";
 import type { RefObject } from "react";
+
+import IconButton from "@/components/ui/IconButton";
 
 import AudioPlayer from "@/components/AudioPlayer";
 import RecordingTagEditor from "@/components/RecordingTagEditor";
@@ -21,6 +23,10 @@ interface RecordingHeaderProps {
   setRecording: (recording: Recording) => void;
   setTitleValue: (value: string) => void;
   setIsEditingTitle: (editing: boolean) => void;
+  setIsMobileHeaderActionsOpen: (
+    update: boolean | ((current: boolean) => boolean),
+  ) => void;
+  onBack: () => void;
   onTitleSubmit: () => void;
   onTimeUpdate: () => void;
   onPlay: () => void;
@@ -38,6 +44,8 @@ export default function RecordingHeader({
   setRecording,
   setTitleValue,
   setIsEditingTitle,
+  setIsMobileHeaderActionsOpen,
+  onBack,
   onTitleSubmit,
   onTimeUpdate,
   onPlay,
@@ -70,14 +78,49 @@ export default function RecordingHeader({
   );
 
   return (
-    <header className={`sticky top-0 z-[var(--z-sticky)] shrink-0 border-b border-surface-border bg-surface-card ${isMobile ? "space-y-3 px-4 pb-3 pt-[calc(env(safe-area-inset-top)+4.75rem)]" : "space-y-3 p-4 md:p-5"}`}>
+    <header className={`sticky top-0 z-[var(--z-sticky)] shrink-0 border-b border-surface-border bg-surface-card ${isMobile ? "space-y-3 px-4 pb-3 pt-[calc(env(safe-area-inset-top)+0.75rem)]" : "space-y-3 p-4 md:p-5"}`}>
       {isMobile ? (
         <>
-          <div className="rounded-2xl bg-surface-inset px-4 py-3">
-            <div className="min-w-0 pt-0.5">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-contrast-icon-muted">
+          {/* Back and actions are inline app-bar controls. A fixed overlay
+              here gets painted over by this sticky header (equal z-index,
+              solid background, later in the DOM), and reserving padding for
+              one wastes the top of every phone screen. */}
+          <div className="rounded-2xl bg-surface-inset px-2 py-2">
+            <div className="flex items-center justify-between gap-1">
+              <IconButton
+                size="sm"
+                icon={<ArrowLeft />}
+                aria-label="Back to Recordings"
+                title="Back to Recordings"
+                onClick={onBack}
+              />
+              <span className="min-w-0 truncate text-[11px] font-semibold uppercase tracking-[0.18em] text-contrast-icon-muted">
                 Meeting Detail
-              </div>
+              </span>
+              <IconButton
+                size="sm"
+                icon={<MoreHorizontal />}
+                aria-label={
+                  isMobileHeaderActionsOpen
+                    ? "Hide meeting actions"
+                    : "Show meeting actions"
+                }
+                title={
+                  isMobileHeaderActionsOpen
+                    ? "Hide meeting actions"
+                    : "Show meeting actions"
+                }
+                onClick={() =>
+                  setIsMobileHeaderActionsOpen((current) => !current)
+                }
+                className={
+                  isMobileHeaderActionsOpen
+                    ? "bg-action-tint text-action-text"
+                    : undefined
+                }
+              />
+            </div>
+            <div className="min-w-0 px-2 pb-1">
               {isEditingTitle ? (
                 <input
                   autoFocus
@@ -110,7 +153,7 @@ export default function RecordingHeader({
           </div>
 
           {isMobileHeaderActionsOpen && (
-            <div className="fixed right-4 top-[calc(env(safe-area-inset-top)+4.5rem)] z-[var(--z-dropdown)] w-[min(18rem,calc(100vw-2rem))] rounded-2xl border border-action-border bg-action-tint p-2.5 shadow-float">
+            <div className="fixed right-4 top-[calc(env(safe-area-inset-top)+4rem)] z-[var(--z-dropdown)] w-[min(18rem,calc(100vw-2rem))] rounded-2xl border border-action-border bg-action-tint p-2.5 shadow-float">
               {renderMobileHeaderActions()}
             </div>
           )}

--- a/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingHeader.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingHeader.tsx
@@ -6,6 +6,7 @@ import type { RefObject } from "react";
 import AudioPlayer from "@/components/AudioPlayer";
 import RecordingTagEditor from "@/components/RecordingTagEditor";
 import LinkedEventPanel from "@/components/LinkedEventPanel";
+import FitText from "@/components/ui/FitText";
 import { getRecording } from "@/lib/api";
 import { Recording, RecordingStatus } from "@/types";
 
@@ -69,7 +70,7 @@ export default function RecordingHeader({
   );
 
   return (
-    <header className={`sticky top-0 z-[var(--z-sticky)] shrink-0 border-b border-surface-border bg-surface-card ${isMobile ? "space-y-3 px-4 pb-3 pt-[calc(env(safe-area-inset-top)+4.75rem)]" : "space-y-4 p-4 md:p-5 lg:p-6"}`}>
+    <header className={`sticky top-0 z-[var(--z-sticky)] shrink-0 border-b border-surface-border bg-surface-card ${isMobile ? "space-y-3 px-4 pb-3 pt-[calc(env(safe-area-inset-top)+4.75rem)]" : "space-y-3 p-4 md:p-5"}`}>
       {isMobile ? (
         <>
           <div className="rounded-2xl bg-surface-inset px-4 py-3">
@@ -95,11 +96,13 @@ export default function RecordingHeader({
                 />
               ) : (
                 <h1
-                  className="mt-1 flex cursor-pointer items-start gap-2 text-lg font-bold text-foreground hover:text-action-text group"
+                  className="mt-1 flex cursor-pointer items-start gap-2 font-bold leading-[1.2] text-foreground hover:text-action-text group"
                   onClick={() => setIsEditingTitle(true)}
                   title="Click to rename"
                 >
-                  <span className="min-w-0 break-words">{recording?.name}</span>
+                  <FitText maxRem={1.125} minRem={1} className="flex-1">
+                    {recording?.name ?? ""}
+                  </FitText>
                   <Edit2 className="mt-1 h-4 w-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-50" />
                 </h1>
               )}
@@ -113,8 +116,7 @@ export default function RecordingHeader({
           )}
         </>
       ) : (
-        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-          <div className="min-w-0 flex-1">
+        <div className="min-w-0">
             {isEditingTitle ? (
               <input
                 autoFocus
@@ -133,40 +135,39 @@ export default function RecordingHeader({
               />
             ) : (
               <h1
-                className="density-heading-section group mb-2 flex cursor-pointer items-start gap-2 text-xl font-bold text-foreground hover:text-action-text md:text-2xl"
+                className="group mb-2 flex cursor-pointer items-start gap-2 font-bold leading-[1.15] text-foreground hover:text-action-text"
                 onClick={() => setIsEditingTitle(true)}
                 title="Click to rename"
               >
-                <span className="min-w-0 break-words md:truncate">
-                  {recording?.name}
-                </span>
+                <FitText maxRem={1.5} minRem={1.0625} className="flex-1">
+                  {recording?.name ?? ""}
+                </FitText>
                 <Edit2 className="mt-1 h-4 w-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-50" />
               </h1>
             )}
 
-            <div className="flex flex-col items-start gap-2">
-              <RecordingTagEditor
-                recordingId={recording.id}
-                tags={recording.tags || []}
-                onTagsUpdated={() => {
-                  getRecording(recording.id)
-                    .then(setRecording)
-                    .catch(console.error);
-                }}
-              />
-              <LinkedEventPanel
-                recordingId={recording.id}
-                linkedEvent={recording.calendar_event}
-                onLinkChanged={() => {
-                  getRecording(recording.id)
-                    .then(setRecording)
-                    .catch(console.error);
-                }}
-              />
-            </div>
+          {/* Tags and the calendar link share one wrapping row to keep the
+              header's fixed vertical cost to a single pill line. */}
+          <div className="flex flex-wrap items-center gap-2">
+            <RecordingTagEditor
+              recordingId={recording.id}
+              tags={recording.tags || []}
+              onTagsUpdated={() => {
+                getRecording(recording.id)
+                  .then(setRecording)
+                  .catch(console.error);
+              }}
+            />
+            <LinkedEventPanel
+              recordingId={recording.id}
+              linkedEvent={recording.calendar_event}
+              onLinkChanged={() => {
+                getRecording(recording.id)
+                  .then(setRecording)
+                  .catch(console.error);
+              }}
+            />
           </div>
-
-
         </div>
       )}
 

--- a/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingHeader.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingHeader.tsx
@@ -153,7 +153,7 @@ export default function RecordingHeader({
           </div>
 
           {isMobileHeaderActionsOpen && (
-            <div className="fixed right-4 top-[calc(env(safe-area-inset-top)+4rem)] z-[var(--z-dropdown)] w-[min(18rem,calc(100vw-2rem))] rounded-2xl border border-action-border bg-action-tint p-2.5 shadow-float">
+            <div className="fixed right-4 top-[calc(env(safe-area-inset-top)+4rem)] z-[var(--z-dropdown)] w-[min(18rem,calc(100vw-2rem))] rounded-2xl border border-surface-float-border bg-surface-float p-2.5 shadow-float">
               {renderMobileHeaderActions()}
             </div>
           )}

--- a/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingMainContent.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_components/RecordingMainContent.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ArrowLeft, MoreHorizontal } from "lucide-react";
 import type { RefObject } from "react";
 
 import type { ActivePanel } from "@/lib/store";
@@ -139,39 +138,12 @@ export default function RecordingMainContent({
 }: RecordingMainContentProps) {
   return (
     <div className="flex-1 flex flex-col min-h-0 h-full">
-      {isMobile ? (
-        <div className="pointer-events-none fixed inset-x-0 top-0 z-[var(--z-sticky)] flex items-start justify-between px-4 pt-[calc(env(safe-area-inset-top)+0.75rem)] lg:hidden">
-          <button
-            onClick={onBack}
-            className="pointer-events-auto inline-flex h-12 shrink-0 items-center gap-2 rounded-2xl border border-surface-border bg-surface-card px-4 text-sm font-medium text-contrast-muted shadow-float transition-colors hover:bg-surface-card"
-            title="Back to Recordings"
-            aria-label="Back to Recordings"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            <span>Back</span>
-          </button>
-
-          <button
-            onClick={() => setIsMobileHeaderActionsOpen((current) => !current)}
-            className={`pointer-events-auto inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border shadow-float transition-colors dark: ${isMobileHeaderActionsOpen ? "border-action-border bg-action-tint text-action-text" : "border-surface-border bg-surface-card text-contrast-muted hover:bg-surface-card"}`}
-            title={
-              isMobileHeaderActionsOpen
-                ? "Hide meeting actions"
-                : "Show meeting actions"
-            }
-            aria-label={
-              isMobileHeaderActionsOpen
-                ? "Hide meeting actions"
-                : "Show meeting actions"
-            }
-          >
-            <MoreHorizontal className="h-5 w-5" />
-          </button>
-        </div>
-      ) : null}
-
-      {/* Header (Title, Tags, Audio Player) */}
+      {/* Header (Title, Tags, Audio Player). On mobile it also carries the
+          back and actions controls inline, so nothing floats over content
+          and no top padding is reserved for an overlay. */}
       <RecordingHeader
+        onBack={onBack}
+        setIsMobileHeaderActionsOpen={setIsMobileHeaderActionsOpen}
         recording={recording}
         isMobile={isMobile}
         isEditingTitle={isEditingTitle}

--- a/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/recordings/[id]/page.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { ArrowLeft, MessageSquare } from "lucide-react";
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronUp,
+  MessageSquare,
+  Users,
+} from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 import ChatPanel from "@/components/ChatPanel";
 import SpeakerPanel from "@/components/SpeakerPanel";
 import RecordingStatusDisplay from "@/components/RecordingStatusDisplay";
 import ExportModal from "@/components/ExportModal";
+import IconButton from "@/components/ui/IconButton";
+import { useNavigationStore } from "@/lib/store";
 
 import { useRecordingDetail } from "./_hooks/useRecordingDetail";
 import { getAutoSpeakerReplacementName } from "./_hooks/recordingDetailUtils";
@@ -20,6 +28,18 @@ interface PageProps {
 
 export default function RecordingPage({ params }: PageProps) {
   const detail = useRecordingDetail({ params });
+  const isSpeakerPanelCollapsed = useNavigationStore(
+    (state) => state.isSpeakerPanelCollapsed,
+  );
+  const setSpeakerPanelCollapsed = useNavigationStore(
+    (state) => state.setSpeakerPanelCollapsed,
+  );
+  const isChatPanelCollapsed = useNavigationStore(
+    (state) => state.isChatPanelCollapsed,
+  );
+  const setChatPanelCollapsed = useNavigationStore(
+    (state) => state.setChatPanelCollapsed,
+  );
 
   const {
     recording,
@@ -224,63 +244,159 @@ export default function RecordingPage({ params }: PageProps) {
             )}
           </div>
         ) : (
-          <PanelGroup
-            direction="horizontal"
-            autoSaveId={`recording-layout-persistence-${isCompact ? "compact" : "comfortable"}`}
-            className="h-full flex-1 min-w-0"
-          >
-            <Panel defaultSize={isCompact ? 78 : 75} minSize={30}>
-              {mainContent}
-            </Panel>
-
-            <PanelResizeHandle
-              className="bg-surface-inset border-l border-control-border w-2 hover:bg-action transition-colors flex items-center justify-center group"
-              onDragging={setIsPanelResizing}
+          <div className="flex h-full flex-1 min-w-0">
+            <PanelGroup
+              direction="horizontal"
+              autoSaveId={`recording-layout-persistence-${isCompact ? "compact" : "comfortable"}`}
+              className="h-full flex-1 min-w-0"
             >
-              <div className="h-8 w-1 bg-surface-card rounded-full group-hover:bg-surface-card transition-colors" />
-            </PanelResizeHandle>
+              <Panel id="recording-main" order={1} defaultSize={isCompact ? 78 : 75} minSize={30}>
+                {mainContent}
+              </Panel>
 
-            {/* Sidebar: Stacked Speaker and Chat panels */}
-            <Panel defaultSize={isCompact ? 22 : 25} minSize={18}>
-              <PanelGroup
-                direction="vertical"
-                onLayout={(sizes) => {
-                  if (sizes.length === 2) {
-                    setChatPanelHeight(sizes[1]);
-                  }
-                }}
-              >
-                <Panel defaultSize={100 - compactChatPanelHeight} minSize={20}>
-                  <SpeakerPanel
-                    speakers={recording.speakers || []}
-                    segments={transcriptSegments}
-                    onPlaySegment={handlePlaySegment}
-                    recordingId={recording.id}
-                    speakerColors={speakerColors}
-                    onColorChange={handleColorChange}
-                    currentTime={currentTime}
-                    isPlaying={isPlaying}
-                    onPause={handlePause}
-                    onResume={handleResume}
-                    onRefresh={refreshRecordingView}
-                    globalSpeakers={globalSpeakers}
-                    onSpeakerRenamed={handleSpeakerRenamed}
-                  />
-                </Panel>
+              {!(isSpeakerPanelCollapsed && isChatPanelCollapsed) && (
+                <>
+                  <PanelResizeHandle
+                    className="bg-surface-inset border-l border-control-border w-2 hover:bg-action transition-colors flex items-center justify-center group"
+                    onDragging={setIsPanelResizing}
+                  >
+                    <div className="h-8 w-1 bg-surface-card rounded-full group-hover:bg-surface-card transition-colors" />
+                  </PanelResizeHandle>
 
-                <PanelResizeHandle
-                  className="bg-surface-inset border-t border-control-border h-2 hover:bg-action transition-colors flex items-center justify-center group"
-                  onDragging={setIsPanelResizing}
-                >
-                  <div className="w-8 h-1 bg-surface-card rounded-full group-hover:bg-surface-card transition-colors" />
-                </PanelResizeHandle>
+                  {/* Sidebar: Speaker and Chat panels, each independently collapsible */}
+                  <Panel
+                    id="recording-side"
+                    order={2}
+                    defaultSize={isCompact ? 22 : 25}
+                    minSize={18}
+                  >
+                    {isSpeakerPanelCollapsed ? (
+                      <div className="flex h-full flex-col">
+                        <button
+                          onClick={() => setSpeakerPanelCollapsed(false)}
+                          className="flex h-9 w-full shrink-0 items-center gap-2 border-b border-surface-border bg-surface-card px-3 text-xs font-medium text-contrast-helper transition-colors hover:bg-surface-inset hover:text-foreground"
+                          aria-expanded={false}
+                          aria-controls="speaker-panel"
+                        >
+                          <Users className="h-3.5 w-3.5" />
+                          Speakers
+                          <ChevronDown className="ml-auto h-3.5 w-3.5" />
+                        </button>
+                        <div className="min-h-0 flex-1">
+                          <ChatPanel
+                            onNotesUpdate={fetchRecording}
+                            onCollapse={() => setChatPanelCollapsed(true)}
+                          />
+                        </div>
+                      </div>
+                    ) : isChatPanelCollapsed ? (
+                      <div className="flex h-full flex-col">
+                        <div className="min-h-0 flex-1">
+                          <SpeakerPanel
+                            speakers={recording.speakers || []}
+                            segments={transcriptSegments}
+                            onPlaySegment={handlePlaySegment}
+                            recordingId={recording.id}
+                            speakerColors={speakerColors}
+                            onColorChange={handleColorChange}
+                            currentTime={currentTime}
+                            isPlaying={isPlaying}
+                            onPause={handlePause}
+                            onResume={handleResume}
+                            onRefresh={refreshRecordingView}
+                            globalSpeakers={globalSpeakers}
+                            onSpeakerRenamed={handleSpeakerRenamed}
+                            onCollapse={() => setSpeakerPanelCollapsed(true)}
+                          />
+                        </div>
+                        <button
+                          onClick={() => setChatPanelCollapsed(false)}
+                          className="flex h-9 w-full shrink-0 items-center gap-2 border-t border-surface-border bg-surface-card px-3 text-xs font-medium text-contrast-helper transition-colors hover:bg-surface-inset hover:text-foreground"
+                          aria-expanded={false}
+                          aria-controls="meeting-chat"
+                        >
+                          <MessageSquare className="h-3.5 w-3.5" />
+                          Chat
+                          <ChevronUp className="ml-auto h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    ) : (
+                      <PanelGroup
+                        direction="vertical"
+                        onLayout={(sizes) => {
+                          if (sizes.length === 2) {
+                            setChatPanelHeight(sizes[1]);
+                          }
+                        }}
+                      >
+                        <Panel
+                          id="side-speakers"
+                          order={1}
+                          defaultSize={100 - compactChatPanelHeight}
+                          minSize={20}
+                        >
+                          <SpeakerPanel
+                            speakers={recording.speakers || []}
+                            segments={transcriptSegments}
+                            onPlaySegment={handlePlaySegment}
+                            recordingId={recording.id}
+                            speakerColors={speakerColors}
+                            onColorChange={handleColorChange}
+                            currentTime={currentTime}
+                            isPlaying={isPlaying}
+                            onPause={handlePause}
+                            onResume={handleResume}
+                            onRefresh={refreshRecordingView}
+                            globalSpeakers={globalSpeakers}
+                            onSpeakerRenamed={handleSpeakerRenamed}
+                            onCollapse={() => setSpeakerPanelCollapsed(true)}
+                          />
+                        </Panel>
 
-                <Panel defaultSize={compactChatPanelHeight} minSize={18}>
-                  <ChatPanel onNotesUpdate={fetchRecording} />
-                </Panel>
-              </PanelGroup>
-            </Panel>
-          </PanelGroup>
+                        <PanelResizeHandle
+                          className="bg-surface-inset border-t border-control-border h-2 hover:bg-action transition-colors flex items-center justify-center group"
+                          onDragging={setIsPanelResizing}
+                        >
+                          <div className="w-8 h-1 bg-surface-card rounded-full group-hover:bg-surface-card transition-colors" />
+                        </PanelResizeHandle>
+
+                        <Panel
+                          id="side-chat"
+                          order={2}
+                          defaultSize={compactChatPanelHeight}
+                          minSize={18}
+                        >
+                          <ChatPanel
+                            onNotesUpdate={fetchRecording}
+                            onCollapse={() => setChatPanelCollapsed(true)}
+                          />
+                        </Panel>
+                      </PanelGroup>
+                    )}
+                  </Panel>
+                </>
+              )}
+            </PanelGroup>
+
+            {isSpeakerPanelCollapsed && isChatPanelCollapsed && (
+              <div className="flex h-full w-12 shrink-0 flex-col items-center gap-1 border-l border-surface-border bg-surface-inset py-2">
+                <IconButton
+                  size="sm"
+                  icon={<Users />}
+                  aria-label="Show speakers panel"
+                  title="Show speakers panel"
+                  onClick={() => setSpeakerPanelCollapsed(false)}
+                />
+                <IconButton
+                  size="sm"
+                  icon={<MessageSquare />}
+                  aria-label="Show meeting chat panel"
+                  title="Show meeting chat panel"
+                  onClick={() => setChatPanelCollapsed(false)}
+                />
+              </div>
+            )}
+          </div>
         )}
       </div>
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -639,18 +639,39 @@ html {
   .density-heading-page {
     line-height: 1.05;
   }
+}
 
-  html[data-ui-density="compact"] .density-heading-page {
-    font-size: clamp(2rem, 2vw + 1.35rem, 2.75rem);
+/* The heading scale overrides live outside the cascade layers deliberately.
+   Inside @layer components they lose to the text-* utilities on the same
+   elements, because the utilities layer is declared after components and
+   layer order beats selector specificity — which left these rules silently
+   inert. Unlayered declarations beat every layer, so the scaling actually
+   applies. */
+html[data-ui-density="compact"] .density-heading-page {
+  font-size: clamp(2rem, 2vw + 1.35rem, 2.75rem);
+}
+
+html[data-ui-density="compact"] .density-heading-section {
+  font-size: clamp(1.375rem, 1vw + 1rem, 1.875rem);
+  line-height: 1.1;
+}
+
+html[data-ui-density="compact"] .density-body-copy {
+  line-height: 1.55;
+}
+
+/* Below the desktop breakpoint the density attribute is always
+   "comfortable", so phones and small tablets need their own fluid step.
+   The upper bounds match the largest text-* size each class is paired
+   with, so the clamp only ever steps a heading down. */
+@media (max-width: 63.9375rem) {
+  .density-heading-page {
+    font-size: clamp(1.625rem, 3vw + 0.9rem, 2.25rem);
   }
 
-  html[data-ui-density="compact"] .density-heading-section {
-    font-size: clamp(1.375rem, 1vw + 1rem, 1.875rem);
+  .density-heading-section {
+    font-size: clamp(1.125rem, 1.5vw + 0.75rem, 1.5rem);
     line-height: 1.1;
-  }
-
-  html[data-ui-density="compact"] .density-body-copy {
-    line-height: 1.55;
   }
 }
 

--- a/frontend/src/app/setup/_components/AccountStep.tsx
+++ b/frontend/src/app/setup/_components/AccountStep.tsx
@@ -50,7 +50,7 @@ export default function AccountStep({
           type="text"
           name="setup-admin-username"
           data-field-key="username"
-          autoComplete="section-setup-admin username"
+          autoComplete="username"
           autoCapitalize="none"
           autoCorrect="off"
           spellCheck={false}
@@ -73,7 +73,7 @@ export default function AccountStep({
           type="password"
           name="setup-admin-new-password"
           data-field-key="password"
-          autoComplete="section-setup-admin new-password"
+          autoComplete="new-password"
           aria-describedby={error ? "setup-error" : undefined}
           aria-invalid={Boolean(error)}
           required
@@ -94,7 +94,7 @@ export default function AccountStep({
           type="password"
           name="setup-admin-confirm-password"
           data-field-key="confirmPassword"
-          autoComplete="section-setup-admin new-password"
+          autoComplete="new-password"
           aria-describedby={error ? "setup-error" : undefined}
           aria-invalid={Boolean(error)}
           required

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -145,7 +145,7 @@ export default function AudioPlayer({
     !isDemo;
   const shellClassName = compact
     ? "w-full rounded-2xl border border-control-border bg-surface-card px-3 py-2.5 shadow-card"
-    : "w-full bg-surface-card border border-control-border rounded-lg p-2 md:p-3 flex flex-wrap md:flex-nowrap items-center gap-x-3 gap-y-2 shadow-card";
+    : "w-full bg-surface-card border border-control-border rounded-lg p-2 md:p-2.5 flex flex-wrap md:flex-nowrap items-center gap-x-3 gap-y-2 shadow-card";
   const compactMockContent = (
     <div className="flex flex-col gap-2 opacity-30 pointer-events-none filter blur-[1px]">
       <div className="flex items-center justify-between gap-3">

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
   Tag as TagIcon,
   ChevronDown,
+  ChevronsRight,
   ChevronUp,
 } from "lucide-react";
 import { useParams } from "next/navigation";
@@ -29,11 +30,15 @@ import MarkdownBubble from "./MarkdownBubble";
 import { useNotificationStore } from "@/lib/notificationStore";
 import ConfirmationModal from "./ConfirmationModal";
 import MultiSelect, { Option } from "@/components/ui/MultiSelect";
+import IconButton from "@/components/ui/IconButton";
 
 export default function ChatPanel({
   onNotesUpdate,
+  onCollapse,
 }: {
   onNotesUpdate?: () => void;
+  /** Desktop side-column collapse; the mobile full-screen chat omits it. */
+  onCollapse?: () => void;
 }) {
   const params = useParams();
   const recordingId: RecordingId | null =
@@ -230,9 +235,9 @@ export default function ChatPanel({
   return (
     <aside
       id="meeting-chat"
-      className="flex-1 min-w-0 border-l border-surface-border bg-surface-inset h-full flex flex-col shadow-float z-10"
+      className="@container flex-1 min-w-0 bg-surface-inset h-full flex flex-col"
     >
-      <div className="p-4 border-b border-surface-border flex justify-between items-center bg-surface-card">
+      <div className="py-1 pl-3 pr-2 @min-[20rem]:pl-4 border-b border-surface-border flex justify-between items-center bg-surface-card">
         <h2 className="text-sm font-semibold text-foreground flex items-center gap-2">
           <MessageSquare className="w-4 h-4 text-action-text" />
           Chat
@@ -271,6 +276,15 @@ export default function ChatPanel({
               <Trash2 className="w-4 h-4" />
             </button>
           )}
+          {onCollapse && (
+            <IconButton
+              size="sm"
+              icon={<ChevronsRight />}
+              aria-label="Collapse chat panel"
+              title="Collapse chat panel"
+              onClick={onCollapse}
+            />
+          )}
         </div>
       </div>
 
@@ -288,7 +302,7 @@ export default function ChatPanel({
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto p-3 space-y-3 @min-[20rem]:p-4 @min-[20rem]:space-y-4">
         {!recordingId ? (
           <div className="h-full flex flex-col items-center justify-center text-center text-contrast-helper opacity-60">
             <MessageSquare className="w-12 h-12 mb-4" />
@@ -309,7 +323,7 @@ export default function ChatPanel({
               className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
             >
               <div
-                className={`max-w-[85%] rounded-surface-panel px-4 py-3 text-sm shadow-card ${
+                className={`max-w-[85%] rounded-surface-panel px-3 py-2 @min-[20rem]:px-4 @min-[20rem]:py-3 text-sm shadow-card ${
                   msg.role === "user"
                     ? "bg-action text-action-on rounded-tr-none"
                     : "bg-surface-card border border-surface-border text-foreground rounded-tl-none"
@@ -341,7 +355,7 @@ export default function ChatPanel({
         <div ref={messagesEndRef} />
       </div>
 
-      <div className="p-4 border-t border-surface-border bg-surface-card relative">
+      <div className="p-3 @min-[20rem]:p-4 border-t border-surface-border bg-surface-card relative">
         {!availability.available && (
           <div className="absolute inset-0 bg-surface-card z-20 flex items-center justify-center p-4 text-center">
             <div className="text-sm text-contrast-helper font-medium">
@@ -388,7 +402,7 @@ export default function ChatPanel({
             placeholder={
               recordingId ? "Ask a question..." : "Select a meeting first..."
             }
-            className="w-full bg-surface-inset border border-control-border rounded-xl pl-4 pr-12 py-4 text-sm focus:outline-none focus:ring-2 focus:ring-action focus:border-transparent resize-none h-14 max-h-32 flex items-center"
+            className="w-full bg-surface-inset border border-control-border rounded-xl pl-4 pr-12 py-3 h-12 @min-[20rem]:py-4 @min-[20rem]:h-14 text-sm focus:outline-none focus:ring-2 focus:ring-action focus:border-transparent resize-none max-h-32 flex items-center"
             disabled={!recordingId}
           />
           <div className="absolute right-2 top-1/2 -translate-y-1/2">

--- a/frontend/src/components/MainNav.tsx
+++ b/frontend/src/components/MainNav.tsx
@@ -25,7 +25,8 @@ import {
 import {
   DndContext,
   DragOverlay,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   pointerWithin,
@@ -243,11 +244,21 @@ export default function MainNav() {
     },
   ];
 
-  // Drag and drop logic
+  // Drag and drop logic. Mouse drags start on an 8px move, but touch
+  // requires a press-and-hold: a bare movement threshold turns every
+  // scroll swipe over the tag tree into a drag, which both traps the
+  // scroll and nests tags by accident on release. Movement beyond the
+  // tolerance during the hold cancels activation, so a swipe scrolls.
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: {
         distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 250,
+        tolerance: 8,
       },
     }),
   );

--- a/frontend/src/components/RecordingInfoModal.tsx
+++ b/frontend/src/components/RecordingInfoModal.tsx
@@ -60,14 +60,16 @@ export default function RecordingInfoModal({
         </Button>
       }
     >
-      <div className="space-y-6">
+      <div className="@container space-y-6">
         {/* General Info */}
         <div className="rounded-lg bg-surface-inset p-4">
           <h4 className="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground">
             <Monitor aria-hidden="true" className="w-4 h-4 text-status-info-fg" />
             General
           </h4>
-          <div className="grid grid-cols-2 gap-4 text-sm">
+          {/* 22rem covers two columns wide enough for a locale timestamp,
+              plus the gap and the card's own padding. */}
+          <div className="grid gap-4 text-sm @min-[22rem]:grid-cols-2">
             <div>
               <span className="block text-xs text-contrast-helper">Name</span>
               <span
@@ -79,7 +81,9 @@ export default function RecordingInfoModal({
             </div>
             <div>
               <span className="block text-xs text-contrast-helper">ID</span>
-              <span className="font-mono text-contrast-muted">{recording.id}</span>
+              <span className="break-all font-mono text-contrast-muted">
+                {recording.id}
+              </span>
             </div>
             <div>
               <span className="block text-xs text-contrast-helper">Created At</span>
@@ -110,7 +114,7 @@ export default function RecordingInfoModal({
               Proxy Audio (Web optimized)
             </h4>
             {info.proxy ? (
-              <div className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+              <div className="grid gap-x-4 gap-y-3 text-sm @min-[13rem]:grid-cols-2">
                 <div>
                   <span className="block text-xs text-contrast-helper">Format</span>
                   <span className="uppercase text-foreground">

--- a/frontend/src/components/RecordingTagEditor.tsx
+++ b/frontend/src/components/RecordingTagEditor.tsx
@@ -36,7 +36,7 @@ export default function RecordingTagEditor({ recordingId, tags, onTagsUpdated, c
 
   return (
     <>
-      <div className={`flex flex-wrap items-center ${compact ? "gap-2" : "mb-4 gap-3"}`}>
+      <div className="flex flex-wrap items-center gap-2">
         {tags.map((tag) => {
           const color = getColorByKey(tag.color);
           const parentName = getParentName(tag.parent_id);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -15,7 +15,13 @@ import {
   X,
   CheckSquare,
   Square,
+  Archive,
+  Mic,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Trash2,
 } from "lucide-react";
+import IconButton from "./ui/IconButton";
 import RecordingInfoModal from "./RecordingInfoModal";
 import MeetingControls from "./MeetingControls";
 import { useState, useEffect, useCallback, useMemo } from "react";
@@ -122,6 +128,8 @@ export default function Sidebar() {
     clearSelection,
     recordingsSidebarWidth,
     setRecordingsSidebarWidth,
+    isRecordingsSidebarCollapsed,
+    toggleRecordingsSidebarCollapse,
   } = useNavigationStore();
 
   const [mounted, setMounted] = useState(false);
@@ -143,9 +151,14 @@ export default function Sidebar() {
   const [reprocessRecordingId, setReprocessRecordingId] = useState<RecordingId | null>(null);
   const MIN_SIDEBAR_WIDTH = isCompact ? 240 : 256;
   const MAX_SIDEBAR_WIDTH = isCompact ? 520 : 600;
+  const COLLAPSED_SIDEBAR_WIDTH = isCompact ? 60 : 64;
   const resolvedSidebarWidth = isCompact
     ? Math.min(recordingsSidebarWidth, 304)
     : recordingsSidebarWidth;
+
+  // The persisted collapse only applies on desktop, and we fall back to
+  // expanded until mounted to avoid a hydration mismatch (mirrors MainNav).
+  const isCollapsed = mounted && isDesktopLayout && isRecordingsSidebarCollapsed;
 
   const { onResizePointerDown: handleResizePointerDown } = useSidebarResize({
     minWidth: MIN_SIDEBAR_WIDTH,
@@ -633,11 +646,46 @@ export default function Sidebar() {
   return (
     <aside
       id="sidebar-recordings-list"
-      className={`shrink-0 border-r border-rail-border bg-rail flex flex-col h-full relative transition-opacity ${
+      className={`shrink-0 border-r border-rail-border bg-rail flex flex-col h-full relative transition-all duration-300 ${
         isRecordingView ? "hidden lg:flex" : "w-full lg:flex"
       }`}
-      style={mounted && isDesktopLayout ? { width: `${resolvedSidebarWidth}px` } : {}}
+      style={
+        mounted && isDesktopLayout
+          ? {
+              width: isCollapsed
+                ? `${COLLAPSED_SIDEBAR_WIDTH}px`
+                : `${resolvedSidebarWidth}px`,
+            }
+          : {}
+      }
     >
+      {isCollapsed && (
+        <div className="flex flex-col items-center gap-1 p-2">
+          <IconButton
+            onClick={toggleRecordingsSidebarCollapse}
+            size="sm"
+            icon={<PanelLeftOpen aria-hidden="true" />}
+            className="text-rail-fg-muted hover:bg-rail-item-hover hover:text-rail-fg"
+            title="Expand recordings list"
+            aria-label="Expand recordings list"
+            aria-expanded={false}
+          />
+          {/* Non-interactive hint for which library view the hidden list holds. */}
+          <span
+            className="flex h-10 w-10 items-center justify-center text-rail-fg-muted"
+            title={currentViewLabel}
+          >
+            {view === "archived" ? (
+              <Archive aria-hidden="true" className="h-4 w-4" />
+            ) : view === "deleted" ? (
+              <Trash2 aria-hidden="true" className="h-4 w-4" />
+            ) : (
+              <Mic aria-hidden="true" className="h-4 w-4" />
+            )}
+          </span>
+        </div>
+      )}
+      {!isCollapsed && (
       <div className="flex-1 overflow-y-auto">
       {view === "recordings" && (
         <div className="hidden lg:block">
@@ -684,21 +732,32 @@ export default function Sidebar() {
           </div>
         ) : (
           <div className="space-y-2">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-contrast-icon-muted" />
-              <input
-                type="text"
-                placeholder="Search..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-9 pr-4 py-2 text-sm bg-control-bg border border-control-border rounded-lg text-foreground placeholder:text-control-placeholder focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-focus-ring"
+            <div className="flex items-center gap-1">
+              <div className="relative min-w-0 flex-1">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-contrast-icon-muted" />
+                <input
+                  type="text"
+                  placeholder="Search..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full pl-9 pr-4 py-2 text-sm bg-control-bg border border-control-border rounded-lg text-foreground placeholder:text-control-placeholder focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-focus-ring"
+                />
+                <button
+                  onClick={() => setShowFilters(!showFilters)}
+                  className={`absolute right-2 top-1/2 transform -translate-y-1/2 p-1 rounded-md hover:bg-rail-item-hover ${showFilters ? "text-action-text" : "text-contrast-icon-muted"}`}
+                >
+                  <Filter className="w-4 h-4" />
+                </button>
+              </div>
+              <IconButton
+                onClick={toggleRecordingsSidebarCollapse}
+                size="sm"
+                icon={<PanelLeftClose aria-hidden="true" />}
+                className="hidden lg:inline-flex text-rail-fg-muted hover:bg-rail-item-hover hover:text-rail-fg"
+                title="Collapse recordings list"
+                aria-label="Collapse recordings list"
+                aria-expanded={true}
               />
-              <button
-                onClick={() => setShowFilters(!showFilters)}
-                className={`absolute right-2 top-1/2 transform -translate-y-1/2 p-1 rounded-md hover:bg-rail-item-hover ${showFilters ? "text-action-text" : "text-contrast-icon-muted"}`}
-              >
-                <Filter className="w-4 h-4" />
-              </button>
             </div>
             {/* ... filters ... */}
           </div>
@@ -859,7 +918,7 @@ export default function Sidebar() {
       </div>
 
       {/* Recording List */}
-      <div className="p-2 space-y-2">
+      <div className="@container p-2 space-y-2">
         {filteredRecordings.length === 0 && (
           <div className="text-center p-4 text-rail-fg-muted text-sm">
             <p>{getEmptyMessage().main}</p>
@@ -929,7 +988,7 @@ export default function Sidebar() {
                           </div>
                         )}
                         <h3
-                          className={`text-sm font-semibold truncate ${isActive && !selectionMode ? "text-action-text" : "text-foreground"}`}
+                          className={`text-sm font-semibold line-clamp-2 ${isActive && !selectionMode ? "text-action-text" : "text-foreground"}`}
                           title="Double-click to rename"
                           onDoubleClick={(e) => {
                             e.preventDefault();
@@ -944,19 +1003,22 @@ export default function Sidebar() {
                     </div>
 
                     <div
-                      className={`flex items-center text-xs text-contrast-helper gap-2 ${selectionMode || isSelected ? "pl-6" : ""}`}
+                      className={`flex items-center overflow-hidden text-xs text-contrast-helper gap-2 ${selectionMode || isSelected ? "pl-6" : ""}`}
                     >
-                      <span>{formatDate(recording.created_at)}</span>
-                      <span className="text-contrast-icon-muted">
+                      <span className="whitespace-nowrap">
+                        {formatDate(recording.created_at)}
+                      </span>
+                      {/* The time range yields first when the rail narrows; date and duration stay. */}
+                      <span className="hidden whitespace-nowrap text-contrast-icon-muted @min-[19rem]:inline">
                         |
                       </span>
-                      <span>
+                      <span className="hidden whitespace-nowrap @min-[19rem]:inline">
                         {formatTime(startDate)} - {formatTime(endDate)}
                       </span>
-                      <span className="text-contrast-icon-muted">
+                      <span className="whitespace-nowrap text-contrast-icon-muted">
                         |
                       </span>
-                      <span>
+                      <span className="whitespace-nowrap">
                         {formatDurationString(recording.duration_seconds)}
                       </span>
                     </div>
@@ -1026,14 +1088,17 @@ export default function Sidebar() {
       )}
         {/* Footer/Empty States could go here if needed */}
       </div>
+      )}
 
-      {/* Resize Handle - Hidden on Mobile */}
-      <div
-        className="absolute right-0 top-0 bottom-0 z-[var(--z-sticky)] hidden w-1 cursor-col-resize touch-none hover:bg-action active:bg-action-hover lg:block"
-        onPointerDown={handleResizePointerDown}
-      >
-        <div className="absolute top-1/2 right-0 -translate-y-1/2 w-1 h-12 bg-rail-border hover:bg-action transition-colors" />
-      </div>
+      {/* Resize Handle - Hidden on Mobile, inert while collapsed */}
+      {!isCollapsed && (
+        <div
+          className="absolute right-0 top-0 bottom-0 z-[var(--z-sticky)] hidden w-1 cursor-col-resize touch-none hover:bg-action active:bg-action-hover lg:block"
+          onPointerDown={handleResizePointerDown}
+        >
+          <div className="absolute top-1/2 right-0 -translate-y-1/2 w-1 h-12 bg-rail-border hover:bg-action transition-colors" />
+        </div>
+      )}
     </aside>
   );
 }

--- a/frontend/src/components/SpeakerAssignmentPopover.tsx
+++ b/frontend/src/components/SpeakerAssignmentPopover.tsx
@@ -265,7 +265,7 @@ export default function SpeakerAssignmentPopover({
   return createPortal(
     <div
       ref={containerRef}
-      className="fixed z-[var(--z-popover)] flex flex-col overflow-hidden rounded-lg border border-surface-float-border bg-surface-float shadow-float animate-in fade-in zoom-in-95 duration-100"
+      className="@container fixed z-[var(--z-popover)] flex flex-col overflow-hidden rounded-lg border border-surface-float-border bg-surface-float shadow-float animate-in fade-in zoom-in-95 duration-100"
       style={{
         top: position.top,
         left: position.left,
@@ -287,7 +287,10 @@ export default function SpeakerAssignmentPopover({
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-1 border-b border-surface-divider bg-surface-inset p-2">
+      {/* Below 21rem the popover has been clamped to a narrow viewport and
+          "Whole transcript" no longer fits beside its twin, so the scope
+          buttons stack rather than truncate. */}
+      <div className="grid gap-1 @min-[21rem]:grid-cols-2 border-b border-surface-divider bg-surface-inset p-2">
         {scopeOptions.map(({ value, label, Icon }) => {
           const isSelected = selectedScope === value;
 

--- a/frontend/src/components/SpeakerPanel.tsx
+++ b/frontend/src/components/SpeakerPanel.tsx
@@ -10,11 +10,14 @@ import {
   Play,
   Pause,
   ArrowRightToLine,
+  ChevronsRight,
   User,
   UserCheck,
+  Users,
   Loader2,
 } from "lucide-react";
 import { useState } from "react";
+import IconButton from "./ui/IconButton";
 import ContextMenu from "./ContextMenu";
 import ConfirmationModal from "./ConfirmationModal";
 import VoiceprintModal from "./VoiceprintModal";
@@ -43,6 +46,8 @@ interface SpeakerPanelProps {
   onRefresh: () => void;
   globalSpeakers: GlobalSpeaker[];
   onSpeakerRenamed?: (oldName: string, newName: string) => Promise<void> | void;
+  /** Desktop side-column collapse; the mobile Speakers tab omits it. */
+  onCollapse?: () => void;
 }
 
 export default function SpeakerPanel({
@@ -59,6 +64,7 @@ export default function SpeakerPanel({
   onRefresh,
   globalSpeakers,
   onSpeakerRenamed,
+  onCollapse,
 }: SpeakerPanelProps) {
   const { addNotification } = useNotificationStore();
   const [contextMenu, setContextMenu] = useState<{
@@ -140,11 +146,25 @@ export default function SpeakerPanel({
   return (
     <aside
       id="speaker-panel"
-      className="shrink-0 border-l border-surface-border bg-surface-inset h-full overflow-y-auto"
+      className="@container flex h-full min-w-0 flex-col bg-surface-inset"
     >
-      {/* Header with batch voiceprint action */}
+      {onCollapse && (
+        <div className="flex shrink-0 items-center justify-between border-b border-surface-border bg-surface-card py-1 pl-4 pr-2">
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Users className="h-4 w-4 text-action-text" />
+            Speakers
+          </h2>
+          <IconButton
+            size="sm"
+            icon={<ChevronsRight />}
+            aria-label="Collapse speakers panel"
+            title="Collapse speakers panel"
+            onClick={onCollapse}
+          />
+        </div>
+      )}
 
-      <div className="p-2 space-y-2 mt-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-2 space-y-2">
         {speakerEntries.length === 0 ? (
           <div className="p-4 text-sm text-contrast-helper text-center italic">
             No speakers detected.
@@ -218,11 +238,11 @@ export default function SpeakerPanel({
             return (
               <div
                 key={entry.key}
-                className="relative group p-3 rounded-lg bg-surface-card border border-control-border hover:border-status-info-border transition-colors shadow-card"
+                className="relative group p-2.5 @min-[18rem]:p-3 rounded-lg bg-surface-card border border-control-border hover:border-status-info-border transition-colors shadow-card"
                 onContextMenu={(e) => handleContextMenu(e, entry)}
               >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex items-center gap-3 min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-2 @min-[18rem]:gap-3">
+                  <div className="flex items-center gap-2 @min-[18rem]:gap-3 min-w-0 flex-1">
                     <div className="relative shrink-0">
                       <div className="relative">
                         <div className="w-8 h-8 rounded-full border border-control-border flex items-center justify-center bg-surface-inset">

--- a/frontend/src/components/TasksWorkspace.tsx
+++ b/frontend/src/components/TasksWorkspace.tsx
@@ -482,8 +482,12 @@ export default function TasksWorkspace() {
             </p>
           </div>
 
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <div className="grid grid-cols-3 gap-2 rounded-2xl border border-surface-border bg-surface-inset p-1">
+          {/* The container is scoped to below lg deliberately: at lg this div
+              becomes a content-sized flex item, and inline-size containment
+              would collapse it. With no query container at lg the @min falls
+              back to the viewport, which is always past the threshold there. */}
+          <div className="max-lg:@container flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="grid gap-2 @min-[23rem]:grid-cols-3 rounded-2xl border border-surface-border bg-surface-inset p-1">
               {(["open", "completed", "archived"] as TaskView[]).map((item) => (
                 <button
                   key={item}

--- a/frontend/src/components/VoiceprintModal.tsx
+++ b/frontend/src/components/VoiceprintModal.tsx
@@ -290,7 +290,7 @@ export default function VoiceprintModal({
     const currentAction = batchActions[currentResult.diarization_label];
 
     return (
-      <div className="space-y-4">
+      <div className="@container space-y-4">
         {/* Progress indicator */}
         <div className="flex items-center justify-between text-sm text-contrast-helper">
           <span>Speaker {currentBatchIndex + 1} of {successfulResults.length}</span>
@@ -310,8 +310,10 @@ export default function VoiceprintModal({
           {renderMatchInfo(currentResult.matched_speaker)}
         </div>
 
-        {/* Quick Actions */}
-        <div className="grid grid-cols-2 gap-2">
+        {/* Quick Actions. The link button carries a speaker name of unbounded
+            length, so the pair stacks below roughly two 9.5rem buttons plus
+            the gap. */}
+        <div className="grid gap-2 @min-[20rem]:grid-cols-2">
           <button
             onClick={() => {
               if (currentResult.matched_speaker) {

--- a/frontend/src/components/mainNav/TagItem.tsx
+++ b/frontend/src/components/mainNav/TagItem.tsx
@@ -170,7 +170,7 @@ export default function TagItem({
       {...attributes}
       {...listeners}
       className={`
-        group flex items-center gap-2 px-3 py-1.5 rounded-lg transition-all cursor-pointer relative select-none touch-none
+        group flex items-center gap-2 px-3 py-1.5 rounded-lg transition-all cursor-pointer relative select-none touch-manipulation
         ${isSelected ? "bg-rail-item-active text-rail-item-active-fg" : "text-rail-fg hover:bg-rail-item-hover"}
         ${isDragging ? "opacity-50" : ""}
         ${isOver ? "bg-action-tint ring-2 ring-action-border" : ""}

--- a/frontend/src/components/settings/AiRoutingSection.tsx
+++ b/frontend/src/components/settings/AiRoutingSection.tsx
@@ -190,7 +190,7 @@ export default function AiRoutingSection({
         <div
           role="radiogroup"
           aria-label="AI routing"
-          className="grid gap-3 sm:grid-cols-2"
+          className="grid gap-3 @min-[36rem]:grid-cols-2"
         >
           <RoutingCard
             selected={!isCli}
@@ -233,7 +233,7 @@ export default function AiRoutingSection({
               </SettingsCallout>
             )}
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="grid grid-cols-1 gap-4 @min-[44rem]:grid-cols-2">
               <div>
                 <div className="flex items-center justify-between mb-2">
                   <label className="block text-sm font-medium text-contrast-muted">

--- a/frontend/src/components/settings/CalendarConnectionsSettings.tsx
+++ b/frontend/src/components/settings/CalendarConnectionsSettings.tsx
@@ -323,7 +323,7 @@ export default function CalendarConnectionsSettings() {
                     ? `You will be redirected to ${PROVIDER_LABELS[provider.provider]} to sign in and approve access.`
                     : "Not configured by an administrator yet."
                 }
-                controlClassName="sm:min-w-0 sm:flex sm:justify-end"
+                controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
               >
                 <button
                   type="button"
@@ -423,17 +423,17 @@ export default function CalendarConnectionsSettings() {
                       </div>
                     </div>
 
-                    <div className="grid gap-2 sm:grid-cols-2">
+                    <div className="grid gap-2 @min-[35rem]:grid-cols-2">
                       {connection.calendars.map((calendar) => (
                         <div
                           key={calendar.id}
-                          className={`rounded-xl border px-4 py-4 transition-all ${
+                          className={`@container rounded-xl border px-4 py-4 transition-all ${
                             calendar.is_selected
                               ? "border-action-border bg-action-tint shadow-card hover:border-action-border hover:bg-action-tint"
                               : "border-surface-border bg-surface-card hover:border-action-border hover:bg-action-tint"
                           }`}
                         >
-                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="flex flex-col gap-3 @min-[24rem]:flex-row @min-[24rem]:items-start @min-[24rem]:justify-between">
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2 text-foreground">
                                 <span className="truncate text-sm font-semibold">
@@ -453,7 +453,7 @@ export default function CalendarConnectionsSettings() {
                               )}
                             </div>
 
-                            <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
+                            <div className="flex flex-wrap items-center gap-2 @min-[24rem]:shrink-0">
                               {busyKey === `colour:${calendar.id}` ? (
                                 <div className="inline-flex items-center gap-2 rounded-full border border-surface-border bg-surface-card px-3 py-2 text-xs font-medium text-contrast-helper">
                                   <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/frontend/src/components/settings/CalendarProviderSettings.tsx
+++ b/frontend/src/components/settings/CalendarProviderSettings.tsx
@@ -184,7 +184,10 @@ export default function CalendarProviderSettings() {
           </div>
         </SettingsBlock>
       ) : (
-        <SettingsBlock contentClassName="grid gap-4 lg:grid-cols-2">
+        // Two provider columns only once each gets ~26rem; under the settings
+        // page cap the card stays single-column, deliberately: the old lg
+        // viewport variant split a ~45rem block at every desktop width.
+        <SettingsBlock contentClassName="grid gap-4 @min-[54rem]:grid-cols-2">
           {providers.map((provider) => {
             const form = forms[provider.provider];
             const isSaving = savingProvider === provider.provider;

--- a/frontend/src/components/settings/CaptureProcessingSettings.tsx
+++ b/frontend/src/components/settings/CaptureProcessingSettings.tsx
@@ -28,7 +28,7 @@ export default function CaptureProcessingSettings() {
   );
   const resetWarnings = useAudioWarningStore((state) => state.resetWarnings);
 
-  const toggleControlClass = "sm:min-w-0 sm:flex sm:justify-end";
+  const toggleControlClass = "@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end";
 
   return (
     <>
@@ -101,7 +101,7 @@ export default function CaptureProcessingSettings() {
               ? "Currently suppressed. Reset them to see the prompts again."
               : "Currently enabled."
           }
-          controlClassName="sm:min-w-0 sm:flex sm:justify-end"
+          controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
         >
           <button
             type="button"

--- a/frontend/src/components/settings/CaptureSettings.tsx
+++ b/frontend/src/components/settings/CaptureSettings.tsx
@@ -433,7 +433,7 @@ export default function CaptureSettings() {
         label="Automatic levels"
         description="Nojoin balances sources while recording. The sliders above set the baseline mix it starts from."
         icon={<Volume2 className="h-4 w-4 contrast-icon-muted" aria-hidden="true" />}
-        controlClassName="sm:min-w-0 sm:flex sm:justify-end"
+        controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
       >
         <SettingsStatusBadge tone="success">
           Enabled with manual baseline
@@ -465,7 +465,7 @@ export default function CaptureSettings() {
         inset
         contentClassName="space-y-4"
       >
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 @min-[35rem]:grid-cols-2">
           <MeterBar label="Raw microphone" value={previewRawLevel} tone="emerald" />
           <MeterBar
             label="After microphone gain"

--- a/frontend/src/components/settings/ConnectedAppsSettings.tsx
+++ b/frontend/src/components/settings/ConnectedAppsSettings.tsx
@@ -104,7 +104,7 @@ export default function ConnectedAppsSettings() {
             label={app.client_name}
             description={`${SCOPE_LABELS[app.scope] ?? app.scope} · Connected ${formatTimestamp(app.created_at)} · Last used ${formatTimestamp(app.last_used_at)}`}
             icon={<Plug className="h-4 w-4 contrast-icon-muted" aria-hidden="true" />}
-            controlClassName="sm:min-w-0 sm:flex sm:justify-end"
+            controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
           >
             <button
               type="button"

--- a/frontend/src/components/settings/GeneralSettings.tsx
+++ b/frontend/src/components/settings/GeneralSettings.tsx
@@ -395,7 +395,7 @@ export default function GeneralSettings({
             label="Voice activity detection"
             description="Filters out silence and background noise before transcription. Disabling it may increase processing time, but can help if quiet speech is being cut off."
             icon={<Mic className="h-4 w-4 contrast-icon-muted" aria-hidden="true" />}
-            controlClassName="sm:min-w-0 sm:flex sm:justify-end"
+            controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
           >
             <Switch
               checked={settings.enable_vad !== false} // Default true
@@ -410,7 +410,7 @@ export default function GeneralSettings({
             label="Speaker diarization"
             description="Distinguishes between speakers. Disable it for single-speaker recordings to speed up processing."
             icon={<Users className="h-4 w-4 contrast-icon-muted" aria-hidden="true" />}
-            controlClassName="sm:min-w-0 sm:flex sm:justify-end"
+            controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
           >
             <Switch
               checked={settings.enable_diarization !== false} // Default true

--- a/frontend/src/components/settings/InvitesTab.tsx
+++ b/frontend/src/components/settings/InvitesTab.tsx
@@ -180,7 +180,7 @@ export default function InvitesTab() {
           message="Create an invitation to generate a registration link for a new user."
         />
       ) : (
-        <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-4 grid-cols-1 @min-[33rem]:grid-cols-2 @min-[50rem]:grid-cols-3">
           {invitations.map((inv) => (
             <div
               key={inv.id}

--- a/frontend/src/components/settings/NotesTemplateEditorModal.tsx
+++ b/frontend/src/components/settings/NotesTemplateEditorModal.tsx
@@ -219,7 +219,11 @@ export default function NotesTemplateEditorModal({
         </>
       }
     >
-      <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,1fr)]">
+      {/* Container on a wrapper because the modal, not the viewport, decides
+          how wide the editor is. 64rem gives the narrowest of the three
+          columns roughly 19rem before they sit side by side. */}
+      <div className="@container h-full min-h-0">
+      <div className="grid h-full min-h-0 gap-6 @min-[64rem]:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,1fr)]">
           {/* Generate */}
           <div className="flex flex-col min-h-0 gap-3">
             <div>
@@ -355,6 +359,7 @@ export default function NotesTemplateEditorModal({
                 "Select Preview to see the exact prompt this structure produces, using a short sample transcript. No AI request is made."}
             </pre>
           </div>
+      </div>
       </div>
     </Modal>
   );

--- a/frontend/src/components/settings/SecondaryProviderSection.tsx
+++ b/frontend/src/components/settings/SecondaryProviderSection.tsx
@@ -126,7 +126,7 @@ export default function SecondaryProviderSection({
           </div>
 
           {isOllama && (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 @min-[42rem]:grid-cols-2 gap-6">
               <div>
                 <label className="block text-sm font-medium text-contrast-muted mb-2">
                   Secondary Ollama API URL

--- a/frontend/src/components/settings/ServerProviderSection.tsx
+++ b/frontend/src/components/settings/ServerProviderSection.tsx
@@ -90,7 +90,7 @@ export default function ServerProviderSection({
           </div>
 
           {isOllama && (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 @min-[42rem]:grid-cols-2 gap-6">
               <div>
                 <label className="block text-sm font-medium text-contrast-muted mb-2">
                   Ollama API URL

--- a/frontend/src/components/settings/SettingsBlock.tsx
+++ b/frontend/src/components/settings/SettingsBlock.tsx
@@ -42,7 +42,9 @@ export default function SettingsBlock({
   const hasHeader = Boolean(label || description || aside);
 
   return (
-    <div id={id} className={cn("settings-cell px-5 py-4 sm:px-6 scroll-mt-24", className)}>
+    // The block is a container so any grid in its content can query the width
+    // it actually has, which the viewport cannot see once the page is capped.
+    <div id={id} className={cn("@container settings-cell px-5 py-4 sm:px-6 scroll-mt-24", className)}>
       {hasHeader && (
         <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
           <div className="min-w-0">

--- a/frontend/src/components/settings/SettingsCard.tsx
+++ b/frontend/src/components/settings/SettingsCard.tsx
@@ -57,7 +57,9 @@ export default function SettingsCard({
         {headerAside && <div className="shrink-0">{headerAside}</div>}
       </div>
 
-      <div className={cn("settings-card-body border-t settings-divider", contentClassName)}>
+      {/* The body is a container so grids placed directly in a card, outside
+          any block, can query the card's width rather than the viewport's. */}
+      <div className={cn("@container settings-card-body border-t settings-divider", contentClassName)}>
         {children}
       </div>
     </section>

--- a/frontend/src/components/settings/SettingsRow.test.tsx
+++ b/frontend/src/components/settings/SettingsRow.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import SettingsRow from "./SettingsRow";
+
+describe("SettingsRow", () => {
+  it("renders label, description, and the control", () => {
+    render(
+      <SettingsRow label="Microphone" description="Pick the input device.">
+        <button type="button">Choose</button>
+      </SettingsRow>,
+    );
+
+    expect(screen.getByText("Microphone")).toBeTruthy();
+    expect(screen.getByText("Pick the input device.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Choose" })).toBeTruthy();
+  });
+
+  it("exposes the id as a scroll anchor on the root", () => {
+    const { container } = render(
+      <SettingsRow id="capture-microphone" label="Microphone" />,
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.id).toBe("capture-microphone");
+    expect(root.className).toContain("scroll-mt-24");
+  });
+
+  // jsdom cannot evaluate container queries, so the contract under test is the
+  // class strings: the row is its own container and every beside-layout class
+  // keys off the row's width rather than a viewport breakpoint.
+  it("marks the root as a container", () => {
+    const { container } = render(<SettingsRow label="Microphone" />);
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("@container");
+  });
+
+  it("switches to the beside-layout with container variants, not viewport ones", () => {
+    const { container } = render(
+      <SettingsRow label="Microphone" description="Pick the input device.">
+        <button type="button">Choose</button>
+      </SettingsRow>,
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    const layout = root.firstElementChild as HTMLElement;
+    expect(layout.className).toContain("flex-col");
+    expect(layout.className).toContain("@min-[26rem]:flex-row");
+    expect(layout.className).toContain("@min-[26rem]:justify-between");
+
+    const label = layout.children[0] as HTMLElement;
+    expect(label.className).toContain("@min-[26rem]:max-w-md");
+
+    const control = layout.children[1] as HTMLElement;
+    expect(control.className).toContain("w-full");
+    expect(control.className).toContain("@min-[26rem]:min-w-56");
+
+    // The stale viewport variants must not creep back in.
+    expect(root.outerHTML).not.toMatch(/sm:flex-row|sm:min-w-56|sm:max-w-md/);
+  });
+
+  it("lets controlClassName override the control's container variants", () => {
+    const { container } = render(
+      <SettingsRow
+        label="Connect"
+        controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
+      >
+        <button type="button">Connect</button>
+      </SettingsRow>,
+    );
+
+    const layout = (container.firstElementChild as HTMLElement)
+      .firstElementChild as HTMLElement;
+    const control = layout.children[1] as HTMLElement;
+    expect(control.className).toContain("@min-[26rem]:min-w-0");
+    expect(control.className).not.toContain("@min-[26rem]:min-w-56");
+  });
+});

--- a/frontend/src/components/settings/SettingsRow.tsx
+++ b/frontend/src/components/settings/SettingsRow.tsx
@@ -11,11 +11,6 @@ interface SettingsRowProps {
   icon?: ReactNode;
   /** Trailing badge next to the label, for status or scope. */
   badge?: ReactNode;
-  /**
-   * Stack the control beneath the label instead of beside it. For controls that
-   * need the full width: textareas, editors, multi-line pickers.
-   */
-  stacked?: boolean;
   className?: string;
   controlClassName?: string;
   children?: ReactNode;
@@ -26,6 +21,11 @@ interface SettingsRowProps {
  * control on the right, hairline separated from its neighbours by the parent
  * card. It draws no border and no background of its own, which is what keeps a
  * page to two surface levels.
+ *
+ * The row is its own container: rows land inside provider tiles and grid
+ * columns whose width the viewport cannot see, so the beside-layout keys off
+ * the row's own width. Below the threshold the row stacks, which is also the
+ * phone layout, so narrow columns and small screens share one mechanism.
  */
 export default function SettingsRow({
   id,
@@ -33,7 +33,6 @@ export default function SettingsRow({
   description,
   icon,
   badge,
-  stacked = false,
   className,
   controlClassName,
   children,
@@ -41,39 +40,41 @@ export default function SettingsRow({
   return (
     <div
       id={id}
+      // Padding stays on the viewport scale: it must line up with the card
+      // gutter, which globals.css steps at the same sm breakpoint.
       className={cn(
-        "settings-cell px-5 py-4 sm:px-6",
-        stacked
-          ? "space-y-3"
-          : "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-6",
-        "scroll-mt-24",
+        "@container settings-cell px-5 py-4 sm:px-6 scroll-mt-24",
         className,
       )}
     >
-      <div className={cn("min-w-0", !stacked && "sm:max-w-md")}>
-        <div className="flex flex-wrap items-center gap-2">
-          {icon}
-          <span className="text-sm font-medium text-foreground">
-            {label}
-          </span>
-          {badge}
+      {/* 26rem = the control's 14rem floor + the 1.5rem gap + at least
+          10.5rem for the label before the two sit side by side. */}
+      <div className="flex flex-col gap-3 @min-[26rem]:flex-row @min-[26rem]:items-start @min-[26rem]:justify-between @min-[26rem]:gap-6">
+        <div className="min-w-0 @min-[26rem]:max-w-md">
+          <div className="flex flex-wrap items-center gap-2">
+            {icon}
+            <span className="text-sm font-medium text-foreground">
+              {label}
+            </span>
+            {badge}
+          </div>
+
+          {description && (
+            <p className="mt-1 text-xs leading-5 contrast-helper">{description}</p>
+          )}
         </div>
 
-        {description && (
-          <p className="mt-1 text-xs leading-5 contrast-helper">{description}</p>
+        {children && (
+          <div
+            className={cn(
+              "w-full shrink-0 @min-[26rem]:w-auto @min-[26rem]:min-w-56 @min-[26rem]:max-w-sm",
+              controlClassName,
+            )}
+          >
+            {children}
+          </div>
         )}
       </div>
-
-      {children && (
-        <div
-          className={cn(
-            stacked ? "w-full" : "w-full shrink-0 sm:w-auto sm:min-w-56 sm:max-w-sm",
-            controlClassName,
-          )}
-        >
-          {children}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/settings/SystemTab.tsx
+++ b/frontend/src/components/settings/SystemTab.tsx
@@ -641,7 +641,7 @@ export default function SystemTab() {
       )}
 
       {adminHealth && (
-        <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-4 @min-[33rem]:grid-cols-2 @min-[67rem]:grid-cols-4">
           {HEALTH_CARDS.map(({ key, title, icon: Icon }) => {
             const check = adminHealth.checks[key];
             const styles = STATUS_STYLES[check.status as AdminHealthCheckStatus];

--- a/frontend/src/components/settings/TelemetrySection.tsx
+++ b/frontend/src/components/settings/TelemetrySection.tsx
@@ -134,7 +134,7 @@ export default function TelemetrySection() {
             ? "A ping is sent once a day."
             : "Nothing is sent."
         }
-        controlClassName="sm:min-w-0 sm:flex sm:justify-end"
+        controlClassName="@min-[26rem]:min-w-0 @min-[26rem]:flex @min-[26rem]:justify-end"
       >
         <Switch
           checked={status.enabled}
@@ -170,7 +170,7 @@ export default function TelemetrySection() {
       </SettingsBlock>
 
       <SettingsBlock>
-        <dl className="grid gap-3 text-sm sm:grid-cols-2">
+        <dl className="grid gap-3 text-sm @min-[33rem]:grid-cols-2">
           <div>
             <dt className="text-contrast-helper">Install ID</dt>
             <dd className="font-mono text-xs break-all text-foreground">
@@ -183,7 +183,7 @@ export default function TelemetrySection() {
               {formatTimestamp(status.last_sent_at)}
             </dd>
           </div>
-          <div className="sm:col-span-2">
+          <div className="@min-[33rem]:col-span-2">
             <dt className="text-contrast-helper">Endpoint</dt>
             <dd className="font-mono text-xs break-all text-foreground">
               {status.endpoint}

--- a/frontend/src/components/settings/UpdatesSettings.tsx
+++ b/frontend/src/components/settings/UpdatesSettings.tsx
@@ -330,9 +330,11 @@ export default function UpdatesSettings({
           </button>
         }
       >
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.85fr)]">
-          <div className="space-y-4">
-            <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-6 @min-[46rem]:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.85fr)]">
+          {/* The column is a container of its own so the stat pair below
+              queries the column's width, not the whole card's. */}
+          <div className="@container space-y-4">
+            <div className="grid gap-4 @min-[33rem]:grid-cols-2">
               <SettingsBlock inset>
                 <p className="text-xs font-semibold uppercase tracking-wide contrast-helper">
                   Installed version

--- a/frontend/src/components/settings/UsersTab.tsx
+++ b/frontend/src/components/settings/UsersTab.tsx
@@ -233,7 +233,7 @@ export default function UsersTab() {
           <form
             onSubmit={handleCreateUser}
             autoComplete="off"
-            className="grid grid-cols-1 md:grid-cols-2 gap-4"
+            className="grid grid-cols-1 @min-[44rem]:grid-cols-2 gap-4"
           >
             <input
               name="new-user-username"
@@ -270,7 +270,7 @@ export default function UsersTab() {
               <option value="admin">Admin</option>
               <option value="owner">Owner</option>
             </select>
-            <div className="md:col-span-2 flex justify-end gap-2">
+            <div className="@min-[44rem]:col-span-2 flex justify-end gap-2">
               <button
                 type="button"
                 onClick={() => {

--- a/frontend/src/components/ui/FitText.test.tsx
+++ b/frontend/src/components/ui/FitText.test.tsx
@@ -1,0 +1,100 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import FitText from "./FitText";
+
+// jsdom performs no layout, so the sizes the fit calculation reads are
+// simulated at the prototype level: clientWidth for the container,
+// scrollWidth for the invisible measurement span.
+const defineSizes = (clientWidth: number, scrollWidth: number) => {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return clientWidth;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+    configurable: true,
+    get() {
+      return scrollWidth;
+    },
+  });
+};
+
+afterEach(() => {
+  defineSizes(0, 0);
+});
+
+const visibleSpan = (host: HTMLElement) => {
+  const span = host.querySelector("span > span:not([aria-hidden])");
+  expect(span).not.toBeNull();
+  return span as HTMLElement;
+};
+
+describe("FitText", () => {
+  it("keeps the designed size when no measurements are available", () => {
+    const { container } = render(
+      <FitText maxRem={1.5} minRem={1}>
+        Quarterly Planning Sync
+      </FitText>,
+    );
+
+    const span = visibleSpan(container);
+    expect(span.style.fontSize).toBe("1.5rem");
+    expect(span.className).toContain("truncate");
+    expect(span.className).not.toContain("line-clamp-2");
+  });
+
+  it("keeps the designed size when the line already fits", () => {
+    defineSizes(400, 300);
+    const { container } = render(
+      <FitText maxRem={1.5} minRem={1}>
+        Short title
+      </FitText>,
+    );
+
+    expect(visibleSpan(container).style.fontSize).toBe("1.5rem");
+  });
+
+  it("shrinks proportionally when the line overflows", () => {
+    defineSizes(200, 300);
+    const { container } = render(
+      <FitText maxRem={1.5} minRem={1}>
+        A title that is somewhat too long
+      </FitText>,
+    );
+
+    const span = visibleSpan(container);
+    // 1.5rem scaled by 200/300 = 1rem exactly, still at the floor boundary.
+    expect(span.style.fontSize).toBe("1rem");
+    expect(span.className).toContain("truncate");
+  });
+
+  it("floors at minRem and wraps to two lines when even the floor overflows", () => {
+    defineSizes(100, 1000);
+    const { container } = render(
+      <FitText maxRem={1.5} minRem={1}>
+        An exceedingly long meeting title that cannot fit on one line at any
+        permitted size
+      </FitText>,
+    );
+
+    const span = visibleSpan(container);
+    expect(span.style.fontSize).toBe("1rem");
+    expect(span.className).toContain("line-clamp-2");
+    expect(span.className).not.toContain("truncate");
+  });
+
+  it("renders the measurement copy at the designed size, hidden from assistive tech", () => {
+    const { container } = render(
+      <FitText maxRem={2} minRem={1}>
+        Measured
+      </FitText>,
+    );
+
+    const measure = container.querySelector("span[aria-hidden]") as HTMLElement;
+    expect(measure).not.toBeNull();
+    expect(measure.style.fontSize).toBe("2rem");
+    expect(measure.className).toContain("invisible");
+  });
+});

--- a/frontend/src/components/ui/FitText.tsx
+++ b/frontend/src/components/ui/FitText.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "@/lib/cn";
+
+interface FitTextProps {
+  /** Designed size, in rem, used whenever the text fits on one line. */
+  maxRem: number;
+  /** Readability floor, in rem. Below it the text wraps instead of shrinking. */
+  minRem: number;
+  children: string;
+  className?: string;
+}
+
+/**
+ * Shrinks a single line of text to fit its container's width, stepping the
+ * font down from maxRem towards minRem. CSS alone cannot do this: clamp()
+ * tracks the container's size, never the text's own length. When even minRem
+ * cannot fit the line, the text wraps and clamps to two lines instead — the
+ * floor is a readability contract, not a truncation point.
+ */
+export default function FitText({
+  maxRem,
+  minRem,
+  children,
+  className,
+}: FitTextProps) {
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const [fontRem, setFontRem] = useState(maxRem);
+  const [wraps, setWraps] = useState(false);
+
+  const fit = useCallback(() => {
+    const container = containerRef.current;
+    const measure = measureRef.current;
+    if (!container || !measure) return;
+    const available = container.clientWidth;
+    const needed = measure.scrollWidth;
+    // jsdom and the pre-paint frame both report zero; keep the designed size.
+    if (available <= 0 || needed <= 0) {
+      setFontRem(maxRem);
+      setWraps(false);
+      return;
+    }
+    const scaled = maxRem * (available / needed);
+    if (scaled >= maxRem) {
+      setFontRem(maxRem);
+      setWraps(false);
+    } else if (scaled >= minRem) {
+      setFontRem(scaled);
+      setWraps(false);
+    } else {
+      setFontRem(minRem);
+      setWraps(true);
+    }
+  }, [maxRem, minRem]);
+
+  useLayoutEffect(() => {
+    fit();
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(fit);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [fit, children]);
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn("relative block w-full min-w-0", className)}
+    >
+      {/* Invisible copy at the designed size gives the single-line width the
+          fit calculation needs without disturbing layout. */}
+      <span
+        ref={measureRef}
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute whitespace-nowrap"
+        style={{ fontSize: `${maxRem}rem` }}
+      >
+        {children}
+      </span>
+      <span
+        className={
+          wraps
+            ? "block break-words line-clamp-2"
+            : "block truncate whitespace-nowrap"
+        }
+        style={{ fontSize: `${fontRem}rem` }}
+      >
+        {children}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/lib/store.test.ts
+++ b/frontend/src/lib/store.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useNavigationStore } from "./store";
+
+describe("useNavigationStore collapse state", () => {
+  beforeEach(() => {
+    useNavigationStore.setState({
+      isRecordingsSidebarCollapsed: false,
+      isSpeakerPanelCollapsed: false,
+      isChatPanelCollapsed: false,
+    });
+  });
+
+  it("defaults every collapse flag to expanded", () => {
+    const state = useNavigationStore.getState();
+    expect(state.isRecordingsSidebarCollapsed).toBe(false);
+    expect(state.isSpeakerPanelCollapsed).toBe(false);
+    expect(state.isChatPanelCollapsed).toBe(false);
+  });
+
+  it("toggles the recordings sidebar collapse", () => {
+    useNavigationStore.getState().toggleRecordingsSidebarCollapse();
+    expect(
+      useNavigationStore.getState().isRecordingsSidebarCollapsed,
+    ).toBe(true);
+    useNavigationStore.getState().toggleRecordingsSidebarCollapse();
+    expect(
+      useNavigationStore.getState().isRecordingsSidebarCollapsed,
+    ).toBe(false);
+  });
+
+  it("sets the side panels independently", () => {
+    useNavigationStore.getState().setSpeakerPanelCollapsed(true);
+    expect(useNavigationStore.getState().isSpeakerPanelCollapsed).toBe(true);
+    expect(useNavigationStore.getState().isChatPanelCollapsed).toBe(false);
+
+    useNavigationStore.getState().setChatPanelCollapsed(true);
+    expect(useNavigationStore.getState().isChatPanelCollapsed).toBe(true);
+
+    useNavigationStore.getState().setSpeakerPanelCollapsed(false);
+    expect(useNavigationStore.getState().isSpeakerPanelCollapsed).toBe(false);
+    expect(useNavigationStore.getState().isChatPanelCollapsed).toBe(true);
+  });
+
+  it("persists all three collapse flags", () => {
+    // The partialize whitelist is what survives a reload; a flag missing
+    // from it would silently reset on every visit.
+    const persisted = useNavigationStore.persist.getOptions().partialize?.(
+      useNavigationStore.getState(),
+    ) as Record<string, unknown>;
+
+    expect(persisted).toHaveProperty("isRecordingsSidebarCollapsed");
+    expect(persisted).toHaveProperty("isSpeakerPanelCollapsed");
+    expect(persisted).toHaveProperty("isChatPanelCollapsed");
+  });
+});

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -23,6 +23,8 @@ interface NavigationState {
   setNavWidth: (width: number) => void;
   recordingsSidebarWidth: number;
   setRecordingsSidebarWidth: (width: number) => void;
+  isRecordingsSidebarCollapsed: boolean;
+  toggleRecordingsSidebarCollapse: () => void;
   expandedTagIds: number[];
   toggleExpandedTag: (tagId: number) => void;
   setExpandedTagIds: (ids: number[]) => void;
@@ -52,6 +54,12 @@ interface NavigationState {
   // Chat Panel State
   chatPanelHeight: number;
   setChatPanelHeight: (height: number) => void;
+
+  // Recording Detail Side-Panel Collapse State
+  isSpeakerPanelCollapsed: boolean;
+  setSpeakerPanelCollapsed: (collapsed: boolean) => void;
+  isChatPanelCollapsed: boolean;
+  setChatPanelCollapsed: (collapsed: boolean) => void;
 
   // Log Settings
   logShowTimestamps: boolean;
@@ -90,6 +98,11 @@ export const useNavigationStore = create<NavigationState>()(
       setNavWidth: (width) => set({ navWidth: width }),
       recordingsSidebarWidth: 320,
       setRecordingsSidebarWidth: (width) => set({ recordingsSidebarWidth: width }),
+      isRecordingsSidebarCollapsed: false,
+      toggleRecordingsSidebarCollapse: () =>
+        set((state) => ({
+          isRecordingsSidebarCollapsed: !state.isRecordingsSidebarCollapsed,
+        })),
       expandedTagIds: [],
       toggleExpandedTag: (tagId) =>
         set((state) => ({
@@ -154,6 +167,14 @@ export const useNavigationStore = create<NavigationState>()(
       chatPanelHeight: 50,
       setChatPanelHeight: (height) => set({ chatPanelHeight: height }),
 
+      // Recording Detail Side-Panel Collapse State
+      isSpeakerPanelCollapsed: false,
+      setSpeakerPanelCollapsed: (collapsed) =>
+        set({ isSpeakerPanelCollapsed: collapsed }),
+      isChatPanelCollapsed: false,
+      setChatPanelCollapsed: (collapsed) =>
+        set({ isChatPanelCollapsed: collapsed }),
+
       // Log Settings
       logShowTimestamps: true,
       toggleLogShowTimestamps: () =>
@@ -172,11 +193,14 @@ export const useNavigationStore = create<NavigationState>()(
         isNavCollapsed: state.isNavCollapsed,
         navWidth: state.navWidth,
         recordingsSidebarWidth: state.recordingsSidebarWidth,
+        isRecordingsSidebarCollapsed: state.isRecordingsSidebarCollapsed,
         expandedTagIds: state.expandedTagIds,
         hasSeenTour: state.hasSeenTour,
         hasSeenRecordingsTour: state.hasSeenRecordingsTour,
         hasSeenTranscriptTour: state.hasSeenTranscriptTour,
         chatPanelHeight: state.chatPanelHeight,
+        isSpeakerPanelCollapsed: state.isSpeakerPanelCollapsed,
+        isChatPanelCollapsed: state.isChatPanelCollapsed,
         logShowTimestamps: state.logShowTimestamps,
         logWordWrap: state.logWordWrap,
         activePanel: state.activePanel,


### PR DESCRIPTION
## Description

Usability pass for laptops and phones: gives the user control over
workspace space and fixes the layout class that broke the calendar
provider credentials card.

- The meeting view's Speakers and Chat panels collapse independently;
  collapsing both leaves an icon strip. The recordings rail collapses
  to a slim strip matching the nav rail. All collapse states persist.
- The meeting header loses ~70-90px of fixed chrome: tags and the
  link-calendar pill share one wrapping row, a dead flex column and a
  stray margin are gone, and padding steps down one notch.
- New FitText primitive scales the meeting title from its designed
  size to a 17px floor, then wraps to a two-line clamp; fluid heading
  clamps now also apply below the desktop breakpoint. The density
  heading rules moved out of @layer components, where the utilities
  layer had silently beaten them since the flat restyle.
- Sidebar meeting-card metadata never word-wraps again: nowrap spans
  plus a container query that drops the time range below 19rem. Card
  titles clamp to two lines instead of truncating.
- Settings primitives are container-aware: SettingsBlock/SettingsCard
  are containers, SettingsRow stacks on its own width, and every
  settings grid that subdivided on a viewport breakpoint now queries
  its container. The provider credentials card was unsatisfiable at
  every window width (label column capped at ~24px); it now stacks.
- Four fixed grid-cols-N sites (voiceprint actions, speaker scope
  toggle, tasks filter, recording info) collapse behind container
  queries on narrow containers.
- Mobile follow-ups found in smoke testing: the floating Back/More
  overlay was painted over by the solid sticky header (equal z-index,
  later DOM order) - both controls are now inline in the header card
  and the reserved 4.75rem dead band is gone; the actions popover
  moved from translucent action-tint to the solid float surface; the
  tag tree now scrolls on touch (MouseSensor + delay-activated
  TouchSensor, touch-manipulation) instead of dragging tags and
  nesting them by accident; login/register/setup autocomplete tokens
  lost their section- prefixes so password managers fill both fields.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1316 passed)
- [ ] Python quality: `python scripts/check.py` (no Python touched)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (399 passed,
      including new FitText, store persistence, and SettingsRow suites)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Also run: `npm run check:contrast` (190 pairings, 3 themes) and
`git diff --check`.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR: DESIGN.md
      (collapsible surfaces, heading scale and its cascade-layer
      constraint, FitText, settings container-query compliance) and
      USAGE.md (collapsible panels and recordings list).

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

The auth pages change only their autocomplete/name markup for password
manager compatibility; no auth flow, session, or token behaviour is
touched.

## Manual verification

Smoke tested on the live deployment, dark and light themes:

- Desktop (1440x900 and 2560x1440): panel collapse/restore/persist
  across reloads and density changes, vertical divider resize, header
  single-row tags+calendar, long-title shrink and two-line wrap,
  recordings rail collapse, rail at minimum width with one-line
  metadata (with and without selection mode), Calendar Provider
  Credentials card and a sweep of all settings pages.
- Phone (Android Chrome): headings scaled, no horizontal scroll,
  recording view header with inline Back/actions and no dead band,
  actions popover opaque and legible, tag tree scrolls with
  press-and-hold drag still working, Proton Pass fills username and
  password, info/voiceprint dialogs stack to one column, no collapse
  controls present on mobile.

Browser capture flows are untouched; no capture smoke required.

## Screenshots (if relevant)

None attached; before/after phone screenshots exist in the review
conversation.
