### PR TITLE
fix(deploy): pass documented environment variables to containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,12 +19,15 @@ DEFAULT_TIMEZONE=UTC
 MCP_ENABLED=true # Built-in MCP connector for AI assistants (docs/MCP.md); set to false to disable the /mcp endpoint and its OAuth surface
 MCP_ANONYMOUS_DISCOVERY=true # Anonymous MCP handshake and tool listing so Codex Desktop can start OAuth (docs/MCP.md); set to false to require authentication for every request
 NOJOIN_TELEMETRY_ENABLED= # Anonymous usage data (docs/TELEMETRY.md). Leave empty to manage it in Settings; set to false to disable it permanently and lock the UI toggle
+BACKUP_EXPORT_DIR= # Where exported backup archives are written (docs/BACKUP_RESTORE.md). Defaults to data/backups; the API and the workers must agree on the value
+NOJOIN_UMASK= # umask for the application processes. Defaults to 0077 (owner-only access)
 HF_TOKEN= # Optional: only needed to refresh bundled Pyannote assets from Hugging Face
 LLM_PROVIDER= #One of: gemini, openai, anthropic, ollama
 GEMINI_API_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 OLLAMA_API_URL=http://host.docker.internal:11434
+OLLAMA_CONTEXT_WINDOW= # Ollama num_ctx. Defaults to 32768. The KV cache is roughly 190 KiB per token on a 14B model, so 32768 costs about 6 GB of VRAM on top of the weights; raise it only if the card has the headroom
 
 # Secondary LLM Provider (used when primary is unavailable)
 SECONDARY_LLM_PROVIDER= #One of: gemini, openai, anthropic, ollama
@@ -32,6 +35,7 @@ SECONDARY_GEMINI_API_KEY=
 SECONDARY_OPENAI_API_KEY=
 SECONDARY_ANTHROPIC_API_KEY=
 SECONDARY_OLLAMA_API_URL=http://host.docker.internal:11434
+SECONDARY_OLLAMA_CONTEXT_WINDOW= # Ollama num_ctx for the secondary provider. Defaults to 32768
 
 # Calendar OAuth
 GOOGLE_OAUTH_CLIENT_ID=

--- a/backend/tests/test_compose_env_plumbing.py
+++ b/backend/tests/test_compose_env_plumbing.py
@@ -1,0 +1,92 @@
+"""The deployment templates have to carry every setting they promise.
+
+An operator configures Nojoin through three lists that nothing keeps in step:
+``docs/DEPLOYMENT.md`` describes a variable, ``.env.example`` prompts for it,
+and ``docker-compose.example.yml`` is the only one of the three that actually
+puts it inside a container. Compose has no pass-everything-through mode, so a
+variable missing from the last list is read by nobody and fails silently: the
+stack starts, the application default wins, and the operator has no signal that
+their setting was discarded. That is how ``OLLAMA_CONTEXT_WINDOW`` shipped
+documented but inert.
+
+Parsed as text rather than with PyYAML deliberately: PyYAML reaches this suite
+only as a transitive dependency of the model stack and is declared in no
+requirements file, so importing it here would add an undeclared dependency to
+guard against a formatting change that has never happened.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from backend.utils.config_manager import ENV_OVERRIDES
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPO_ROOT / "docker-compose.example.yml"
+ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
+
+# The anchor every service running application code merges in. It is the only
+# placement that guarantees the API and all four worker lanes agree, which these
+# settings need: config_manager is loaded in both, so a value present on one
+# side only makes a worker disagree with the API about the active provider.
+SHARED_ANCHOR = "x-shared-app-environment"
+
+_ENV_KEY_RE = re.compile(r"^(\s+)([A-Z][A-Z0-9_]*):")
+
+
+def _shared_anchor_env_keys(text: str) -> set[str]:
+    """Collect the variable names declared in the shared environment anchor.
+
+    Reads from the anchor's opening line until the first line at or left of its
+    own indentation, which is where the block ends in any valid YAML.
+    """
+    keys: set[str] = set()
+    in_block = False
+    for line in text.splitlines():
+        if not in_block:
+            if line.startswith(f"{SHARED_ANCHOR}:"):
+                in_block = True
+            continue
+        if line.strip() and not line.startswith((" ", "\t")):
+            break
+        match = _ENV_KEY_RE.match(line)
+        if match:
+            keys.add(match.group(2))
+    return keys
+
+
+def _env_example_keys(text: str) -> set[str]:
+    keys: set[str] = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        keys.add(stripped.split("=", 1)[0].strip())
+    return keys
+
+
+def test_shared_anchor_is_parsed_at_all() -> None:
+    """Guard the parser itself: a silent miss would pass every other test."""
+    keys = _shared_anchor_env_keys(COMPOSE_PATH.read_text(encoding="utf-8"))
+    assert "DATABASE_URL" in keys
+    assert "LLM_PROVIDER" in keys
+
+
+def test_env_overrides_reach_the_containers() -> None:
+    keys = _shared_anchor_env_keys(COMPOSE_PATH.read_text(encoding="utf-8"))
+    missing = sorted(set(ENV_OVERRIDES.values()) - keys)
+    assert not missing, (
+        f"{missing} are read by config_manager but no service passes them in. "
+        f"Add them to the {SHARED_ANCHOR} anchor in docker-compose.example.yml, "
+        "or an operator who sets them gets the application default and no warning."
+    )
+
+
+def test_env_overrides_are_offered_to_operators() -> None:
+    keys = _env_example_keys(ENV_EXAMPLE_PATH.read_text(encoding="utf-8"))
+    missing = sorted(set(ENV_OVERRIDES.values()) - keys)
+    assert not missing, (
+        f"{missing} are supported but absent from .env.example, so nothing tells "
+        "an operator the setting exists."
+    )

--- a/backend/utils/config_manager.py
+++ b/backend/utils/config_manager.py
@@ -148,8 +148,14 @@ DEFAULT_SYSTEM_CONFIG = {
     "transcription_backend": "whisper",  # "whisper" | "parakeet" | "canary"
     "parakeet_model": "parakeet-tdt-0.6b-v3",
     "canary_model": "nemo-canary-1b-v2",
-    "ollama_context_window": 131072,
-    "secondary_ollama_context_window": 131072,
+    # Ollama num_ctx. Sized for the hardware this project is actually
+    # self-hosted on rather than for the model's advertised maximum: a KV cache
+    # costs roughly 190 KiB per token on a 14B model, so 32768 is about 6 GB and
+    # fits alongside quantised weights on a 16 GB card. It still covers a
+    # two-hour meeting (~25-30k tokens). The previous 131072 needed ~24 GB of
+    # cache on its own and silently failed to load on any consumer GPU.
+    "ollama_context_window": 32768,
+    "secondary_ollama_context_window": 32768,
     "enable_live_transcription": True,
     "live_context_window_s": 5.0,
     "live_forced_max_s": 8.0,
@@ -202,7 +208,7 @@ DEFAULT_USER_SETTINGS = {
     "ollama_model": None,  # Default Ollama model
     "ollama_live_model": None,  # Optional lower-latency Meeting Edge Ollama model
     "ollama_api_url": "http://host.docker.internal:11434",  # Default Ollama API URL
-    "ollama_context_window": 131072,  # Ollama num_ctx for full-context meeting chat
+    "ollama_context_window": 32768,  # Ollama num_ctx for full-context meeting chat
     "secondary_llm_provider": None,  # Secondary LLM provider (used when primary is unavailable)
     "secondary_gemini_model": None,  # Secondary Gemini model
     "secondary_gemini_live_model": None,  # Optional secondary Meeting Edge Gemini model
@@ -213,7 +219,7 @@ DEFAULT_USER_SETTINGS = {
     "secondary_ollama_model": None,  # Secondary Ollama model
     "secondary_ollama_live_model": None,  # Optional secondary Meeting Edge Ollama model
     "secondary_ollama_api_url": "http://host.docker.internal:11434",  # Default secondary Ollama URL
-    "secondary_ollama_context_window": 131072,  # Secondary Ollama num_ctx
+    "secondary_ollama_context_window": 32768,  # Secondary Ollama num_ctx
     "secondary_gemini_api_key": None,  # Secondary Gemini API key
     "secondary_openai_api_key": None,  # Secondary OpenAI API key
     "secondary_anthropic_api_key": None,  # Secondary Anthropic API key
@@ -236,6 +242,20 @@ DEFAULT_USER_SETTINGS = {
     "enable_diarization": True,  # Enable Speaker Diarization (who said what)
     "spellcheck_language": "en-GB",  # Default spell check language for meeting notes
     "timezone": "UTC",  # Default user timezone for calendar and task rendering
+}
+
+# Install-wide settings an operator can drive from the environment instead of
+# config.json. Module level rather than local to _load_config so the deployment
+# templates can be checked against it: a key here that no service passes through
+# is a setting the documentation promises and the containers never receive
+# (see backend/tests/test_compose_env_plumbing.py).
+ENV_OVERRIDES = {
+    "llm_provider": "LLM_PROVIDER",
+    "ollama_api_url": "OLLAMA_API_URL",
+    "ollama_context_window": "OLLAMA_CONTEXT_WINDOW",
+    "secondary_llm_provider": "SECONDARY_LLM_PROVIDER",
+    "secondary_ollama_api_url": "SECONDARY_OLLAMA_API_URL",
+    "secondary_ollama_context_window": "SECONDARY_OLLAMA_CONTEXT_WINDOW",
 }
 
 WHISPER_MODEL_SIZES = ["turbo", "tiny", "base", "small", "medium", "large"]
@@ -388,15 +408,7 @@ class ConfigManager:
         # Overlay ENV values for install-wide LLM settings. These take precedence
         # over config.json so that operators can manage the active provider and
         # endpoints via .env without having to edit config.json directly.
-        env_overrides = {
-            "llm_provider": "LLM_PROVIDER",
-            "ollama_api_url": "OLLAMA_API_URL",
-            "ollama_context_window": "OLLAMA_CONTEXT_WINDOW",
-            "secondary_llm_provider": "SECONDARY_LLM_PROVIDER",
-            "secondary_ollama_api_url": "SECONDARY_OLLAMA_API_URL",
-            "secondary_ollama_context_window": "SECONDARY_OLLAMA_CONTEXT_WINDOW",
-        }
-        for config_key, env_key in env_overrides.items():
+        for config_key, env_key in ENV_OVERRIDES.items():
             env_val = os.environ.get(env_key)
             if env_val is not None and env_val != "":
                 if config_key.endswith("_context_window"):

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,16 +18,27 @@ x-shared-app-environment: &shared-app-environment
   # they fall back to the localhost default and build the wrong URL.
   WEB_APP_URL: ${WEB_APP_URL:-https://localhost:14443}
   NOJOIN_TELEMETRY_ENABLED: ${NOJOIN_TELEMETRY_ENABLED:-}
+  NOJOIN_TELEMETRY_ENDPOINT: ${NOJOIN_TELEMETRY_ENDPOINT:-}
+  # Exports have to be readable by whoever serves them: a worker writes the
+  # archive and the API streams it back, so both sides must resolve the same
+  # directory. Setting it on one service only silently breaks the download.
+  BACKUP_EXPORT_DIR: ${BACKUP_EXPORT_DIR:-}
+  NOJOIN_UMASK: ${NOJOIN_UMASK:-}
   LLM_PROVIDER: ${LLM_PROVIDER:-gemini}
   GEMINI_API_KEY: ${GEMINI_API_KEY:-}
   OPENAI_API_KEY: ${OPENAI_API_KEY:-}
   ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
   OLLAMA_API_URL: ${OLLAMA_API_URL:-http://host.docker.internal:11434}
+  # No default here on purpose. config_manager owns the application default and
+  # skips an empty value, so an unset variable falls through to it; repeating a
+  # number here would create a second default to keep in step.
+  OLLAMA_CONTEXT_WINDOW: ${OLLAMA_CONTEXT_WINDOW:-}
   SECONDARY_LLM_PROVIDER: ${SECONDARY_LLM_PROVIDER:-}
   SECONDARY_GEMINI_API_KEY: ${SECONDARY_GEMINI_API_KEY:-}
   SECONDARY_OPENAI_API_KEY: ${SECONDARY_OPENAI_API_KEY:-}
   SECONDARY_ANTHROPIC_API_KEY: ${SECONDARY_ANTHROPIC_API_KEY:-}
   SECONDARY_OLLAMA_API_URL: ${SECONDARY_OLLAMA_API_URL:-http://host.docker.internal:11434}
+  SECONDARY_OLLAMA_CONTEXT_WINDOW: ${SECONDARY_OLLAMA_CONTEXT_WINDOW:-}
   DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
   GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID:-}
   GOOGLE_OAUTH_CLIENT_SECRET: ${GOOGLE_OAUTH_CLIENT_SECRET:-}
@@ -64,6 +75,11 @@ x-worker-base: &worker-base
 
 x-worker-environment: &worker-environment
   <<: *shared-app-environment
+  # Only the worker lanes ever run a subscription CLI, and only the two on the
+  # io image carry the binary. Declared for all four rather than merged into
+  # those two separately: it is inert where codex is absent, and a single
+  # declaration cannot drift.
+  NOJOIN_CODEX_PATH: ${NOJOIN_CODEX_PATH:-}
   XDG_CACHE_HOME: /home/appuser/.cache
   HF_HOME: /home/appuser/.cache/huggingface
   OMP_NUM_THREADS: 2
@@ -143,6 +159,7 @@ services:
       <<: *shared-app-environment
       DOCKER_HOST: tcp://socket-proxy:2375
       MCP_ENABLED: ${MCP_ENABLED:-true}
+      MCP_ANONYMOUS_DISCOVERY: ${MCP_ANONYMOUS_DISCOVERY:-true}
       FIRST_RUN_PASSWORD: ${FIRST_RUN_PASSWORD:?Set FIRST_RUN_PASSWORD in .env}
       XDG_CACHE_HOME: /shared_model_cache
       HF_HOME: /shared_model_cache/huggingface

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -333,6 +333,8 @@ lanes then run on CPU.
 Create `.env` from `.env.example` and treat it as the canonical operator configuration file.
 The compose stack derives internal service URLs for PostgreSQL, Redis, and Celery automatically, so those values are intentionally not part of `.env.example`.
 Keep any secrets, private mounts, or machine-specific overrides in your local `docker-compose.yml`, not in the tracked template.
+Every variable below is only read by a container if that container's compose service passes it in, which the shipped `docker-compose.example.yml` does for all of them.
+If you maintain your own compose file, a variable you set in `.env` but never declare in a service's `environment:` block is silently discarded: the stack starts and the application default applies with no warning.
 Nojoin auto-generates and persists its JWT signing keyring under `data/.secret_keys.json` in the default deployment, migrating any legacy `data/.secret_key` file on startup, so no `.env` setting is required for that.
 Nojoin can also auto-generate `data/.data_encryption_key`, but operators should treat that as a fallback rather than the primary persistence strategy.
 
@@ -362,13 +364,13 @@ Nojoin can also auto-generate `data/.data_encryption_key`, but operators should 
 - `OPENAI_API_KEY`: OpenAI API key.
 - `ANTHROPIC_API_KEY`: Anthropic API key.
 - `OLLAMA_API_URL`: Local or remote Ollama endpoint.
-- `OLLAMA_CONTEXT_WINDOW`: Ollama `num_ctx` value used for full-context meeting prompts. Defaults to `131072`; ensure the selected model and hardware can support the requested context.
+- `OLLAMA_CONTEXT_WINDOW`: Ollama `num_ctx` value used for full-context meeting prompts. Defaults to `32768`, which covers a two-hour meeting (roughly 25,000 to 30,000 tokens). Size it against VRAM, not against the model's advertised maximum: the KV cache costs roughly 190 KiB per token on a 14B model, so `32768` is about 6 GB on top of the weights and `131072` would be about 24 GB, which no consumer card can hold. Ollama fails the load outright rather than degrading if the cache does not fit.
 - `SECONDARY_LLM_PROVIDER`: Secondary LLM provider used when the primary fails. Same values as `LLM_PROVIDER`. Leave empty to disable fallback.
 - `SECONDARY_GEMINI_API_KEY`: Gemini API key for the secondary provider.
 - `SECONDARY_OPENAI_API_KEY`: OpenAI API key for the secondary provider.
 - `SECONDARY_ANTHROPIC_API_KEY`: Anthropic API key for the secondary provider.
 - `SECONDARY_OLLAMA_API_URL`: Ollama endpoint for the secondary provider.
-- `SECONDARY_OLLAMA_CONTEXT_WINDOW`: Ollama `num_ctx` value for the secondary Ollama provider. Defaults to `131072`.
+- `SECONDARY_OLLAMA_CONTEXT_WINDOW`: Ollama `num_ctx` value for the secondary Ollama provider. Defaults to `32768`; the same VRAM sizing applies.
 - `GOOGLE_OAUTH_CLIENT_ID`: Google calendar OAuth client ID.
 - `GOOGLE_OAUTH_CLIENT_SECRET`: Google calendar OAuth client secret.
 - `MICROSOFT_OAUTH_CLIENT_ID`: Microsoft calendar OAuth client ID.

--- a/frontend/src/components/settings/aiSettingsModels.ts
+++ b/frontend/src/components/settings/aiSettingsModels.ts
@@ -6,7 +6,13 @@ import { Settings } from "@/types";
  * component remains responsible for calling `onUpdate`/`onPersist`.
  */
 
-export const DEFAULT_OLLAMA_CONTEXT_WINDOW = 131072;
+/**
+ * Placeholder shown before an install has saved a context window, and the
+ * recovery value for unparseable input. Must match `ollama_context_window` in
+ * the backend's DEFAULT_SYSTEM_CONFIG, which is the real default; this copy
+ * exists only so the form has something to render before settings arrive.
+ */
+export const DEFAULT_OLLAMA_CONTEXT_WINDOW = 32768;
 
 export type ModelKind = "main" | "live";
 


### PR DESCRIPTION
# Pull Request

## Description

`OLLAMA_CONTEXT_WINDOW` and `SECONDARY_OLLAMA_CONTEXT_WINDOW` are documented in `docs/DEPLOYMENT.md` and implemented in `config_manager`, but no compose service ever passed them into a container. Compose has no pass-everything-through mode, so a variable that is not named in a service's `environment:` block never reaches the process. An operator who followed the documentation set them and they silently did nothing: the stack starts, the application default applies, and there is no warning anywhere.

Auditing the rest of the documented environment surface against the compose file found five more with the identical defect, so this PR fixes all seven rather than leaving them to be discovered one at a time:

| Variable | Placed on | Note |
| --- | --- | --- |
| `OLLAMA_CONTEXT_WINDOW` | shared anchor | the reported case |
| `SECONDARY_OLLAMA_CONTEXT_WINDOW` | shared anchor | the reported case |
| `BACKUP_EXPORT_DIR` | shared anchor | a worker writes the export and the API streams it back, so a value present on one side only breaks the download; `docs/BACKUP_RESTORE.md` already warned they must agree |
| `NOJOIN_UMASK` | shared anchor | file permissions stayed at the `0077` default regardless |
| `NOJOIN_TELEMETRY_ENDPOINT` | shared anchor | documented as testing-only, but equally inert |
| `MCP_ANONYMOUS_DISCOVERY` | `api` service | already in `.env.example`, so operators were being prompted to set a security toggle that did nothing. Setting it `false` to require authentication for every MCP request had no effect |
| `NOJOIN_CODEX_PATH` | worker anchor | only the worker lanes run a subscription CLI; the Dockerfile default always won |

The two context window variables deliberately carry no compose-side default (`${OLLAMA_CONTEXT_WINDOW:-}`). `config_manager` owns the application default and skips an empty value, so an unset variable falls through to it correctly. Repeating the number in compose would create a second default to keep in step.

`.env.example` gains the two Ollama context entries plus `BACKUP_EXPORT_DIR` and `NOJOIN_UMASK`. `NOJOIN_TELEMETRY_ENDPOINT` and `NOJOIN_CODEX_PATH` are plumbed but intentionally left out of that file: the first is documented as testing-only and the second is an override with a working image default, so prompting for either would be noise.

**Behaviour change:** the Ollama context default drops from `131072` to `32768`. The old value is right for a hosted provider and wrong for the hardware this project is actually self-hosted on. A KV cache costs roughly 190 KiB per token on a 14B model, so `131072` needs about 24 GB of cache on its own, before any weights, and will not load on a consumer GPU. `32768` is about 6 GB, fits alongside quantised weights on a 16 GB card, and still covers a two-hour meeting (roughly 25,000 to 30,000 tokens). Because the key is written to `config.json` on first start, this affects new installs only; existing deployments keep whatever they have. The frontend's duplicate of the constant in `aiSettingsModels.ts` moves with it, since it is the settings form's placeholder and would otherwise display a number the backend no longer uses.

`docs/DEPLOYMENT.md` now states the new default, explains the VRAM sizing rather than just saying "ensure your hardware can support it", and adds a short note that a variable only takes effect if the compose service declares it, which matters to anyone maintaining their own compose file.

**Regression test:** `backend/tests/test_compose_env_plumbing.py` asserts that every key in `config_manager`'s `ENV_OVERRIDES` map appears in both `docker-compose.example.yml` and `.env.example`. That map moves from a local in `_load_config` to a module-level constant so it is importable; its contents and behaviour are unchanged. The compose file is parsed as text rather than with PyYAML, which reaches this suite only as a transitive dependency of the model stack and is declared in no requirements file. The test was confirmed to fail when a variable is removed, not merely to pass as written.

No new dependencies.

No tracking issue: the defect was found while configuring an unrelated demonstration stack.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

Ticking breaking change for the default value only. Nothing about the plumbing is breaking: a variable that previously did nothing now does what the documentation always said. The lowered context default is a real behaviour change, but only for installs created after this ships.

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1319 passed)
- [x] Python quality: `python scripts/check.py` (lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests all OK)
- [x] Frontend lint: `cd frontend && npm run lint`
- [x] Frontend unit tests: `cd frontend && npm run test` (399 passed, 58 files)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (via `scripts/check.py`)

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/DEPLOYMENT.md` for the new default, the VRAM sizing guidance, and the note on compose declaration. `.env.example` for the four operator-facing additions.

## Security impact

- [ ] No security-sensitive change.
- [x] Touches auth, tokens, encryption, capture ownership, or exposure.

Only in the direction of restoring intended control. `MCP_ANONYMOUS_DISCOVERY` now reaches the API container, so an operator who sets it `false` gets the strict `401` challenge on every unauthenticated MCP request as documented. Before this, the anonymous handshake was served no matter what they set. No boundary in `docs/SECURITY.md` changes; a documented switch simply starts working. `NOJOIN_UMASK` likewise now takes effect, so an operator can loosen file permissions from the `0077` default deliberately, which was always the documented intent.

## Manual verification

Verified in two halves, which together cover the whole path. I did not recreate a full stack: this host runs the live production deployment and a separate demonstration stack, and neither should be disturbed by an example-file change.

**1. Compose passes the values through.** Rendered `docker-compose.example.yml` with a throwaway env file setting all seven, and read back the resolved environment of `api`, `worker-gpu`, `worker-io` and `worker-parse`. Every service receives the five shared variables; `MCP_ANONYMOUS_DISCOVERY` is present on `api` only and `NOJOIN_CODEX_PATH` on the worker lanes only, which is the intended placement.

**2. The application reads them.** Ran the real `nojoin-api` image with `config_manager.py` bind-mounted, entrypoint bypassed so no database is needed, network disabled:

- `OLLAMA_CONTEXT_WINDOW=16384 SECONDARY_OLLAMA_CONTEXT_WINDOW=8192` gives `16384` and `8192`.
- Both set to the empty string, which is exactly what compose passes when the operator has not set them, gives `32768` and `32768`: the override loop skips empty values and the new application default applies.
- A non-integer value logs `Ignoring invalid integer value for OLLAMA_CONTEXT_WINDOW.` and falls through to `32768` rather than crashing.

Before this change the first case returned the default no matter what `.env` said. `docker compose -f docker-compose.example.yml config -q` parses the edited file cleanly.

No capture, recording-action, or UI-flow changes: the only frontend edit is one constant used as a form placeholder.
