### PR TITLE
feat(site): compare against Jamie, and drop Fireflies

### DIFF
--- a/docs/SITE.md
+++ b/docs/SITE.md
@@ -211,6 +211,21 @@ credibility of every checkable one.
 Every claim on the site is traceable to `README.md` or a file in `docs/`; nothing is
 invented for marketing effect.
 
+**Three competitors, and which three is a decision.** The page compares Nojoin against
+Jamie, Otter and Granola. Fireflies was dropped when Jamie was added rather than running a
+fifth column: the detailed table is already the widest thing on the site, and another column
+either squeezes every cell or pushes one somewhere nobody scrolls to. Fireflies went because
+it is the least like Nojoin on the axes this page argues — bot-by-default capture, a US
+cloud, no self-hosting to concede against — and Jamie is the opposite on all three, which
+makes it the harder comparison and the more useful one. Jamie sits second, directly after
+Nojoin, because column order decides which competitor actually gets read.
+
+**Dropping a competitor is not a licence to pick easy ones.** The set has to stay honest, and
+the test is whether the table still contains rows a competitor wins. Jamie takes an outright
+yes on no-bot capture and on remembering speakers, and a partial on assistant write access —
+the row Nojoin leads with. If a future edit leaves Nojoin sweeping every row, the problem is
+the competitor set, not the product.
+
 The comparison page holds itself to the standard it would want applied to it:
 
 - Every competitor claim is verified against **that vendor's own current documentation**,
@@ -262,8 +277,9 @@ rather than the technology.
   length, no history that expires while the customer is still paying. There is no meter in
   the software to hit. Every competitor has a tier where something runs out, which the
   comparison page now shows in a sourced row rather than asserting — Otter meters minutes
-  below its upper plans, Fireflies caps storage and AI credits, Granola limits history on
-  its entry plan. Fireflies transcribes without limit on every plan, and the row says so.
+  below its upper plans, Granola limits history on its entry plan, and Jamie charges a
+  credit a meeting and locks the notes you already have when they run out. Where a
+  competitor's upper plans lift a limit, the row says so.
 - **Nothing on the page is a promise that breaks on a bad week.** No uptime figure, no SLA,
   no capacity claim. Same day if the instance is down, next working day otherwise, UK hours,
   and the limit named rather than implied. Monitoring is listed as part of the fee because

--- a/site/src/data/comparison.ts
+++ b/site/src/data/comparison.ts
@@ -8,6 +8,16 @@
 //
 // All vendor pages below were fetched and read on the checked date, and each
 // URL was re-verified to return 200 before this file was committed.
+//
+// THREE COMPETITORS, NOT FOUR. Fireflies was dropped when Jamie was added,
+// rather than running five columns of prose. The table is already the widest
+// thing on the site and a fifth column would either compress every cell or
+// push the right-hand one somewhere most readers never scroll. Fireflies was
+// the one to go because it is the least like Nojoin on the axes this page is
+// about: bot-by-default capture, a US cloud, and no self-hosting story to
+// concede anything against. Jamie is the opposite on all three, so it is the
+// harder and more useful comparison. Removing a competitor is not a licence to
+// pick easy ones -- Jamie beats Nojoin outright on two rows below, and says so.
 
 export interface Cell {
   text: string;
@@ -20,15 +30,22 @@ export interface Row {
   cells: Record<string, Cell>;
 }
 
+// Jamie sits second, directly after Nojoin, because it is the closest product
+// to Nojoin's own pitch -- no bot, speaker memory, an MCP server that writes --
+// and the column order decides which competitor a reader actually reads.
 export const products = [
   { key: "nojoin", name: "Nojoin" },
+  { key: "jamie", name: "Jamie" },
   { key: "otter", name: "Otter" },
   { key: "granola", name: "Granola" },
-  { key: "fireflies", name: "Fireflies" },
 ] as const;
 
 const CHECKED = "2 Aug 2026";
+// Jamie's rows were researched a day after the others. The dates are per-claim
+// rather than per-table so a footnote says when that specific page was read.
+const CHECKED_JAMIE = "3 Aug 2026";
 const src = (url: string) => ({ url, checked: CHECKED });
+const jsrc = (url: string) => ({ url, checked: CHECKED_JAMIE });
 
 const README = src("https://github.com/Valtora/Nojoin/blob/main/README.md");
 const USAGE = src("https://github.com/Valtora/Nojoin/blob/main/docs/USAGE.md");
@@ -45,6 +62,10 @@ export const rows: Row[] = [
         text: "Your browser captures the call. Nothing joins the meeting or appears in the participant list.",
         source: README,
       },
+      jamie: {
+        text: "A native macOS or Windows app captures the audio on your machine, online or in the room. No bot joins the call.",
+        source: jsrc("https://docs.meetjamie.ai/getting-started/quickstart"),
+      },
       otter: {
         text: "An AI meeting agent joins Zoom, Teams and Meet calls; bot-free recording is also available from the desktop, mobile or web app.",
         source: src("https://otter.ai/"),
@@ -52,10 +73,6 @@ export const rows: Row[] = [
       granola: {
         text: "No bot. Desktop apps for macOS and Windows, plus an iPhone app, capture system audio and microphone.",
         source: src("https://docs.granola.ai/help-center/taking-notes/transcription"),
-      },
-      fireflies: {
-        text: "The Fireflies Notetaker bot joins the call; bot-free capture exists via the Chrome extension on Meet and the mobile app.",
-        source: src("https://guide.fireflies.ai/articles/9554534786-how-fireflies-joins-and-records-your-meetings-faqs"),
       },
     },
   },
@@ -67,6 +84,10 @@ export const rows: Row[] = [
         text: "Built-in diarisation plus a global speaker library: voiceprints keep people named across future meetings.",
         source: README,
       },
+      jamie: {
+        text: "You name each speaker once from an audio clip after the meeting, and Jamie identifies them automatically in future ones. No voiceprint library is documented.",
+        source: jsrc("https://docs.meetjamie.ai/getting-started/identify-speaker"),
+      },
       otter: {
         text: "Speaker identification recognises tagged speakers and auto-tags their names in future transcripts.",
         source: src("https://otter.ai/privacy-policy"),
@@ -75,10 +96,6 @@ export const rows: Row[] = [
         text: "Speaker tags use platform display names on Meet and Zoom; no cross-meeting speaker memory documented.",
         source: src("https://docs.granola.ai/help-center/taking-notes/transcription"),
       },
-      fireflies: {
-        text: "Automatic labels, generic without platform metadata; edits apply to the current transcript, with no documented cross-meeting memory.",
-        source: src("https://guide.fireflies.ai/articles/4994477228-how-to-edit-speaker-labels-or-names-in-a-transcript"),
-      },
     },
   },
   {
@@ -86,6 +103,10 @@ export const rows: Row[] = [
     label: "Where processing happens",
     cells: {
       nojoin: { text: "On your own server.", source: README },
+      jamie: {
+        text: "Entirely within the EU: audio goes to Frankfurt and is transcribed on Modal's serverless GPUs, with notes generated through the Anthropic or OpenAI APIs.",
+        source: jsrc("https://docs.meetjamie.ai/faqs-troubleshooting/data"),
+      },
       otter: {
         text: "In Otter's cloud, principally on AWS in the United States.",
         source: src("https://otter.ai/privacy-policy"),
@@ -94,10 +115,6 @@ export const rows: Row[] = [
         text: "Audio goes from your device to Granola's cloud transcription and AI providers.",
         source: src("https://docs.granola.ai/help-center/taking-notes/transcription"),
       },
-      fireflies: {
-        text: "In Fireflies' US cloud on AWS and GCP, including for EU-stored data.",
-        source: src("https://guide.fireflies.ai/articles/9596505232-learn-about-data-storage-and-transfer"),
-      },
     },
   },
   {
@@ -105,6 +122,10 @@ export const rows: Row[] = [
     label: "Where recordings live",
     cells: {
       nojoin: { text: "On your own server.", source: README },
+      jamie: {
+        text: "Transcripts sit on a server in Frankfurt; the audio is deleted permanently once the transcript is ready.",
+        source: jsrc("https://docs.meetjamie.ai/faqs-troubleshooting/data"),
+      },
       otter: {
         text: "In Otter's cloud on AWS S3, with server-side encryption.",
         source: src("https://otter.ai/privacy-security"),
@@ -113,10 +134,6 @@ export const rows: Row[] = [
         text: "Audio is deleted after transcription; transcripts and notes are stored on US-hosted AWS.",
         source: src("https://docs.granola.ai/help-center/consent-security-privacy/security-privacy-data-faqs"),
       },
-      fireflies: {
-        text: "Fireflies' US cloud by default; Enterprise can bring their own S3 or GCS bucket.",
-        source: src("https://guide.fireflies.ai/articles/9596505232-learn-about-data-storage-and-transfer"),
-      },
     },
   },
   {
@@ -124,14 +141,14 @@ export const rows: Row[] = [
     label: "Self-hosting",
     cells: {
       nojoin: { text: "Self-hosting is the product: one compose file on your hardware.", source: README },
+      jamie: {
+        text: "None documented; the app is local but every meeting is processed and stored in Jamie's EU cloud.",
+        source: jsrc("https://docs.meetjamie.ai/enterprise/security-and-compliance"),
+      },
       otter: UNSOURCED,
       granola: {
         text: "None documented; the service runs in Granola's US-hosted cloud.",
         source: src("https://www.granola.ai/security"),
-      },
-      fireflies: {
-        text: "None documented; Enterprise private storage still leaves the service Fireflies-hosted.",
-        source: src("https://guide.fireflies.ai/articles/9596505232-learn-about-data-storage-and-transfer"),
       },
     },
   },
@@ -140,6 +157,10 @@ export const rows: Row[] = [
     label: "Source and licence",
     cells: {
       nojoin: { text: "Open source under AGPLv3.", source: README },
+      jamie: {
+        text: "Closed source, proprietary licence: a non-exclusive, non-transferable right to use, lasting only as long as the contract.",
+        source: jsrc("https://www.meetjamie.ai/terms-of-services"),
+      },
       otter: {
         text: "Closed source, proprietary licence.",
         source: src("https://otter.ai/terms-of-service"),
@@ -147,10 +168,6 @@ export const rows: Row[] = [
       granola: {
         text: "Closed source, proprietary licence.",
         source: src("https://docs.granola.ai/help-center/policies/terms-of-service/application-terms-of-service"),
-      },
-      fireflies: {
-        text: "Closed source, proprietary licence.",
-        source: src("https://fireflies.ai/terms-of-service"),
       },
     },
   },
@@ -162,6 +179,10 @@ export const rows: Row[] = [
         text: "Bring your own API keys, or run fully local inference with Ollama.",
         source: README,
       },
+      jamie: {
+        text: "Vendor-chosen: notes come from the Anthropic or OpenAI APIs, and no bring-your-own-key or local option is documented.",
+        source: jsrc("https://docs.meetjamie.ai/faqs-troubleshooting/data"),
+      },
       otter: {
         text: "Otter's own AI plus vendor-chosen third-party providers; no bring-your-own-key or local option documented.",
         source: src("https://otter.ai/privacy-policy"),
@@ -170,19 +191,24 @@ export const rows: Row[] = [
         text: "Vendor-chosen providers (Deepgram, AssemblyAI, OpenAI, Anthropic); no bring-your-own-key or local option documented.",
         source: src("https://www.granola.ai/security"),
       },
-      fireflies: {
-        text: "Vendor-chosen partners including OpenAI and Anthropic; no bring-your-own-key or local option documented.",
-        source: src("https://guide.fireflies.ai/articles/2154538358-policy-on-keeping-information-safe"),
-      },
     },
   },
   {
+    // Jamie is the one product here with no AI help during the call: its
+    // in-meeting widget is a manual scratchpad and everything else happens
+    // after you stop recording. That is a real difference and it goes in the
+    // detailed table -- but not in the summary, because Otter and Granola both
+    // have it, so it is not a line between Nojoin and the field.
     key: "live",
     label: "Live in-meeting guidance",
     cells: {
       nojoin: {
         text: "Meeting Edge: live questions worth asking, missed points, and concept help.",
         source: README,
+      },
+      jamie: {
+        text: "The in-meeting widget is a private scratchpad for your own notes. Notes and transcript are generated after you stop recording.",
+        source: jsrc("https://docs.meetjamie.ai/getting-started/recorder"),
       },
       otter: {
         text: "The meeting agent gives real-time transcription, takeaways and action items, and answers questions live.",
@@ -192,10 +218,6 @@ export const rows: Row[] = [
         text: "Granola Chat can answer questions about the ongoing meeting.",
         source: src("https://docs.granola.ai/help-center/getting-more-from-your-notes/chatting-with-your-meetings"),
       },
-      fireflies: {
-        text: "Live Assist: real-time transcripts, notes, suggestions and AskFred answers during the meeting.",
-        source: src("https://guide.fireflies.ai/articles/6032274417-learn-about-fireflies-live-assist-get-real-time-suggestions-answers-and-notes-live-during-the-meeting"),
-      },
     },
   },
   {
@@ -203,6 +225,10 @@ export const rows: Row[] = [
     label: "Calendar integration",
     cells: {
       nojoin: { text: "Google and Outlook sync, with meeting context in the dashboard.", source: README },
+      jamie: {
+        text: "Google Calendar or Outlook, used for reminders, automatic meeting titles and better speaker identification.",
+        source: jsrc("https://docs.meetjamie.ai/enterprise/users/calendar-connection"),
+      },
       otter: {
         text: "Google Calendar, Microsoft Outlook and iOS Calendar.",
         source: src("https://otter.ai/features"),
@@ -211,10 +237,6 @@ export const rows: Row[] = [
         text: "Google and Microsoft/Outlook; Apple Calendar isn't supported.",
         source: src("https://docs.granola.ai/help-center/getting-started/syncing-your-calendars"),
       },
-      fireflies: {
-        text: "Google Calendar or Outlook, one connected calendar per account.",
-        source: src("https://guide.fireflies.ai/articles/4246295295-what-calendars-are-supported"),
-      },
     },
   },
   {
@@ -222,6 +244,10 @@ export const rows: Row[] = [
     label: "Search",
     cells: {
       nojoin: { text: "One query across recordings, notes and documents.", source: README },
+      jamie: {
+        text: "Semantic search across your meeting content, reachable from the app, the API and the MCP server.",
+        source: jsrc("https://docs.meetjamie.ai/integrations/mcp"),
+      },
       otter: {
         text: "Search and AI chat across meetings and connected apps, by keyword, speaker and date.",
         source: src("https://otter.ai/"),
@@ -230,26 +256,29 @@ export const rows: Row[] = [
         text: "Chat spans notes and transcripts across meetings and folders, plus files you upload.",
         source: src("https://docs.granola.ai/help-center/getting-more-from-your-notes/chatting-with-your-meetings"),
       },
-      fireflies: {
-        text: "Across recordings and transcripts, with host, participant, title and date filters.",
-        source: src("https://guide.fireflies.ai/articles/4577578901-how-to-search-and-find-your-meetings"),
-      },
     },
   },
   {
     // All four ship an MCP server, so "we have one" is not the claim. The line
     // that survives sourcing is what an assistant can actually do once it is
-    // connected: three of them read the meeting and act elsewhere, and Nojoin's
-    // acts on the meeting itself. Every cell states what that vendor documents
-    // and stops there. In particular no cell asserts that a competitor *cannot*
-    // write back -- that is an unsourced negative, and the gap is visible from
-    // the positives alone.
+    // connected: three of them read the meeting and act elsewhere or on its
+    // filing, and Nojoin's acts on the meeting itself. Every cell states what
+    // that vendor documents and stops there. In particular no cell asserts
+    // that a competitor *cannot* write back -- that is an unsourced negative,
+    // and the gap is visible from the positives alone.
+    //
+    // Jamie is the closest of the three and the reason this row still earns
+    // its place: it writes, but only to tags.
     key: "agents",
     label: "What an assistant can do with your meetings",
     cells: {
       nojoin: {
         text: "Thirty tools on your own deployment, authorised per user and on by default. An assistant corrects a misheard line, names the speaker, re-runs the notes, files the tasks, and syncs your People library with a CRM it's separately connected to — with no CRM integration in Nojoin at all.",
         source: MCP,
+      },
+      jamie: {
+        text: "Thirteen tools for Claude, ChatGPT, Cursor, Windsurf and Copilot: nine read meetings, transcripts, tasks and people, and four change tags — create, rename, delete and apply them.",
+        source: jsrc("https://docs.meetjamie.ai/integrations/mcp"),
       },
       otter: {
         text: "Reads Otter's transcripts to search across time, analyse themes and generate content. Writes outward into Google Docs, Slides, Jira, Salesforce and Slack. Part of Otter for Enterprise.",
@@ -259,23 +288,24 @@ export const rows: Row[] = [
         text: "Reads notes and transcripts on paid plans: list meetings, read a meeting, search the history. On Enterprise it's early-access beta and stays off until an admin enables it.",
         source: src("https://www.granola.ai/blog/granola-mcp"),
       },
-      fireflies: {
-        text: "Nineteen tools: 14 read, and 5 change something about the filing — rename a meeting, move it to a channel, share it, revoke that share, cut a soundbite.",
-        source: src("https://docs.fireflies.ai/mcp-tools/overview"),
-      },
     },
   },
   {
     // Limits, not prices -- the no-competitor-pricing rule still holds. The
-    // concessions here are load-bearing: Fireflies transcribes without limit on
-    // every plan, and Otter's top plans lift the monthly cap. Saying otherwise
-    // would be checkable in one click and would cost the rest of the table.
+    // concessions here are load-bearing: Otter's top plans lift the monthly
+    // cap, and Jamie's upper plans drop the meeting count entirely. Saying
+    // otherwise would be checkable in one click and would cost the rest of the
+    // table.
     key: "caps",
     label: "Limits on how much you process",
     cells: {
       nojoin: {
         text: "None in the software. No monthly allowance, no per-meeting ceiling, no history that expires. How much you get through is a question about your hardware.",
         source: README,
+      },
+      jamie: {
+        text: "One credit a meeting whatever its length: 10 a month and 30-minute meetings on the free plan, 20 and two hours on the next. Above that the count goes but a three-hour ceiling stays. Run out and existing notes lock until you upgrade.",
+        source: jsrc("https://docs.meetjamie.ai/billing-pricing/subscriptions-plans"),
       },
       otter: {
         text: "300 minutes a month and 30 minutes per conversation on the entry plan; 1,200 and 90 on the next. The upper plans lift the monthly cap and hold a four-hour ceiling per meeting.",
@@ -284,10 +314,6 @@ export const rows: Row[] = [
       granola: {
         text: "Meeting history is limited on the entry plan, by an amount the pricing page doesn't state. Unlimited notes and history above it.",
         source: src("https://www.granola.ai/pricing"),
-      },
-      fireflies: {
-        text: "Transcription is unlimited on every plan. Storage isn't: 400 minutes a team on the entry plan, 8,000 a seat above it. AI features draw on a monthly credit allowance.",
-        source: src("https://fireflies.ai/pricing"),
       },
     },
   },
@@ -299,6 +325,10 @@ export const rows: Row[] = [
         text: "Transcript, notes or combined output as DOCX, PDF or plain text, plus full-instance backup archives.",
         source: USAGE,
       },
+      jamie: {
+        text: "Summary, transcript and tasks sync into Notion, Google Docs, OneNote, HubSpot, Salesforce, Dynamics 365, Attio and Asana, with an API and webhooks behind them. No file download is documented.",
+        source: jsrc("https://docs.meetjamie.ai/integrations/overview"),
+      },
       otter: {
         text: "TXT, DOCX, PDF and SRT, plus audio export.",
         source: src("https://otter.ai/transcription"),
@@ -306,10 +336,6 @@ export const rows: Row[] = [
       granola: {
         text: "Bulk export of notes to CSV: titles, summaries, transcripts and details.",
         source: src("https://docs.granola.ai/help-center/sharing/exporting-notes"),
-      },
-      fireflies: {
-        text: "Transcripts in PDF, DOCX, SRT, CSV, JSON or MD; summaries, video and audio too.",
-        source: src("https://guide.fireflies.ai/articles/3319752033-how-to-download-transcripts-summaries-and-meeting-recordings-from-fireflies"),
       },
     },
   },
@@ -323,11 +349,11 @@ export const rows: Row[] = [
 // The rows were chosen because their answers are structural -- where the
 // software runs, who holds the recordings, what the licence permits -- rather
 // than roadmap-sensitive. Nojoin does not sweep the table, deliberately:
-// Granola also records without a bot, Otter also remembers speakers between
-// meetings, and saying otherwise would cost the credibility of the rows where
-// the difference is real. Live in-meeting guidance is absent for the same
-// reason: all four products document some form of it, so it is not a
-// distinction, whatever Meeting Edge is worth on its own merits.
+// Granola and Jamie also record without a bot, Otter and Jamie also remember
+// speakers between meetings, and saying otherwise would cost the credibility
+// of the rows where the difference is real. Live in-meeting guidance is absent
+// for the same reason: Otter and Granola both document some form of it, so it
+// is not a distinction, whatever Meeting Edge is worth on its own merits.
 
 export type Verdict = "yes" | "partial" | "no";
 
@@ -352,9 +378,9 @@ export const summaryRows: SummaryRow[] = [
     label: "Runs on your own hardware",
     cells: {
       nojoin: yes("One compose file"),
+      jamie: no("Vendor cloud, EU"),
       otter: no("Not stated in docs"),
       granola: no("Vendor cloud"),
-      fireflies: no("Vendor cloud"),
     },
   },
   {
@@ -362,9 +388,9 @@ export const summaryRows: SummaryRow[] = [
     label: "Processing stays on your infrastructure",
     cells: {
       nojoin: yes("Your server"),
+      jamie: no("Jamie's EU cloud"),
       otter: no("Otter's cloud"),
       granola: no("Granola's cloud"),
-      fireflies: no("Fireflies' cloud"),
     },
   },
   {
@@ -372,9 +398,9 @@ export const summaryRows: SummaryRow[] = [
     label: "Recordings and transcripts stay yours",
     cells: {
       nojoin: yes("Your server"),
+      jamie: no("Frankfurt-hosted"),
       otter: no("Otter's cloud"),
       granola: no("Vendor-hosted"),
-      fireflies: partial("Own bucket on Enterprise"),
     },
   },
   {
@@ -382,9 +408,9 @@ export const summaryRows: SummaryRow[] = [
     label: "Source available and auditable",
     cells: {
       nojoin: yes("AGPLv3"),
+      jamie: no("Proprietary"),
       otter: no("Proprietary"),
       granola: no("Proprietary"),
-      fireflies: no("Proprietary"),
     },
   },
   {
@@ -392,9 +418,9 @@ export const summaryRows: SummaryRow[] = [
     label: "Your choice of model, including fully local",
     cells: {
       nojoin: yes("Your keys, or Ollama"),
+      jamie: no("Vendor-chosen"),
       otter: no("Vendor-chosen"),
       granola: no("Vendor-chosen"),
-      fireflies: no("Vendor-chosen"),
     },
   },
   {
@@ -402,46 +428,48 @@ export const summaryRows: SummaryRow[] = [
     label: "No bot joins the call",
     cells: {
       nojoin: yes("Never a participant"),
+      jamie: yes("Captures locally"),
       otter: partial("Bot by default"),
       granola: yes("Captures locally"),
-      fireflies: partial("Bot by default"),
     },
   },
   {
+    // Jamie earns a yes: the naming is manual the first time, but it carries
+    // forward on its own after that, which is what the row asks.
     key: "speakers",
     label: "Speakers remembered between meetings",
     cells: {
       nojoin: yes("Voiceprint library"),
+      jamie: yes("Named once, then reused"),
       otter: yes("Auto-tags names"),
       granola: no("Per-meeting tags"),
-      fireflies: no("Per-transcript edits"),
     },
   },
   {
-    // Fireflies earns a partial rather than a no: five of its tools genuinely
-    // change something, they just change the filing rather than the record.
-    // Otter writes too, but outward into other products, so on this axis --
-    // what happens to the meeting itself -- it is a no.
+    // Jamie earns a partial rather than a no: four of its thirteen tools
+    // genuinely change something, they just change the filing rather than the
+    // record. Otter writes too, but outward into other products, so on this
+    // axis -- what happens to the meeting itself -- it is a no.
     key: "agents",
     label: "An assistant can change the record, not just read it",
     cells: {
       nojoin: yes("Thirty tools, on your server"),
+      jamie: partial("Creates and applies tags"),
       otter: no("Reads Otter, writes elsewhere"),
       granola: no("Reads notes and transcripts"),
-      fireflies: partial("Renames, moves, shares"),
     },
   },
   {
-    // Every one of them has a tier where something runs out; none of them is a
-    // flat no, so all three take a partial. Nojoin's yes is structural rather
-    // than generous -- there are no plans, so there is nothing to meter.
+    // Every one of them has a tier where something runs out; none is a flat
+    // no, so all three take a partial. Nojoin's yes is structural rather than
+    // generous -- there are no plans, so there is nothing to meter.
     key: "caps",
     label: "Nothing runs out",
     cells: {
       nojoin: yes("No plans, no meters"),
+      jamie: partial("Credits, and a length cap"),
       otter: partial("Capped below Business"),
       granola: partial("History capped on free"),
-      fireflies: partial("Storage and AI credits"),
     },
   },
   {
@@ -449,9 +477,9 @@ export const summaryRows: SummaryRow[] = [
     label: "Capture without a desktop app",
     cells: {
       nojoin: yes("Any browser"),
+      jamie: no("Desktop or mobile app"),
       otter: yes("Web app"),
       granola: no("Desktop app"),
-      fireflies: partial("Chrome extension"),
     },
   },
 ];

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -36,13 +36,13 @@ const fn = (cell: Cell) => (cell.source ? sourceIndex.get(cell.source.url) : und
 
 <Base
   title="Compare — Nojoin"
-  description="How Nojoin compares to Otter, Granola and Fireflies on capture, storage, self-hosting, licences and model choice, with every claim sourced and dated."
+  description="How Nojoin compares to Jamie, Otter and Granola on capture, storage, self-hosting, licences and model choice, with every claim sourced and dated."
 >
   <main class="section">
     <div class="wrap">
       <div class="centered">
         <p class="eyebrow">Comparison</p>
-        <h1 class="heading-2">Nojoin next to Otter, Granola and Fireflies</h1>
+        <h1 class="heading-2">Nojoin next to Jamie, Otter and Granola</h1>
         <p class="lead" style="max-width: 62ch; margin-inline: auto;">
           Nojoin has taken no funding, employs nobody, and sells nothing you can't
           download. It still runs on your hardware, under a licence you can read, with an

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -306,7 +306,7 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
       <div class="wrap">
         <h2 class="heading-2">How it compares</h2>
         <p class="lead">
-          Otter, Granola and Fireflies, on the axes that matter for ownership and privacy,
+          Jamie, Otter and Granola, on the axes that matter for ownership and privacy,
           with every claim sourced and dated.
         </p>
         <div class="ctas">

--- a/site/src/styles/site.css
+++ b/site/src/styles/site.css
@@ -662,11 +662,13 @@ button:focus-visible {
   margin-top: 3.5rem;
 }
 
-/* Narrower than the detailed table: these cells are a mark and a few words, so
-   they do not need the horizontal scroll the prose table earns. */
-.glance-table {
-  min-width: 32rem;
-}
+/* This carries .compare-table as well, and takes that rule's min-width: the two
+   selectors have equal specificity and .compare-table is declared later, so a
+   min-width here is dead whatever it says. It used to say 32rem, with a comment
+   claiming the glance table was narrower than the prose one -- it never was.
+   Leaving it as intent-that-does-nothing is worse than not saying it: the two
+   tables share a column count and a label column, so sharing a floor is right,
+   and 32rem across five columns would squeeze the notes to about 80px anyway. */
 
 /* Positioned so the visually-hidden verdict inside it is contained here rather
    than by the initial containing block. Left to escape, an absolutely
@@ -734,10 +736,21 @@ button:focus-visible {
   border-bottom: 1px solid var(--surface-divider);
 }
 
+/* The row label wraps rather than forcing its own width. It used to be
+   white-space: nowrap, which let "What an assistant can do with your meetings"
+   claim about 300px of a table whose whole job is the prose to the right of
+   it. A two-line label costs nothing; a squeezed cell costs a claim. */
 .compare-table tbody th {
   color: var(--foreground);
   font-weight: 600;
-  white-space: nowrap;
+  /* An explicit width, not just a min-width. The label used to be
+     white-space: nowrap, which let "What an assistant can do with your
+     meetings" claim ~385px of a table whose whole job is the prose to its
+     right. min-width alone does not fix that: auto table layout sizes a column
+     from its content and will happily overshoot a minimum. A width is a hint
+     the algorithm actually follows, so the labels wrap to two lines and the
+     product columns get the space back. */
+  width: 12rem;
 }
 
 .compare-table td {


### PR DESCRIPTION
# Pull Request

## Description

Jamie ([meetjamie.ai](https://www.meetjamie.ai/)) joins the comparison and Fireflies leaves it, so the page still runs **three** competitors rather than four.

**Why Fireflies went.** It is the least like Nojoin on the axes this page argues: bot-by-default capture, a US cloud, and no self-hosting position to concede anything against. Jamie is the opposite on all three, which makes it the harder comparison and the more useful one. The alternative — a fifth column — is worse: the detailed table is already the widest thing on the site, so another column either squeezes every cell or pushes one somewhere most readers never scroll.

**Jamie sits second**, directly after Nojoin, because column order decides which competitor actually gets read.

**23 claims**, each read from Jamie's own current documentation and carrying the exact URL and the date it was read.

### Jamie does not lose this table

That is the point of running it. Jamie takes an **outright yes** on capturing without a bot and on remembering speakers between meetings, and a **partial** on assistant write access — the row Nojoin leads with. Its thirteen MCP tools genuinely write, just only to tags, and the cell says so rather than rounding it down to a no.

Where Jamie is behind, the reason is structural rather than a feature gap: a proprietary licence, an EU cloud that is still somebody else's, vendor-chosen models, and a credit a meeting that locks the notes you already have when it runs out.

The one row Jamie is alone on is **live in-meeting guidance** — its widget is a manual scratchpad, and everything else happens after recording stops. That stays out of the summary table, because Otter and Granola both document some form of it, so it is not a line between Nojoin and the field.

### Dates

The check dates are **per-claim, not per-table**. Jamie's rows were researched a day after the others and carry `3 Aug 2026`; the rest keep `2 Aug 2026`. A footnote now reports when that page was actually read rather than when the file was last touched.

### Two table fixes that came with it

- The row label was `white-space: nowrap`, so *"What an assistant can do with your meetings"* claimed ~385px of a table whose whole job is the prose beside it. A `min-width` does not fix this — auto table layout sizes a column from its content and overshoots a minimum happily — so the label column takes an explicit `12rem` and wraps. **Product columns gain roughly 40px each**, wider than before this change at the same column count.
- `.glance-table` carried a dead `min-width: 32rem`. The element also carries `.compare-table`, whose rule is declared later at equal specificity, so the glance value never applied and the comment above it described a narrower table that has never existed. Removed rather than left as intent that does nothing.

No new dependencies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1333 passed)
- [x] Python quality: `python scripts/check.py` (all OK)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py` (19 files)
- [ ] Alembic validation: `python3 scripts/validate_alembic.py`

Nothing under `frontend/` changed. Site checks were run instead:

- `cd site && npm run build` — 4 pages built
- `node frontend/scripts/check-contrast.mjs` — 248 pairings across 4 themes
- `git diff --check` — clean

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/SITE.md` records which three competitors the page runs and why, that column order is a decision, and a standing test: **dropping a competitor is not a licence to pick easy ones** — if a future edit leaves Nojoin sweeping every row, the problem is the competitor set, not the product. The managed section's caps passage cited Fireflies for two claims and now cites Jamie and Granola instead.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

Static content.

## Manual verification

No capture-related code changed, so no browser smoke testing applies.

**Every source URL re-verified.** All 30 URLs in `comparison.ts` return 200, including all 10 Jamie sources. Jamie's claims were read from `docs.meetjamie.ai` and `meetjamie.ai` directly, not from third-party summaries or Jamie's own comparison blog posts.

**Table geometry**, measured rather than assumed, at the detailed prose table:

| Viewport | Table | Scrolls | Columns (label, Nojoin, Jamie, Otter, Granola) |
| --- | --- | --- | --- |
| 1440px | 1326 | no | 192, 321, 292, 250, 271 |
| 1280px | 1198 | no | 192, 279, 257, 223, 248 |
| 1024px | 942 | no | 192, 194, 187, 169, 200 |
| 768px | 896 | yes | 192, 179, 174, 160, 192 |

The table needs no sideways scroll above 1024px. Below that it scrolls inside its own `overflow-x: auto` container, which is the deliberate behaviour for this table — the document itself never moves.

**Overflow.** No horizontal overflow in any of 32 cells — 4 pages × 2 widths (360px, 1920px) × 4 theme combinations.

**Rendered output checked**: column order is Nojoin, Jamie, Otter, Granola in both tables; no occurrence of "Fireflies" survives in any built page; footnotes deduplicate by URL to 10 Jamie sources; and both dates render (20 footnotes at 2 Aug, 10 at 3 Aug).

**Copy constraints**: skim layer holds at 456 words against the 400–600 budget, one `.hl` per page, no banned words, and no competitor pricing — Jamie's caps row states credits, meeting counts and duration ceilings, with no currency anywhere.

## Screenshots (if relevant)

The detailed table with Jamie in the second column, and the at-a-glance table above it, both captured at 1440px in light theme.

_Captured locally; available in the working tree._
