### PR TITLE
fix(docs): make the dev compose template match its own rebuild loop

### DIFF
--- a/backend/tests/test_dev_compose_template.py
+++ b/backend/tests/test_dev_compose_template.py
@@ -1,0 +1,226 @@
+"""The development compose template has to match the guide that ships it.
+
+``docs/DEVELOPMENT.md`` appends a compose template and then, earlier in the same
+document, tells a developer which services to rebuild against it. Nothing kept
+the two in step: the rebuild loop named ``worker-gpu worker-cpu worker-io``
+while the template defined a single ``worker``, so following the guide end to
+end produced commands that error on a service that does not exist. The template
+had also quietly fallen behind ``docker-compose.example.yml`` by five variables,
+two of them read by ``config_manager`` -- a variable no service passes in is
+read by nobody, the application default wins, and the developer gets no signal
+that their setting was discarded.
+
+``test_compose_env_plumbing.py`` guards the deployment template. This file
+guards the development one, and pins it to its production counterpart so a lane
+or a setting added to one cannot go missing from the other.
+
+Parsed as text rather than with PyYAML for the reason given there: PyYAML
+reaches this suite only as a transitive dependency of the model stack and is
+declared in no requirements file.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUIDE_PATH = REPO_ROOT / "docs" / "DEVELOPMENT.md"
+COMPOSE_PATH = REPO_ROOT / "docker-compose.example.yml"
+
+TEMPLATE_HEADING = "## Localhost Dev Compose Template"
+SHARED_ANCHOR = "x-shared-app-environment"
+
+# Services a rebuild command may name that the development template does not
+# define. The document gives one command for docker-compose.example.yml, whose
+# proxy service is `nginx` where the development template's is `nginx-dev`.
+# Every entry is asserted to exist in that file, so the allowlist cannot absorb
+# a typo.
+EXAMPLE_ONLY_SERVICES = {"nginx"}
+
+_TOP_LEVEL_KEY_RE = re.compile(r"^([A-Za-z_][\w-]*):")
+_SERVICE_RE = re.compile(r"^ {2}([a-z][a-z0-9-]*):\s*$")
+_ENV_KEY_RE = re.compile(r"^(\s+)([A-Z][A-Z0-9_]*):")
+
+
+def _yaml_blocks(markdown: str) -> list[str]:
+    """Return the body of every ```yaml fence, in document order."""
+    blocks: list[str] = []
+    current: list[str] | None = None
+    for line in markdown.splitlines():
+        if current is None:
+            if line.strip() == "```yaml":
+                current = []
+            continue
+        if line.strip() == "```":
+            blocks.append("\n".join(current))
+            current = None
+            continue
+        current.append(line)
+    return blocks
+
+
+def _template() -> str:
+    """Return the compose template appended to the development guide."""
+    markdown = GUIDE_PATH.read_text(encoding="utf-8")
+    _, _, after_heading = markdown.partition(TEMPLATE_HEADING)
+    assert after_heading, f"{TEMPLATE_HEADING} is missing from {GUIDE_PATH.name}"
+    blocks = _yaml_blocks(after_heading)
+    assert blocks, "no yaml block follows the template heading"
+    return blocks[0]
+
+
+def _service_names(text: str) -> set[str]:
+    """Collect the service keys under the top-level ``services:`` mapping."""
+    names: set[str] = set()
+    in_services = False
+    for line in text.splitlines():
+        if not in_services:
+            in_services = line.startswith("services:")
+            continue
+        if line.strip() and _TOP_LEVEL_KEY_RE.match(line):
+            break
+        match = _SERVICE_RE.match(line)
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+def _block_env_keys(text: str, opening: str, indent: int) -> set[str]:
+    """Collect variable names declared under ``opening``.
+
+    Reads from the opening line until the first line at or left of that line's
+    own indentation, which is where the block ends in any valid YAML.
+    """
+    keys: set[str] = set()
+    in_block = False
+    for line in text.splitlines():
+        if not in_block:
+            if line.startswith(f"{' ' * indent}{opening}"):
+                in_block = True
+            continue
+        stripped = line.strip()
+        if stripped and len(line) - len(line.lstrip(" ")) <= indent:
+            break
+        match = _ENV_KEY_RE.match(line)
+        if match:
+            keys.add(match.group(2))
+    return keys
+
+
+def _shared_anchor_keys(text: str) -> set[str]:
+    return _block_env_keys(text, f"{SHARED_ANCHOR}:", indent=0)
+
+
+def _api_env_keys(text: str) -> set[str]:
+    _, _, after_api = text.partition("\n  api:\n")
+    assert after_api, "no api service found"
+    return _block_env_keys(after_api, "environment:", indent=4)
+
+
+def _rebuild_command_services(markdown: str) -> set[str]:
+    """Collect every service named in a ``docker compose ... build`` command."""
+    names: set[str] = set()
+    for line in markdown.splitlines():
+        tokens = line.strip().split()
+        if tokens[:2] != ["docker", "compose"]:
+            continue
+        if "build" not in tokens and "--build" not in tokens:
+            continue
+        marker = "build" if "build" in tokens else "--build"
+        for token in tokens[tokens.index(marker) + 1 :]:
+            if not token.startswith("-"):
+                names.add(token)
+    return names
+
+
+def _patch_snippet_services(markdown: str) -> set[str]:
+    """Collect service keys from the guide's compose patch snippets.
+
+    Everything except the appended template, which is the thing being patched.
+    """
+    names: set[str] = set()
+    before_template, _, _ = markdown.partition(TEMPLATE_HEADING)
+    for block in _yaml_blocks(before_template):
+        names |= _service_names(block)
+    return names
+
+
+def test_template_is_parsed_at_all() -> None:
+    """Guard the parser itself: a silent miss would pass every other test."""
+    template = _template()
+    assert "api" in _service_names(template)
+    assert "DATABASE_URL" in _shared_anchor_keys(template)
+    assert "FIRST_RUN_PASSWORD" in _api_env_keys(template)
+    assert "api" in _rebuild_command_services(GUIDE_PATH.read_text(encoding="utf-8"))
+
+
+def test_rebuild_commands_name_services_the_template_defines() -> None:
+    markdown = GUIDE_PATH.read_text(encoding="utf-8")
+    defined = _service_names(_template()) | EXAMPLE_ONLY_SERVICES
+    missing = sorted(_rebuild_command_services(markdown) - defined)
+    assert not missing, (
+        f"{missing} are named in a rebuild command in {GUIDE_PATH.name} but the "
+        "compose template it appends defines no such service, so the documented "
+        "command fails for anyone following the guide."
+    )
+
+
+def test_patch_snippets_name_services_the_template_defines() -> None:
+    markdown = GUIDE_PATH.read_text(encoding="utf-8")
+    missing = sorted(_patch_snippet_services(markdown) - _service_names(_template()))
+    assert not missing, (
+        f"{missing} are patched by a snippet in {GUIDE_PATH.name} but the compose "
+        "template it appends defines no such service, so the patch applies to "
+        "nothing."
+    )
+
+
+def test_example_only_services_really_are_in_the_example_compose() -> None:
+    """Keep the allowlist from absorbing a typo or a deleted service."""
+    unknown = sorted(
+        EXAMPLE_ONLY_SERVICES - _service_names(COMPOSE_PATH.read_text(encoding="utf-8"))
+    )
+    assert not unknown, f"{unknown} exist in neither compose file."
+
+
+def test_worker_lanes_match_the_deployment_template() -> None:
+    """A lane added to one template has to appear in the other.
+
+    The point of the development template is that queue routing behaves locally
+    as it does in production. A lane present in only one of the two files means
+    some queue is drained live and never drained in development, or the reverse.
+    """
+    template_lanes = {
+        name for name in _service_names(_template()) if name.startswith("worker")
+    }
+    deployment_lanes = {
+        name
+        for name in _service_names(COMPOSE_PATH.read_text(encoding="utf-8"))
+        if name.startswith("worker")
+    }
+    assert template_lanes == deployment_lanes, (
+        "the worker lanes in the docs/DEVELOPMENT.md template and in "
+        "docker-compose.example.yml have diverged: "
+        f"{sorted(template_lanes ^ deployment_lanes)}"
+    )
+
+
+def test_template_passes_every_shared_setting_the_deployment_template_does() -> None:
+    compose_keys = _shared_anchor_keys(COMPOSE_PATH.read_text(encoding="utf-8"))
+    missing = sorted(compose_keys - _shared_anchor_keys(_template()))
+    assert not missing, (
+        f"{missing} are passed to every service by docker-compose.example.yml but "
+        f"not by the template in {GUIDE_PATH.name}. A development stack built from "
+        "the guide silently discards them."
+    )
+
+
+def test_template_api_carries_every_setting_the_deployment_api_does() -> None:
+    compose_keys = _api_env_keys(COMPOSE_PATH.read_text(encoding="utf-8"))
+    missing = sorted(compose_keys - _api_env_keys(_template()))
+    assert not missing, (
+        f"{missing} reach the api service in docker-compose.example.yml but not in "
+        f"the template in {GUIDE_PATH.name}, so the development API cannot be "
+        "configured the way the deployment documentation describes."
+    )

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -203,14 +203,14 @@ Use the normal container rebuild loop when you are staying in the containerised 
 
 ```bash
 docker compose up -d --build api
-docker compose up -d --build worker-gpu worker-cpu worker-io
+docker compose up -d --build worker-gpu worker-cpu worker-io worker-parse
 docker compose up -d --build frontend
 ```
 
 Practical use:
 
 - Run `docker compose up -d --build api` after API changes or shared backend changes.
-- Run `docker compose up -d --build worker-gpu worker-cpu worker-io` after worker code, dependency, or worker-image changes. The three worker lanes share one image, so this rebuilds it once and recreates all three containers.
+- Run `docker compose up -d --build worker-gpu worker-cpu worker-io worker-parse` after worker code, dependency, or worker-image changes. Name all four: they do not all share one image. `worker-gpu` and `worker-cpu` run the shared worker image, `worker-io` layers the subscription-CLI tooling on top of it, and `worker-parse` runs the `worker-io` image without building anything of its own. Compose builds each image once and recreates the four containers.
 - Run `docker compose up -d --build frontend` after frontend changes that you want to verify through Nginx.
 
 The compose files now gate `frontend` on a healthy `api`, and gate `nginx` (or `nginx-dev` in development) on healthy `api` plus `frontend`, so the proxy waits for both application tiers before becoming ready.
@@ -237,11 +237,22 @@ docker compose build --no-cache api worker-gpu worker-cpu worker-io frontend
 docker compose up -d --force-recreate
 ```
 
+`worker-parse` is deliberately absent from that build list. It declares no build
+of its own, so it has nothing to rebuild; `--force-recreate` picks up the fresh
+`worker-io` image it shares.
+
 ### Optional Backend Source-Mount Patch
 
-If you want the API and worker to reflect Python changes without rebuilding those two images every time, patch your local ignored `docker-compose.yml` like this:
+If you want the API and the workers to reflect Python changes without rebuilding those images every time, patch your local ignored `docker-compose.yml` like this. Add `.:/app` to the shared worker runtime anchor once, so every lane picks the source mount up, then wrap each lane's command in `watchmedo`:
 
 ```yaml
+x-worker-runtime: &worker-runtime
+  volumes:
+    - .:/app
+    - ./data:/app/data
+    - model_cache:/home/appuser/.cache
+    - /sys/class/drm:/sys/class/drm:ro
+
 services:
   api:
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000
@@ -250,16 +261,24 @@ services:
       - ./data:/app/data
       - model_cache:/shared_model_cache:ro
 
-  worker:
-    command: watchmedo auto-restart --directory=./backend --pattern=*.py --recursive -- celery -A backend.celery_app.celery_app worker -Q gpu,cpu,io -B -s /app/data/celerybeat-schedule --loglevel=info --pool=solo
-    volumes:
-      - .:/app
-      - ./data:/app/data
-      - model_cache:/home/appuser/.cache
-      - /sys/class/drm:/sys/class/drm:ro
+  worker-gpu:
+    command: watchmedo auto-restart --directory=./backend --pattern=*.py --recursive -- celery -A backend.celery_app.celery_app worker -Q gpu --pool=solo --concurrency=1 --loglevel=info
+
+  worker-cpu:
+    command: watchmedo auto-restart --directory=./backend --pattern=*.py --recursive -- celery -A backend.celery_app.celery_app worker -Q cpu --pool=prefork --concurrency=3 --loglevel=info
+
+  worker-io:
+    command: watchmedo auto-restart --directory=./backend --pattern=*.py --recursive -- celery -A backend.celery_app.celery_app worker -Q io -B -s /app/data/celerybeat-schedule --pool=prefork --concurrency=4 --loglevel=info
+
+  worker-parse:
+    command: watchmedo auto-restart --directory=./backend --pattern=*.py --recursive -- celery -A backend.celery_app.celery_app worker -Q parse --pool=prefork --concurrency=2 --loglevel=info
 ```
 
-The development compose runs a single worker that drains all three resource lanes (`-Q gpu,cpu,io`) with embedded beat, which keeps the local loop simple. Production instead splits that work across dedicated `worker-gpu`, `worker-cpu`, and `worker-io` services; see [Worker Concurrency Lanes](DEPLOYMENT.md#worker-concurrency-lanes). The `-Q gpu,cpu,io` flag above is required — without it the worker would only consume the default (gpu) queue and CPU/IO tasks would never run.
+Every lane keeps the `-Q`, `--pool`, and `--concurrency` values it has in the template. Those flags are load-bearing rather than cosmetic:
+
+- A lane that drains the wrong queue either starves that queue or duplicates work another lane is already doing. Anything unrouted falls back to the GPU queue, so a missing `-Q` quietly turns a lane into a second GPU worker.
+- `-B` belongs to `worker-io` alone. A second embedded scheduler double-fires every periodic job.
+- `--pool` is part of the dispatch model, not a tuning knob. Worker code queues follow-on Celery work with a blocking call, which is safe only while one task owns one operating-system process; see [Worker Concurrency Lanes](DEPLOYMENT.md#worker-concurrency-lanes).
 
 That patch is optional. It changes the backend feedback loop only. It does not change the frontend contract. If Nginx still proxies the `frontend` container, rebuilding `frontend` remains the way to update `https://localhost:14443`.
 
@@ -663,28 +682,83 @@ x-shared-app-environment: &shared-app-environment
   CELERY_RESULT_BACKEND: redis://:${REDIS_PASSWORD:-change_to_secure_string}@redis:6379/0
   HF_TOKEN: ${HF_TOKEN:-}
   DEFAULT_TIMEZONE: ${DEFAULT_TIMEZONE:-UTC}
-  # Shared, not api-only: the worker resolves the public origin too, for
+  # Shared, not api-only: the worker lanes resolve the public origin too, for
   # calendar webhook URLs and the telemetry local-origin flag.
   WEB_APP_URL: ${WEB_APP_URL:-https://localhost:14443}
   # Local development stacks should not contribute to the public telemetry
   # dataset; unset it here if you deliberately want to exercise the ping.
   NOJOIN_TELEMETRY_ENABLED: ${NOJOIN_TELEMETRY_ENABLED:-false}
+  NOJOIN_TELEMETRY_ENDPOINT: ${NOJOIN_TELEMETRY_ENDPOINT:-}
+  # Exports have to be readable by whoever serves them: a worker writes the
+  # archive and the API streams it back, so both sides must resolve the same
+  # directory. Setting it on one service only silently breaks the download.
+  BACKUP_EXPORT_DIR: ${BACKUP_EXPORT_DIR:-}
+  NOJOIN_UMASK: ${NOJOIN_UMASK:-}
   LLM_PROVIDER: ${LLM_PROVIDER:-gemini}
   GEMINI_API_KEY: ${GEMINI_API_KEY:-}
   OPENAI_API_KEY: ${OPENAI_API_KEY:-}
   ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
   OLLAMA_API_URL: ${OLLAMA_API_URL:-http://host.docker.internal:11434}
+  # No default here on purpose. config_manager owns the application default and
+  # skips an empty value, so an unset variable falls through to it; repeating a
+  # number here would create a second default to keep in step.
+  OLLAMA_CONTEXT_WINDOW: ${OLLAMA_CONTEXT_WINDOW:-}
   SECONDARY_LLM_PROVIDER: ${SECONDARY_LLM_PROVIDER:-}
   SECONDARY_GEMINI_API_KEY: ${SECONDARY_GEMINI_API_KEY:-}
   SECONDARY_OPENAI_API_KEY: ${SECONDARY_OPENAI_API_KEY:-}
   SECONDARY_ANTHROPIC_API_KEY: ${SECONDARY_ANTHROPIC_API_KEY:-}
   SECONDARY_OLLAMA_API_URL: ${SECONDARY_OLLAMA_API_URL:-http://host.docker.internal:11434}
+  SECONDARY_OLLAMA_CONTEXT_WINDOW: ${SECONDARY_OLLAMA_CONTEXT_WINDOW:-}
   DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
   GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID:-}
   GOOGLE_OAUTH_CLIENT_SECRET: ${GOOGLE_OAUTH_CLIENT_SECRET:-}
   MICROSOFT_OAUTH_CLIENT_ID: ${MICROSOFT_OAUTH_CLIENT_ID:-}
   MICROSOFT_OAUTH_CLIENT_SECRET: ${MICROSOFT_OAUTH_CLIENT_SECRET:-}
   MICROSOFT_OAUTH_TENANT_ID: ${MICROSOFT_OAUTH_TENANT_ID:-common}
+
+# Runtime settings shared by every worker lane. Deliberately carries no image:
+# or build:, so the one lane that runs a different image (worker-parse) cannot
+# inherit the wrong one. A YAML merge key replaces a whole key; it never merges
+# the values under it.
+x-worker-runtime: &worker-runtime
+  volumes:
+    - ./data:/app/data
+    - model_cache:/home/appuser/.cache
+    - /sys/class/drm:/sys/class/drm:ro
+  depends_on:
+    db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  extra_hosts:
+    - host.docker.internal:host-gateway
+  restart: unless-stopped
+  networks:
+    - nojoin_net
+  logging: *default-logging
+
+# The lanes that run the shared worker image built from Dockerfile.worker.
+# worker-io overrides the image and build below; worker-parse must not use this
+# anchor at all, because it runs the worker-io image and would otherwise tag a
+# plain worker build as nojoin-dev-worker-io:local.
+x-worker-base: &worker-base
+  <<: *worker-runtime
+  build:
+    context: .
+    dockerfile: docker/Dockerfile.worker
+  image: nojoin-dev-worker:local
+  pull_policy: never
+
+x-worker-environment: &worker-environment
+  <<: *shared-app-environment
+  NOJOIN_CODEX_PATH: ${NOJOIN_CODEX_PATH:-}
+  XDG_CACHE_HOME: /home/appuser/.cache
+  HF_HOME: /home/appuser/.cache/huggingface
+  OMP_NUM_THREADS: 2
+  MKL_NUM_THREADS: 2
+  OPENBLAS_NUM_THREADS: 2
+  VECLIB_MAXIMUM_THREADS: 2
+  NUMEXPR_NUM_THREADS: 2
 
 services:
   db:
@@ -755,10 +829,17 @@ services:
     environment:
       <<: *shared-app-environment
       DOCKER_HOST: tcp://socket-proxy:2375
+      MCP_ENABLED: ${MCP_ENABLED:-true}
+      MCP_ANONYMOUS_DISCOVERY: ${MCP_ANONYMOUS_DISCOVERY:-true}
       NOJOIN_AUTO_REPAIR_MISSING_ALEMBIC_REVISIONS: ${NOJOIN_AUTO_REPAIR_MISSING_ALEMBIC_REVISIONS:-true}
       FIRST_RUN_PASSWORD: ${FIRST_RUN_PASSWORD:?Set FIRST_RUN_PASSWORD in .env}
       XDG_CACHE_HOME: /shared_model_cache
       HF_HOME: /shared_model_cache/huggingface
+      # Trust proxies by IP or CIDR, never by container name, whenever the edge
+      # proxy runs on a network the API is not itself attached to: the API
+      # resolves these entries at startup and silently drops any name it cannot
+      # resolve, collapsing every external client into one rate-limit bucket.
+      NOJOIN_TRUSTED_PROXIES: ${NOJOIN_TRUSTED_PROXIES:-127.0.0.1,::1,nginx}
     depends_on:
       db:
         condition: service_healthy
@@ -783,24 +864,21 @@ services:
       - nojoin_net
     logging: *default-logging
 
-  worker:
-    container_name: nojoin-dev-worker
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.worker
-    image: nojoin-dev-worker:local
-    pull_policy: never
-    volumes:
-      - ./data:/app/data
-      - model_cache:/home/appuser/.cache
-      - /sys/class/drm:/sys/class/drm:ro
+  # Four worker lanes, matching production. Each drains one Celery queue (see
+  # backend/celery_app.py TASK_ROUTES), so local work is routed exactly as it is
+  # live. Worker Concurrency Lanes in docs/DEPLOYMENT.md explains the split.
+  #
+  # GPU lane: finalize, live ASR, embeddings. Single-slot (--pool=solo
+  # --concurrency=1). This is the ONLY worker with GPU access; remove the deploy
+  # block on a CPU-only host.
+  worker-gpu:
+    <<: *worker-base
+    container_name: nojoin-dev-worker-gpu
     environment:
-      <<: *shared-app-environment
+      <<: *worker-environment
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
       NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-compute,utility}
       WHISPER_ENABLE_WORD_TIMESTAMPS: ${WHISPER_ENABLE_WORD_TIMESTAMPS:-true}
-      XDG_CACHE_HOME: /home/appuser/.cache
-      HF_HOME: /home/appuser/.cache/huggingface
     deploy:
       resources:
         reservations:
@@ -808,17 +886,73 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
+    command:
+      [
+        "celery", "-A", "backend.celery_app.celery_app", "worker",
+        "-Q", "gpu", "--pool=solo", "--concurrency=1", "--loglevel=info",
+      ]
+
+  # CPU lane: ffmpeg segment transcode, proxy generation, backups. No GPU.
+  worker-cpu:
+    <<: *worker-base
+    container_name: nojoin-dev-worker-cpu
+    environment: *worker-environment
+    command:
+      [
+        "celery", "-A", "backend.celery_app.celery_app", "worker",
+        "-Q", "cpu", "--pool=prefork", "--concurrency=3", "--loglevel=info",
+      ]
+
+  # IO/LLM lane: Meeting Edge, notes, chat embeddings, calendar sync, cleanup.
+  # Owns Celery Beat (-B) so the periodic jobs fire exactly once across the
+  # stack. No other lane may carry -B.
+  worker-io:
+    <<: *worker-base
+    container_name: nojoin-dev-worker-io
+    # CLI OAuth AI mode needs Node plus the subscription CLIs, layered on the
+    # shared worker image by docker/Dockerfile.worker-io.
+    image: nojoin-dev-worker-io:local
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker-io
+      # Build the shared worker base FIRST, then layer worker-io on it. Without
+      # this the two builds run in parallel and worker-io can ship stale code on
+      # the previous base.
+      additional_contexts:
+        worker_base: "service:worker-gpu"
+      args:
+        WORKER_BASE_IMAGE: worker_base
+    environment: *worker-environment
+    command:
+      [
+        "celery", "-A", "backend.celery_app.celery_app", "worker",
+        "-Q", "io", "-B", "-s", "/app/data/celerybeat-schedule",
+        "--pool=prefork", "--concurrency=4", "--loglevel=info",
+      ]
+
+  # Document parsing, isolated from every other lane. A parse has no page cap,
+  # so one large upload can hold a worker slot for a long time; on the io lane
+  # that would degrade Meeting Edge during a live meeting. Reuses the worker-io
+  # IMAGE (no extra build) because visual parsing may route through a
+  # subscription CLI whose binaries ship only there.
+  worker-parse:
+    # *worker-runtime, NOT *worker-base: this lane runs the worker-io image, so
+    # inheriting the base build would build Dockerfile.worker and tag the result
+    # nojoin-dev-worker-io:local, racing worker-io for that tag.
+    <<: *worker-runtime
+    container_name: nojoin-dev-worker-parse
+    image: nojoin-dev-worker-io:local
+    pull_policy: never
     depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    extra_hosts:
-      - host.docker.internal:host-gateway
-    restart: unless-stopped
-    networks:
-      - nojoin_net
-    logging: *default-logging
+      worker-io:
+        condition: service_started
+    environment: *worker-environment
+    command:
+      [
+        "celery", "-A", "backend.celery_app.celery_app", "worker",
+        "-Q", "parse",
+        "--pool=prefork", "--concurrency=2", "--loglevel=info",
+      ]
 
   frontend:
     container_name: nojoin-dev-frontend


### PR DESCRIPTION
# Pull Request

## Description

`docs/DEVELOPMENT.md` contradicted itself. The Incremental Rebuild Loop told the reader to run:

```bash
docker compose up -d --build worker-gpu worker-cpu worker-io
docker compose build --no-cache api worker-gpu worker-cpu worker-io frontend
```

against the Localhost Dev Compose Template appended to the same document, which defined a single `worker` service draining `-Q gpu,cpu,io`. Following the guide end to end produced commands that error on services that do not exist. `worker-parse` was absent from both halves, so a developer never rebuilt that lane at all.

Found while standing up a development deployment by following this document.

**Direction taken: promote the four production lanes into the template**, rather than narrowing the rebuild loop to the single worker. A worker draining every queue never exercises queue routing, which is one of the behaviours a development stack most needs to reproduce. The lanes carry the same queue, pool, and concurrency values as `docker-compose.example.yml`, split across two anchors so that `worker-parse` inherits the runtime settings without inheriting a `build:`/`image:` pair — merging the base anchor there would build `Dockerfile.worker` and tag the result `nojoin-dev-worker-io:local`, racing `worker-io` for that tag. `worker-io` declares `additional_contexts: worker_base: "service:worker-gpu"` so the shared base builds first.

The template had also fallen behind the deployment template on settings it never passes in:

- api service: `NOJOIN_TRUSTED_PROXIES`, `MCP_ENABLED`, `MCP_ANONYMOUS_DISCOVERY`. Without the first, the template cannot be used behind an edge proxy without an undocumented edit.
- shared anchor: `BACKUP_EXPORT_DIR`, `NOJOIN_UMASK`, `NOJOIN_TELEMETRY_ENDPOINT`, `OLLAMA_CONTEXT_WINDOW`, `SECONDARY_OLLAMA_CONTEXT_WINDOW`. The last two are read by `config_manager`, so a developer who set them got the application default and no warning — the same failure mode `test_compose_env_plumbing.py` was written for, on the one template that test does not cover.

The Optional Backend Source-Mount Patch still patched the `worker` service the template no longer defines; it now patches all four lanes, and states why `-Q`, `-B`, and `--pool` are load-bearing rather than cosmetic.

`backend/tests/test_dev_compose_template.py` is new and locks all of this: it fails when a rebuild command or a patch snippet names a service the template does not define, when a worker lane exists in one compose template and not the other, or when a shared/api setting reaches `docker-compose.example.yml` but not the guide. Reintroducing the original drift fails four of its seven assertions.

The rewritten template was extracted and validated with `docker compose config`: it renders ten services, and `worker-parse` correctly resolves to `nojoin-dev-worker-io:local` with no build stanza of its own.

No new dependencies. No product code changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

`1333 passed` on this branch, including the seven new assertions. The frontend checks were not run because no frontend path is touched.

One caveat, stated plainly: on the machine this was written on, `pytest` also reports `test_security_surface.py::test_initial_config_masks_prefilled_secrets` as failing. That failure is pre-existing on `main`, unrelated to this change, and is fixed separately in #209 — it reproduces only where an LLM provider is configured in `.env` or `data/config.json`, which is why CI has never seen it. With that one variable neutralised (`LLM_PROVIDER=gemini pytest`), this branch is `1333 passed`, which is what CI will run.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/DEPLOYMENT.md` already documents the four lanes correctly and needed no change; this brings the development guide into line with it.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

Adding `NOJOIN_TRUSTED_PROXIES` to the template restores a documented control rather than changing one. The accompanying comment records the constraint that matters in practice: entries must be IPs or CIDRs, never a container name, whenever the edge proxy sits on a network the API is not attached to, because the API resolves the list at startup and silently drops a name it cannot resolve, collapsing every external client into one rate-limit bucket.

## Manual verification

The four-lane layout in this template is the one running as a development deployment on the author's host, built by following this guide, so the arrangement is proven rather than theoretical: the lane split, the `worker-parse` anchor separation, and the `worker_base` build ordering were all derived from making that stack work.

For this PR specifically: extracted the template from the Markdown and ran `docker compose config` against it (ten services render; image tags and build stanzas resolve as intended), ran the new guard test against a deliberately reintroduced version of the original drift to confirm it fails, and scanned the diff for host-specific paths, hostnames, and secrets.