### PR TITLE
docs(site): stop three files calling a revert a rollback

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -4,7 +4,13 @@ name: Site deploy
 # main, a published release (so the baked-in version and star count refresh),
 # a weekly schedule (same reason, without needing a release), and by hand.
 # There is deliberately no branch trigger: the workflow only ever deploys what
-# main contains, which is what makes reverting a commit a complete rollback.
+# main contains, so whatever lands there is what the public gets.
+#
+# That does NOT make reverting a complete rollback. Reverting an ordinary site/
+# commit is fine, because the deploy just publishes the earlier content. But the
+# route in site/wrangler.jsonc has nothing behind it any more — GitHub Pages was
+# disabled and deleted when this site went live — so reverting the commit that
+# added it takes www.nojoin.co.uk down instead of restoring it. Roll forward.
 on:
   push:
     branches:

--- a/docs/SITE.md
+++ b/docs/SITE.md
@@ -452,9 +452,16 @@ liability: `Base.astro` builds its canonical from `Astro.site` and so pointed cr
 at `www.nojoin.co.uk`, but that is mitigation rather than a reason to keep it. Reviewing an
 unmerged change is what `npm run serve` and a quick tunnel are for.
 
-**Rolling back is `git revert` of the commit that added the route, then letting CI deploy.**
-Deleting the route in the Cloudflare dashboard is not the rollback path: the weekly scheduled
-deploy from `main` re-applies whatever `wrangler.jsonc` says.
+**Fixing a bad deploy means rolling `site/` forward, not backwards.** There is no revert that
+lands on a working site, and reverting the commit that added the route takes the site down
+rather than restoring it — the reasoning is two paragraphs below, and it is the single
+easiest thing to get wrong here under pressure. Deleting the route in the Cloudflare
+dashboard is not a rollback either: the weekly scheduled deploy from `main` re-applies
+whatever `wrangler.jsonc` says.
+
+`git revert` of an ordinary `site/` commit is fine, and is just another way of rolling
+forward — the deploy publishes whatever `main` holds. What is not survivable is reverting
+the route itself.
 
 That rollback used to land on a live GitHub Pages origin. It no longer does. Pages served
 the previous Jekyll site from `main` as a `build_type: legacy` build — no workflow, just a

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -10,9 +10,14 @@
 // adding it intercepts traffic atomically, and removing it stops intercepting
 // just as atomically.
 //
-// Rollback is reverting the commit that added this block and letting CI deploy.
-// Deleting the route in the Cloudflare dashboard is NOT the rollback path: the
-// weekly scheduled deploy from main would silently re-add it.
+// DO NOT revert the commit that added this route to roll back. It reads like
+// the undo button and it is not one: GitHub Pages used to sit behind this route
+// and was disabled and deleted when the Astro site went live, so removing the
+// Worker now leaves the DNS record pointing at nothing. That is an outage, not
+// a rollback. Fix a bad deploy by rolling site/ forward.
+//
+// Deleting the route in the Cloudflare dashboard is not a rollback either: the
+// weekly scheduled deploy from main re-applies whatever this file says.
 //
 // workers_dev is off. It was on while the site was being built, so it could be
 // reviewed before the route existed, and it served a complete public duplicate


### PR DESCRIPTION
# Pull Request

## Description

Reverting the commit that added the Worker route reads like the undo button and is the opposite of one. GitHub Pages used to sit behind that route and was disabled and its sources deleted when the Astro site went live, so removing the Worker now leaves the DNS record pointing at nothing. **That is an outage, not a rollback.**

`docs/SITE.md` has said so since the cutover — in a paragraph three below the one telling you to revert.

Three files carried the old advice and none carried the correction:

| File | What it said |
| --- | --- |
| `site/wrangler.jsonc` | *"Rollback is reverting the commit that added this block"* — the first thing anyone reads when they go looking for the route under pressure |
| `.github/workflows/site-deploy.yml` | explained its own no-branch-trigger design as *"what makes reverting a commit a complete rollback"* |
| `docs/SITE.md` | led the section with a **bolded** *"Rolling back is `git revert` of the commit that added the route"*, then contradicted it further down |

All three now say the same thing: **fix a bad deploy by rolling `site/` forward.**

The distinction that was missing everywhere is now drawn explicitly — reverting an *ordinary* `site/` commit is fine and is just another way of rolling forward, because the deploy publishes whatever `main` holds. It is reverting **the route itself** that has nothing to land on. Deleting the route in the Cloudflare dashboard is still not a rollback either, and all three still say so, because the weekly scheduled deploy re-applies whatever `wrangler.jsonc` holds.

Comments only. No behaviour change, and this commit triggers no deploy: it touches no file under `site/` that the build reads, and the workflow edit is a comment above the trigger block.

No new dependencies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1333 passed)
- [x] Python quality: `python scripts/check.py` (all OK)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py` (19 files)
- [ ] Alembic validation: `python3 scripts/validate_alembic.py`

Nothing under `frontend/` changed. Also ran: `cd site && npm run build` (4 pages), `node frontend/scripts/check-contrast.mjs` (248 pairings), `git diff --check` clean.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

This PR *is* the documentation change.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

It reduces the chance of an availability incident caused by following the repository's own instructions, but changes no code.

## Manual verification

Both edited config files were re-parsed after the comment changes, because a stray character in a comment block is exactly how a "comments only" change stops being one:

- `site/wrangler.jsonc` still parses as JSONC, with `workers_dev: false` and the route unchanged.
- `.github/workflows/site-deploy.yml` still parses as YAML, with both jobs (`deploy`, `check-comparison-sources`) intact.

**Checked live rather than assumed**, since these contracts only exist on a real deployment:

- `https://www.nojoin.co.uk/` serves the merged nav (Quick start, Pricing present).
- `/docs/TELEMETRY`, `/docs/README` and `/docs/MCP` each still return **301** to their GitHub blob URL.

I also confirmed no CI job probes the `workers.dev` hostname turned off in #211, so nothing in the pipeline went red from that change. The weekly source-URL check reads its list out of `comparison.ts`, so it picked up Jamie's ten URLs and dropped Fireflies' automatically.

### Not in this PR, and why

Two items I raised earlier are genuinely blocked rather than skipped:

- **A real screenshot for the agent band.** `docs/SITE.md` carries a standing note that the band should earn one now that MCP edit provenance shipped in #208. The site's own rule is that screenshots are real captures from a seeded demonstration instance processed through the genuine pipeline — that needs a running instance with MCP-edited transcripts, and I am deliberately not starting a stack on this host given the shared `:local` image tags.
- **The `docs/MCP.md` Codex → ChatGPT pass.** `docs/SITE.md` records that its three literal strings (`codex mcp logout nojoin`, `~/.codex/config.toml`, the `"Codex MCP Credentials"` keychain entry) survived the rename, and that the troubleshooting section describes behaviour observed on a Codex build nobody has re-tested. Renaming without that re-test is precisely what the note exists to prevent.
