### PR TITLE
test(setup): pin the provider the initial-config test asserts against

### DIFF
--- a/backend/tests/test_security_surface.py
+++ b/backend/tests/test_security_surface.py
@@ -614,6 +614,15 @@ async def test_setup_requests_are_rate_limited(monkeypatch) -> None:
 @pytest.mark.anyio
 async def test_initial_config_masks_prefilled_secrets(monkeypatch) -> None:
     app, _ = _build_app(initialized=False)
+    # config_manager resolves a key from its loaded config first and only then
+    # from the environment, and that config is built once at import from
+    # data/config.json overlaid with .env. Setting an environment variable here
+    # is therefore too late to change it. Clear the two keys this test drives so
+    # the env fallback is what answers, whatever provider the developer running
+    # the suite happens to have configured; without this the test asserts
+    # against the host's own installation and passes only on a bare checkout.
+    monkeypatch.setitem(setup.config_manager.config, "llm_provider", None)
+    monkeypatch.setitem(setup.config_manager.config, "gemini_model", None)
     monkeypatch.setenv(setup.FIRST_RUN_PASSWORD_ENV_KEY, BOOTSTRAP_PASSWORD)
     monkeypatch.setenv("LLM_PROVIDER", "gemini")
     monkeypatch.setenv("GEMINI_MODEL", "gemini-2.5-flash")


### PR DESCRIPTION
# Pull Request

## Description

`backend/tests/test_security_surface.py::test_initial_config_masks_prefilled_secrets` fails on any checkout whose `.env` or `data/config.json` names an LLM provider, so `python scripts/check.py` does not pass from a working development installation. CI never saw it because a bare CI checkout has neither file.

The test sets `LLM_PROVIDER` and `GEMINI_MODEL` in the environment and expects `/api/v1/setup/initial-config` to resolve a model from them. `ConfigManager.get` reads its loaded config first and falls back to the uppercase environment variable only when that value is `None`, and the config is built once at import from `data/config.json` overlaid with `.env` (`config_manager.py` calls `load_dotenv()` at module scope). A variable set inside the test therefore arrives after the provider has already been decided.

With no provider configured, the fallback answers and the test passes. With one configured, the endpoint computes `selected_model_key` from that provider, looks up a model key the test never populated, and returns `null`.

Reproduced both ways on the same commit:

```
pytest backend/tests/test_security_surface.py::test_initial_config_masks_prefilled_secrets   -> 1 failed
LLM_PROVIDER=gemini pytest <same>                                                            -> 1 passed
```

The fix clears `llm_provider` and `gemini_model` on the loaded config for the duration of the test, so the environment fallback is what answers regardless of how the machine running the suite is configured. No product code changes: the endpoint and `ENV_OVERRIDES` behave correctly, and the assertion still fails if the environment value stops reaching the response (verified by removing the `GEMINI_MODEL` setenv).

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

`python scripts/check.py` passes in full on this branch: `1326 passed`, `OK: lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests`. The frontend checks were not run because no frontend path is touched.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

This test covers a security surface (secret masking on the first-run setup endpoint), but the masking assertions are untouched and no product behaviour changes.

## Manual verification

Ran the target test on the same commit with and without a provider present in the environment, confirming the old test tracked the host's installation and the new one does not. Ran the full suite on a machine that has both a populated `.env` and a populated `data/config.json`, which is the configuration that previously failed.