### PR TITLE
feat(site): distil the copy down to one argument

### DIFF
--- a/docs/SITE.md
+++ b/docs/SITE.md
@@ -76,13 +76,6 @@ Locked by decision, rendered and chosen from variants, and not to be re-litigate
   faint, so two `.band`s in a row do not look like a seam, they look like nothing at all, and
   the rhythm quietly disappears. Removing the privacy section left three consecutive bands
   before anyone noticed.
-- **The spell check is in the notes screenshot on purpose.** The generated demo notes use
-  American spellings and the editor underlines them, which read as errors in Nojoin's output
-  until the copy beside the shot claimed them: the row now points at the red line under
-  "emphasizing" and says the spell check reads British English. That turns an artefact into
-  the feature it actually is. It is also the honest reading — nothing was retouched, and four
-  attempts to suppress the underlines failed because the editor re-renders through DOM and
-  stylesheet overrides alike.
 - **The quick-start code block is dark in both themes**, and it is the only surface that
   ignores the theme toggle. It followed the theme until a reader pointed out it was still
   hard to look at in light: the syntax colours were legible on the measurements, but the
@@ -99,6 +92,11 @@ Locked by decision, rendered and chosen from variants, and not to be re-litigate
   page still ends on a deliberate surface rather than trailing off, and the last thing a
   visitor reads is the one offer the hero does not make. A page that has to ask twice is
   usually too long, which is what the rest of this pass was about.
+- **The landing page carries no three-up strip.** It had one under the hero — no bot, any
+  platform, your hardware — and two of those three were the hero's own claims, restated
+  before the reader had scrolled past them. Its one unique line, that any platform works with
+  nothing to install, moved into the hero. `/managed/` keeps a strip of its own, where the
+  three cards say things that page says nowhere else.
 - **The landing page carries no privacy section.** It had one, and it was cut when the page
   was shortened: those claims are made better elsewhere. Self-hosting and local inference
   lead the three-up strip, the licence is in the footer, telemetry has a footer link on every
@@ -139,11 +137,13 @@ Locked by decision, rendered and chosen from variants, and not to be re-litigate
 - **The header is sticky**, with a solid fill rather than a blurred scrim. Glass is out by
   the flat canon, and `backdrop-filter` over text this dense costs a repaint per scroll
   frame for an effect the design does not want.
-- **The agent band sits directly under the strip**, on the page surface with the hero's
+- **The agent band sits directly under the hero**, on the page surface with the hero's
   wash. It carries three devices rather than prose. A flow card walks one real post-meeting
   job and tags each step with the actor who performs it, chevrons between the steps so it
   reads downward as a sequence rather than as a table. A six-card showcase groups the thirty
-  tools by what they touch, each led by a glyph. A wider card carries the CRM bridge on its
+  tools by what they touch, each led by a glyph and carrying its count. The cards used to
+  name every tool in the group; that is an inventory, not an argument, and the six counts add
+  to thirty on their own. A wider card carries the CRM bridge on its
   own, because an assistant reconciling your People library with anything it can already
   reach is the claim with no equivalent in the comparison, and it was a clause in a
   paragraph. The actor pills say "Agent", never a vendor name: more than one assistant is
@@ -173,7 +173,7 @@ Locked by decision, rendered and chosen from variants, and not to be re-litigate
   "Agentic" is jargon and stays anyway: on the landing page it flatters a reader who knows
   the word, and the subhead immediately spells it out in plain terms for one who does not.
   The `/managed/` page, whose reader is far less likely to be technical, avoids it entirely.
-  No-bot did not disappear; it opens the subhead and leads the strip beneath the hero.
+  No-bot did not disappear; it opens the subhead.
 - **The agents section carries no screenshot, and this has now been tried both ways.** The
   original reason still stands: the capability happens in Claude's or ChatGPT's window, not
   Nojoin's, and the frame chrome reads `nojoin.your-server.net`, so a framed capture of
@@ -283,8 +283,24 @@ The rules:
 - **Parallel closers.** Paired elements end on matched short sentences.
 - **Whole jobs, not first drafts.** Every feature example ends with something genuinely
   delivered: the transcript attributed, the notes written, the task filed.
-- **A word budget**: 400–600 words of prose in the skim layer (headlines, ledes, labels).
-  Devices, screenshots and the table carry the rest.
+- **Say each idea once, on the page where it lands hardest.** The landing page had drifted
+  into a sequence of self-contained pitches: no-bot appeared three times, "your own server"
+  three times, CRM six times, and one thirteen-word clause about plain primitives ran
+  verbatim in two places a screen apart. Repetition does not reinforce a claim, it tells a
+  reader the page has nothing further to say. The page argues **one** thing — an agentic
+  meeting intelligence platform on hardware you own — and every section below the hero is
+  evidence for it rather than a fresh advert. When a claim appears twice, delete the weaker
+  instance rather than rewording it.
+- **Do not inventory the product.** The tool showcase used to name all thirty MCP tools; the
+  goal is not to have every feature listed, it is to pitch one platform. A count carries the
+  same claim without the reader having to audit a list.
+- **A word budget, and it is a ceiling rather than a range.** No more than about 400 words of
+  prose in the skim layer (headlines, ledes, labels) across the site; devices, screenshots and
+  the table carry the rest. This replaces a 400–600 range, which had a floor for no good
+  reason. Two deliberate passes — cutting the privacy section and the repeat-CTA closer, then
+  distilling the copy so each idea appears once — took the real figure to about 300, and a
+  floor would have argued for padding it back up. Fewer words are not a defect. Repetition
+  is.
 
 **Banned everywhere**: seamless, powerful, robust, enterprise-grade, best-in-class,
 cutting-edge, unlock, empower, leverage, revolutionise, game-changing, AI-powered,

--- a/site/src/pages/compare.astro
+++ b/site/src/pages/compare.astro
@@ -24,15 +24,13 @@ const READS: Record<Verdict, string> = { yes: "Yes", partial: "Partly", no: "No"
         <h1 class="heading-2">Nojoin Next to Jamie, Otter and Granola</h1>
         <p class="lead" style="max-width: 62ch; margin-inline: auto;">
           Nojoin has taken no funding, employs nobody, and sells nothing you can't
-          download. It still runs on your hardware, under a licence you can read, with an
-          agent that edits your meetings and nothing that runs out at month end. Here's
-          the whole thing next to three products that have raised money to build it.
+          download. Here it is next to three products that raised money to build the same
+          thing.
         </p>
         <p class="lead" style="max-width: 62ch; margin-inline: auto; font-size: 1rem;">
-          Every competitor claim below comes from that vendor's own current documentation
-          and carries the URL and the date it was read. Where they're better, the table
-          says so. That's the part most comparison pages leave out, and it's the reason
-          you can trust the rest of this one.
+          Every claim below comes from that vendor's own current documentation. Where
+          they're better, the table says so — which is the part most comparison pages
+          leave out.
         </p>
       </div>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -13,7 +13,7 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
 <Base
   title="Nojoin"
   ogTitle="Nojoin — agentic meeting intelligence on your own server"
-  description="Transcripts, speaker attribution, notes and search on hardware you own, with no bot in the call. Thirty MCP tools let Claude or ChatGPT correct the record, file the actions and reconcile your people with any CRM. Nothing is capped."
+  description="Meeting intelligence on hardware you own, with no bot in the call. Nojoin hands your whole meeting library to Claude or ChatGPT through thirty tools that change the record rather than just read it. Nothing is capped."
 >
   <main>
     <section class="hero">
@@ -27,9 +27,8 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
           <span>Agentic meeting intelligence isn't.</span>
         </h1>
         <p class="lead">
-          No bot joins the call, and nothing leaves your server. Then Nojoin hands the whole
-          library to Claude or ChatGPT: thirty tools that correct the record, file the actions,
-          and reconcile your people with any CRM your agent already reaches.
+          No bot joins the call — Meet, Teams or Zoom, with nothing to install — and nothing
+          leaves your server. Then Nojoin hands the whole library to the assistant you already use.
           <mark class="hl">It was built to be that bridge, and nothing about it is metered.</mark>
         </p>
         <div class="ctas">
@@ -47,45 +46,12 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
       </div>
     </section>
 
-    <section class="strip" aria-label="What makes Nojoin different">
-      <div class="wrap">
-        <div class="strip-grid">
-          <div class="strip-item">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"></path>
-              <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
-              <line x1="12" y1="19" x2="12" y2="22"></line>
-            </svg>
-            <h2>No Bot Joins the Call</h2>
-            <p>Capture happens in your browser tab, so nothing ever sits in the participant list.</p>
-          </div>
-          <div class="strip-item">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <circle cx="12" cy="12" r="10"></circle>
-              <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"></path>
-              <path d="M2 12h20"></path>
-            </svg>
-            <h2>Works With Any Platform</h2>
-            <p>Google Meet, Microsoft Teams and Zoom, with no integration to install and no meeting links to hand over.</p>
-          </div>
-          <div class="strip-item">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <rect width="20" height="8" x="2" y="2" rx="2"></rect>
-              <rect width="20" height="8" x="2" y="14" rx="2"></rect>
-              <line x1="6" x2="6.01" y1="6" y2="6"></line>
-              <line x1="6" x2="6.01" y1="18" y2="18"></line>
-            </svg>
-            <h2>Runs on Your Hardware</h2>
-            <p>Recordings, transcripts and models stay on a server you control, with optional fully local AI through Ollama.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    {/* The agent band. Promoted to just under the strip because the MCP surface
-        is the capability with no equivalent elsewhere, and it sat five sections
-        down as prose. No screenshot, deliberately, and it has now been tried
-        both ways: the work happens in Claude's or ChatGPT's window, and a
+    {/* The agent band, directly under the hero: the MCP surface is the
+        capability with no equivalent elsewhere, so the page argues it first and
+        everything below is evidence for it. The three-up strip that used to sit
+        between them is gone -- it restated two of the hero's own claims before
+        the reader had scrolled past them. No screenshot, deliberately, and it
+        has now been tried both ways: the work happens in Claude's or ChatGPT's window, and a
         capture of Nojoin's own transcript showing the AI-corrected labels
         turned out to say the same thing as the transcripts row two sections
         below. Three devices carry it instead, each with a claim no capture
@@ -97,17 +63,9 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
             <p class="eyebrow">Agents</p>
             <h2 class="heading-2">An Assistant That Changes the Record, Not Just Reads It</h2>
             <p>
-              Connect Claude or ChatGPT to your own instance. Thirty tools, eighteen of them
-              writing, authorised per user and on by default — no API key, no configuration,
-              nothing to paste.
-            </p>
-            <p>
-              The CRM sync needs no CRM integration in Nojoin. An assistant already connected
-              to HubSpot or Airtable reconciles both sides itself, because what Nojoin exposes
-              are plain primitives over its own data rather than a fixed list of partners.
-            </p>
-            <p>
-              Every change it makes is reversible. The bin is the strongest delete it has.
+              Connect Claude or ChatGPT to your own instance. Eighteen of the thirty tools
+              write, authorised per user and on by default — no API key, nothing to paste.
+              Every change is reversible, and the bin is the strongest delete it has.
             </p>
             <a class="text-link" href={`${docs}/MCP.md`}>
               The connector, tool by tool →
@@ -135,7 +93,6 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
               <line x1="12" y1="19" x2="12" y2="22"></line>
             </svg>
             <h3>Recordings <span class="n">8</span></h3>
-            <p>List, rename, tag, untag, archive, restore, bin, reprocess.</p>
           </li>
           <li>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -144,7 +101,6 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
               <path d="M8 13h8M8 17h5"></path>
             </svg>
             <h3>Transcript <span class="n">5</span></h3>
-            <p>Read it, read it as utterances, correct the text, correct the speaker, unlock.</p>
           </li>
           <li>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -153,7 +109,6 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
               <path d="M18.4 13.6a2 2 0 0 1 2.8 2.8L17 20.6l-3 .7.7-3Z"></path>
             </svg>
             <h3>Notes and Documents <span class="n">5</span></h3>
-            <p>Read the notes, regenerate them, append your own, read documents, attach one.</p>
           </li>
           <li>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -163,7 +118,6 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
               <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
             </svg>
             <h3>People and Speakers <span class="n">5</span></h3>
-            <p>List, read one, import, read a meeting's speakers, name one.</p>
           </li>
           <li>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -172,7 +126,6 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
               <path d="m9 14 2 2 4-4"></path>
             </svg>
             <h3>Tasks <span class="n">3</span></h3>
-            <p>List them, create them, complete them.</p>
           </li>
           <li>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -180,7 +133,6 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
               <path d="m21 21-4.3-4.3"></path>
             </svg>
             <h3>Calendar, Search and Tags <span class="n">4</span></h3>
-            <p>List events, link one to a recording, search everything, list tags.</p>
           </li>
         </ul>
 
@@ -195,9 +147,9 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
             <h3>The Bridge Between Your Meetings and Any CRM</h3>
             <p>
               Nojoin ships no CRM integration and needs none. An assistant already connected
-              to something else reads both sides and reconciles them, because what Nojoin
-              exposes are plain primitives over its own data rather than a fixed list of
-              partners. Nothing to wait for, and nothing to be dropped from.
+              to HubSpot or Airtable reconciles both sides itself, because Nojoin exposes plain
+              primitives rather than a partner list. Nothing to wait for, nothing to be dropped
+              from.
             </p>
             <div class="bridge-chips">
               <span>HubSpot</span><span>Airtable</span><span>Salesforce</span>
@@ -215,8 +167,8 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
             <p class="eyebrow">Meeting Edge</p>
             <h2 class="heading-2">Guidance While the Meeting Is Still Happening</h2>
             <p>
-              Live in-meeting help with questions worth asking, points you've missed, and
-              concepts explained as they come up, grounded in what's been said so far.
+              Questions worth asking, points you've missed and concepts explained as they come
+              up — grounded in what has actually been said so far.
             </p>
             <a class="text-link" href={`${docs}/USAGE.md`}>How it works in practice →</a>
           </div>
@@ -239,9 +191,8 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
             <p class="eyebrow">Transcripts</p>
             <h2 class="heading-2">Every Word, Attributed to the Right Person</h2>
             <p>
-              Built-in transcription with speaker attribution, backed by a global speaker
-              library. Voiceprints match the people you've named across every future
-              meeting. Corrections take one click.
+              Voiceprints, not name tags. Name someone once and they stay named across every
+              future meeting. Corrections take one click.
             </p>
             <a class="text-link" href={`${docs}/USAGE.md`}>Speakers and voiceprints →</a>
           </div>
@@ -264,9 +215,9 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
             <p class="eyebrow">Notes</p>
             <h2 class="heading-2">Notes Written From What Was Actually Said</h2>
             <p>
-              A summary, the decisions and the actions, generated from the transcript rather
-              than from memory. Meeting Chat is grounded in all of it — the notes, the
-              transcript and the documents you attach — and one query searches all three.
+              A summary, the decisions and the actions, written from the transcript by a model
+              you choose — your own API key, or Ollama on the same machine. One query searches
+              the notes, the transcript and your documents together.
             </p>
             <a class="text-link" href={`${docs}/USAGE.md`}>Notes, search and Meeting Chat →</a>
           </div>
@@ -312,8 +263,7 @@ const docs = "https://github.com/Valtora/Nojoin/blob/main/docs";
       <div class="wrap">
         <h2 class="heading-2">How It Compares</h2>
         <p class="lead">
-          Jamie, Otter and Granola, on the axes that matter for ownership and privacy,
-          with every claim sourced and dated.
+          Jamie, Otter and Granola, on the axes that decide who owns the meeting.
         </p>
         <div class="ctas">
           <a class="btn btn-secondary" href="/compare/">See the comparison</a>

--- a/site/src/pages/managed.astro
+++ b/site/src/pages/managed.astro
@@ -39,7 +39,7 @@ const contact = "hello@nojoin.co.uk";
     <section class="hero">
       <div class="wrap">
         <p class="eyebrow">Managed</p>
-        <h1 class="display">All the control, none of the admin</h1>
+        <h1 class="display">All the Control, None of the Admin</h1>
         <p class="lead">
           Nojoin is free, and setting it up yourself is four steps. Someone still has to
           own the server, apply the upgrades and notice when it stops. I built Nojoin, and


### PR DESCRIPTION
# Pull Request

## Description

The landing page had become a sequence of self-contained pitches, each re-introducing the product. Measured before this change:

| Idea | Times on the landing page |
| --- | --- |
| CRM | **6** |
| "no bot" | 3 |
| "your own server / hardware" | 3 |
| Claude or ChatGPT | 2 |
| thirty tools | 2 |

Plus a **thirteen-word clause repeated verbatim** — *"because what Nojoin exposes are plain primitives over its own data rather than a fixed list of partners"* — once in the agent band copy and once in the bridge card one screen below it.

The page now argues one thing — an agentic meeting intelligence platform on hardware you own — and everything under the hero is evidence for it rather than a fresh advert.

| Change | Why |
| --- | --- |
| **The three-up strip is gone** | Two of its three cards were the hero's own claims, restated before the reader had scrolled past them. Its one unique line — any platform, nothing to install — moved into the hero. |
| **The hero lede** | Drops the feature list the agent band repeats two sections later; keeps the bridge claim and the highlight. |
| **The agent band** | Loses the duplicated CRM paragraph. The bridge card was already making that argument and is now the only place it is made. |
| **The tool showcase** | Six cards keep their glyph, group and count, and lose the sentence naming every tool in the group. An inventory is not an argument, and the counts still add to thirty. |
| **Feature rows** | One idea each. Local inference moved into the notes row, where the model actually runs, rather than disappearing with the strip. |

**Result: 701 words of visible text down to 504, and zero phrases repeated verbatim.** CRM 6→3, no-bot 3→1, thirty tools 2→1.

### Two claims that were false, not merely long

Both were left behind when the comparison footnotes were removed:

- The landing page's comparison teaser promised *"every claim sourced and dated"*.
- The comparison page's own intro promised each claim *"carries the URL and the date it was read"*.

Neither is true any more. Both now say the claims come from each vendor's own current documentation, which is still exactly what happens.

### The word budget is rewritten

It was 400–600 words in the skim layer. That range had a floor for no good reason, and after two deliberate passes that shortened the page on purpose — cutting the privacy section and the repeat-CTA closer, then this one — the real figure is about 300. A floor would have argued for padding it back up. It is now **a ceiling of about 400**, with the reasoning recorded: fewer words are not a defect, repetition is.

No new dependencies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1333 passed)
- [x] Python quality: `python scripts/check.py` (all OK)
- [ ] Frontend lint / unit tests / build
- [x] Docs validation: `python3 scripts/validate_docs.py` (19 files)
- [ ] Alembic validation

Nothing under `frontend/` changed. Site checks instead: `npm run build` (4 pages), `node frontend/scripts/check-contrast.mjs` (248 pairings), `git diff --check` clean.

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR.

`docs/SITE.md` records the rule this pass came down to — **say each idea once, on the page where it lands hardest, and delete the weaker instance rather than rewording it** — plus a matching rule against inventorying the product, the strip removal, the showcase change and the new budget. It also drops the now-stale note about the spell-check joke, which went with the underlines.

## Security impact

- [x] No security-sensitive change.

Marketing copy.

## Manual verification

**Repetition, measured before and after** by extracting the visible text from the built page and counting repeated 5–12 word sequences: 8+ repeated phrases before, **0** after.

**Structure.** Sections still alternate `band / section / band / section` down the page after the strip's removal, and there is still exactly one `.hl`.

**Overflow.** No horizontal overflow in any of 32 cells — 4 pages × 2 widths (360px, 1920px) × 4 theme combinations.

Page height 6435px → 5911px.

### A note on how this branch was made

The branch this work started on was `feat/site-cropped-screenshots`, which you squash-merged as #217 while the copy pass was in progress. Pushing it recreated a branch for an already-merged PR, and because it predated #215 and #216 a PR from it would have **reverted** the rollback-comment fix and the full-page scroll fix. I rebuilt the work as a single commit on current `main` and deleted the stale branch. The diff here is four files and nothing else.
