### PR TITLE
feat(site): sharpen the comparison axes and cut the summary sweep

### DIFF
--- a/docs/SITE.md
+++ b/docs/SITE.md
@@ -329,6 +329,45 @@ As it stands Jamie takes an outright yes on no-bot capture and on remembering sp
 partial on assistant write access — the row Nojoin leads with. A table Nojoin swept would be
 worth a second look for that reason alone.
 
+**What that sweep test actually catches, revised.** The summary table was audited and it was
+swept: ten rows, ten Nojoin yeses. The cause was not generous verdicts. It was row selection.
+Four detailed rows — live guidance, calendar, search, export — never had a summary verdict,
+and those were exactly the axes where Nojoin ties or trails. Every axis Nojoin led got a
+summary row and every axis it did not was left in the prose table. So the test needs
+sharpening: **count the axes you left out, not just the verdicts you put in.** A summary table
+that is a filtered subset of the detailed one will always sweep, whatever the verdicts say.
+
+Two things came out of that audit, and the second reverses a decision this document recorded.
+
+- **Five rows were saying one thing.** Self-hosting, processing, storage, licence and model
+  choice all read Nojoin yes against three crosses. That is one argument — how much of the
+  stack is yours to change — counted five times, which inflated the win count without adding
+  an idea and broke the site's own rule that each idea appears once. They are now two rows:
+  "Runs on your hardware, and stays there" and "Open source, and your choice of model".
+  Merging the first three also resolved Otter's "not stated in docs" self-hosting cell, since
+  where its processing and storage run *is* documented. The detailed table keeps all five rows;
+  it is the place for detail, and nothing was deleted from it.
+- **The rows recovered went to axes that discriminate.** "Voice models you hold and can
+  rebuild" is new, and "Your data comes out whole" replaces the four missing portability
+  verdicts with one. The summary is eight rows rather than ten and covers more ground.
+
+**Nojoin still takes a yes on every summary row, and that is now a decision rather than an
+oversight.** The earlier framing treated a sweep as a defect in itself. It is not: the defect
+is a sweep produced by hiding the axes where you lose. Every concession on the page is a tie
+rather than a loss — Nojoin is a yes on no-bot capture, on speaker memory and on portability,
+alongside a competitor who is also a yes — so conceding costs nothing and buys the wins their
+meaning. What the page must never do is manufacture a Nojoin cross to look even-handed, or
+delete a competitor's tick to look ahead. On this page the concessions carry the argument
+without either.
+
+**The speaker question is two rows, and the first one exists to make the second legible.**
+"Speakers remembered between meetings" concedes Jamie's and Otter's outright yes. "Voice
+models you hold and can rebuild" then asks what happens to the voice model afterwards, which
+is where `USAGE.md` has an answer nobody else documents. Run alone, the second row would read
+to a buyer as *Nojoin remembers speakers and the others do not* — a claim Otter's own
+marketing contradicts, and one that would discredit the rows around it. The concession is what
+makes the sharper row a specific claim rather than a dubious one. Do not collapse the pair.
+
 **The page no longer shows its sources.** It used to carry a numbered footnote under every
 competitor cell with the exact URL and the date it was read, plus a weekly CI job that
 re-checked each link. All of it is gone: the footnotes, the `source` field on `Cell`, and the
@@ -364,7 +403,20 @@ What has *not* changed is the standard the claims themselves are held to:
   open, voiceprints you can recalibrate from better samples, automatic rebuilds after an
   upgrade, and deletion that actually removes the voiceprint — none of which any competitor
   documents, all of it in `USAGE.md`. Argue from that rather than from a competitor being
-  worse than they are.
+  worse than they are. That argument is now on the page as its own summary row, sitting under
+  the row that concedes the matching. The competitor cells there read "Not stated in docs" —
+  the sanctioned wording — because each vendor's own documentation was searched for voiceprint
+  management and none was found. They do not assert that no such feature exists.
+- **Some vendor documentation cannot be fetched, and that constrains what can be claimed.**
+  `help.otter.ai` returns 403 to an automated fetch and `docs.meetjamie.ai` returned 404 on
+  the speaker page during this pass. Search indexes still surface the text, but a search
+  engine's extract is not the same as having read the page. Where that gap applies, write
+  "Not stated in current docs" and claim nothing sharper. An axis that would need a competitor
+  cross to work, and whose source cannot be opened, does not go on the page at all: that is
+  why an edit-provenance row was drafted and dropped. Nojoin's own edit labelling is a real
+  differentiator, but neither Otter's nor Jamie's editing docs could be read to check it, and
+  three "not stated" cells on a row about editing would imply those products cannot be edited,
+  which is a false impression even when every individual cell is defensible.
 
 ## The managed service
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -198,7 +198,10 @@ Within a processed recording you can:
 - Follow synced transcript highlighting.
 - Click transcript text to seek playback.
 - Edit transcript text and speaker assignments.
-- Export transcript-only, notes-only, or combined text output.
+- Export transcript-only, notes-only, or combined output as TXT, PDF, or DOCX.
+- Export the recording's audio as MP3.
+
+Exported transcripts carry a `[MM:SS]` timestamp and the resolved speaker name on every line, in all three document formats, so an export stays navigable against the audio without a separate subtitle file. Notes-only exports carry the meeting notes as written. Every export is headed with the meeting name, date, duration, and speaker list.
 
 Historical recordings carried forward from before the unified pipeline cutover may open in a read-only compatibility state. Playback, transcript viewing, and export remain available, but transcript or speaker edits require explicit reprocess first.
 
@@ -316,7 +319,7 @@ Calendar events can provide meeting context, dashboard agenda views, linked reco
 
 ## AI Assistant Connections (MCP)
 
-Nojoin includes a read-only MCP connector so AI assistants such as Claude can search your recordings and read transcripts, meeting notes, and tags on your behalf. Add `https://your-nojoin-domain/mcp` as a custom connector in the assistant and approve access on Nojoin's authorisation page. Active connections are listed under **Settings → Integrations → Connected apps**, where each one can be revoked. See [MCP.md](MCP.md) for setup, supported clients, and troubleshooting.
+Nojoin includes a built-in MCP connector so AI assistants such as Claude can work with your meeting library on your behalf. It has two access tiers: read tools cover the whole library including semantic search across every meeting and document, and write tools cover recoverable changes such as organising recordings, managing tasks, correcting transcripts, regenerating notes, and maintaining People records. Permanent deletion is not available through the connector at all. Add `https://your-nojoin-domain/mcp` as a custom connector in the assistant and approve access on Nojoin's authorisation page. Active connections are listed under **Settings → Integrations → Connected apps**, where each one can be revoked. See [MCP.md](MCP.md) for setup, supported clients, and troubleshooting.
 
 ## Settings
 

--- a/site/src/data/comparison.ts
+++ b/site/src/data/comparison.ts
@@ -1,13 +1,11 @@
 // The comparison data. Rules, from the plan:
 // - Every competitor claim is verified against that vendor's own current
-//   documentation, carries the exact URL read and the date it was checked,
-//   and renders as a footnote. A claim that cannot be sourced does not go on
-//   the page: it appears as the explicit "Not stated in current docs" cell.
-// - No competitor pricing, ever.
-// - Nojoin's claims cite the repository documentation the same way.
-//
-// All vendor pages below were fetched and read on the checked date, and each
-// URL was re-verified to return 200 before this file was committed.
+//   documentation before it goes up. The page no longer displays the URL or the
+//   date read, but the standard behind the cell has not changed. A claim that
+//   cannot be checked does not go on the page: it appears as the explicit
+//   "Not stated in current docs" cell.
+// - No competitor pricing, ever. Limits and caps are fine.
+// - Nojoin's claims trace to README.md or a file in docs/.
 //
 // THREE COMPETITORS, NOT FOUR. Fireflies was dropped when Jamie was added,
 // rather than running five columns of prose. The table is already the widest
@@ -43,6 +41,9 @@ const UNSOURCED: Cell = { text: "Not stated in current docs" };
 
 export const rows: Row[] = [
   {
+    // This row carries a truth the summary table compresses. "No bot joins the
+    // call" is one summary row, so Otter's bot-free desktop, mobile and web
+    // recording has nowhere else to appear. It appears here, in full.
     key: "capture",
     label: "How audio is captured",
     cells: {
@@ -50,10 +51,10 @@ export const rows: Row[] = [
         text: "Your browser captures the call. Nothing joins the meeting or appears in the participant list."
       },
       jamie: {
-        text: "A native macOS or Windows app captures the audio on your machine, online or in the room. No bot joins the call."
+        text: "A native macOS or Windows app captures audio on your machine, online or in the room. No bot joins the call."
       },
       otter: {
-        text: "An AI meeting agent joins Zoom, Teams and Meet calls; bot-free recording is also available from the desktop, mobile or web app."
+        text: "An AI agent joins Zoom, Teams and Meet calls. Bot-free recording is also available from the desktop, mobile or web app."
       },
       granola: {
         text: "No bot. Desktop apps for macOS and Windows, plus an iPhone app, capture system audio and microphone."
@@ -61,20 +62,29 @@ export const rows: Row[] = [
     },
   },
   {
+    // Two summary rows come from this one detailed row, because there are two
+    // questions in it and they have different answers. Whether speakers are
+    // remembered: Jamie and Otter both do it, and both say so here. Whether you
+    // hold the voice models: that is Nojoin's, and it is argued from USAGE.md
+    // (a library you can open, recalibration from better samples, automatic
+    // rebuilds after an upgrade, deletion that removes the voiceprint) rather
+    // than from any competitor being worse than they are. No cell below claims
+    // a competitor cannot match speakers between meetings, because all three
+    // vendors document that they can.
     key: "attribution",
     label: "Speaker attribution",
     cells: {
       nojoin: {
-        text: "Built-in diarisation plus a global speaker library: voiceprints keep people named across future meetings."
+        text: "A speaker library you can open. Voiceprints recalibrate from better samples and rebuild after an upgrade."
       },
       jamie: {
-        text: "You name each speaker once from an audio clip after the meeting, and Jamie identifies them automatically in future ones. No voiceprint library is documented."
+        text: "Name each speaker once from an audio clip; Jamie identifies them in later meetings. No voiceprint library documented."
       },
       otter: {
-        text: "Speaker identification recognises tagged speakers and auto-tags their names in future transcripts."
+        text: "Speaker identification recognises tagged speakers and auto-tags them in later transcripts."
       },
       granola: {
-        text: "Speaker tags use platform display names on Meet and Zoom; no cross-meeting speaker memory documented."
+        text: "Speaker tags come from platform display names on Meet and Zoom. No cross-meeting memory documented."
       },
     },
   },
@@ -84,7 +94,7 @@ export const rows: Row[] = [
     cells: {
       nojoin: { text: "On your own server." },
       jamie: {
-        text: "Entirely within the EU: audio goes to Frankfurt and is transcribed on Modal's serverless GPUs, with notes generated through the Anthropic or OpenAI APIs."
+        text: "Entirely in the EU: audio to Frankfurt, transcribed on Modal's GPUs, notes through the Anthropic or OpenAI APIs."
       },
       otter: {
         text: "In Otter's cloud, principally on AWS in the United States."
@@ -100,7 +110,7 @@ export const rows: Row[] = [
     cells: {
       nojoin: { text: "On your own server." },
       jamie: {
-        text: "Transcripts sit on a server in Frankfurt; the audio is deleted permanently once the transcript is ready."
+        text: "Transcripts sit on a server in Frankfurt; audio is deleted permanently once the transcript is ready."
       },
       otter: {
         text: "In Otter's cloud on AWS S3, with server-side encryption."
@@ -130,7 +140,7 @@ export const rows: Row[] = [
     cells: {
       nojoin: { text: "Open source under AGPLv3." },
       jamie: {
-        text: "Closed source, proprietary licence: a non-exclusive, non-transferable right to use, lasting only as long as the contract."
+        text: "Closed source: a non-transferable right to use, lasting as long as the contract."
       },
       otter: {
         text: "Closed source, proprietary licence."
@@ -148,7 +158,7 @@ export const rows: Row[] = [
         text: "Bring your own API keys, or run fully local inference with Ollama."
       },
       jamie: {
-        text: "Vendor-chosen: notes come from the Anthropic or OpenAI APIs, and no bring-your-own-key or local option is documented."
+        text: "Vendor-chosen: notes come from the Anthropic or OpenAI APIs. No bring-your-own-key or local option documented."
       },
       otter: {
         text: "Otter's own AI plus vendor-chosen third-party providers; no bring-your-own-key or local option documented."
@@ -171,7 +181,7 @@ export const rows: Row[] = [
         text: "Meeting Edge: live questions worth asking, missed points, and concept help."
       },
       jamie: {
-        text: "The in-meeting widget is a private scratchpad for your own notes. Notes and transcript are generated after you stop recording."
+        text: "The in-meeting widget is a scratchpad for your own notes. Notes and transcript come after you stop recording."
       },
       otter: {
         text: "The meeting agent gives real-time transcription, takeaways and action items, and answers questions live."
@@ -187,7 +197,7 @@ export const rows: Row[] = [
     cells: {
       nojoin: { text: "Google and Outlook sync, with meeting context in the dashboard." },
       jamie: {
-        text: "Google Calendar or Outlook, used for reminders, automatic meeting titles and better speaker identification."
+        text: "Google Calendar or Outlook, for reminders, meeting titles and better speaker identification."
       },
       otter: {
         text: "Google Calendar, Microsoft Outlook and iOS Calendar."
@@ -203,7 +213,7 @@ export const rows: Row[] = [
     cells: {
       nojoin: { text: "One query across recordings, notes and documents." },
       jamie: {
-        text: "Semantic search across your meeting content, reachable from the app, the API and the MCP server."
+        text: "Semantic search across your meeting content, from the app, the API and the MCP server."
       },
       otter: {
         text: "Search and AI chat across meetings and connected apps, by keyword, speaker and date."
@@ -214,13 +224,14 @@ export const rows: Row[] = [
     },
   },
   {
-    // All four ship an MCP server, so "we have one" is not the claim. The line
-    // that survives sourcing is what an assistant can actually do once it is
-    // connected: three of them read the meeting and act elsewhere or on its
-    // filing, and Nojoin's acts on the meeting itself. Every cell states what
-    // that vendor documents and stops there. In particular no cell asserts
-    // that a competitor *cannot* write back -- that is an unsourced negative,
-    // and the gap is visible from the positives alone.
+    // All four ship an MCP server, so "we have one" is not the claim, and no
+    // row on this page should imply otherwise. The line that survives sourcing
+    // is what an assistant can actually do once it is connected: three of them
+    // read the meeting and act elsewhere or on its filing, and Nojoin's acts on
+    // the meeting itself. Every cell states what that vendor documents and
+    // stops there. In particular no cell asserts that a competitor *cannot*
+    // write back -- that is an unsourced negative, and the gap is visible from
+    // the positives alone.
     //
     // Jamie is the closest of the three and the reason this row still earns
     // its place: it writes, but only to tags.
@@ -228,16 +239,16 @@ export const rows: Row[] = [
     label: "What an assistant can do with your meetings",
     cells: {
       nojoin: {
-        text: "Thirty tools on your own deployment, authorised per user and on by default. An assistant corrects a misheard line, names the speaker, re-runs the notes, files the tasks, and syncs your People library with a CRM it's separately connected to — with no CRM integration in Nojoin at all."
+        text: "Thirty tools on your deployment: correct a line, name a speaker, re-run the notes, file the tasks. Every change is labelled and reversible."
       },
       jamie: {
-        text: "Thirteen tools for Claude, ChatGPT, Cursor, Windsurf and Copilot: nine read meetings, transcripts, tasks and people, and four change tags — create, rename, delete and apply them."
+        text: "Thirteen tools for Claude, ChatGPT, Cursor and Copilot. Nine read meetings, transcripts, tasks and people; four create and apply tags."
       },
       otter: {
-        text: "Reads Otter's transcripts to search across time, analyse themes and generate content. Writes outward into Google Docs, Slides, Jira, Salesforce and Slack. Part of Otter for Enterprise."
+        text: "Reads transcripts to search, analyse themes and generate content. Writes outward into Docs, Jira, Salesforce and Slack. Otter for Enterprise."
       },
       granola: {
-        text: "Reads notes and transcripts on paid plans: list meetings, read a meeting, search the history. On Enterprise it's early-access beta and stays off until an admin enables it."
+        text: "Reads notes and transcripts on paid plans: list, read and search meetings. On Enterprise it's beta, off until an admin enables it."
       },
     },
   },
@@ -251,28 +262,33 @@ export const rows: Row[] = [
     label: "Limits on how much you process",
     cells: {
       nojoin: {
-        text: "None in the software. No monthly allowance, no per-meeting ceiling, no history that expires. How much you get through is a question about your hardware."
+        text: "None. No allowance, no per-meeting ceiling, no history that expires. What you get through is a hardware question."
       },
       jamie: {
-        text: "One credit a meeting whatever its length: 10 a month and 30-minute meetings on the free plan, 20 and two hours on the next. Above that the count goes but a three-hour ceiling stays. Run out and existing notes lock until you upgrade."
+        text: "One credit a meeting. 10 a month and 30-minute meetings free; 20 and two hours next. Higher plans drop the count, keep a three-hour cap."
       },
       otter: {
-        text: "300 minutes a month and 30 minutes per conversation on the entry plan; 1,200 and 90 on the next. The upper plans lift the monthly cap and hold a four-hour ceiling per meeting."
+        text: "300 minutes a month, 30 per conversation, on the entry plan; 1,200 and 90 next. Upper plans lift the monthly cap but keep a four-hour ceiling."
       },
       granola: {
-        text: "Meeting history is limited on the entry plan, by an amount the pricing page doesn't state. Unlimited notes and history above it."
+        text: "Meeting history is limited on the entry plan, by an amount the pricing page doesn't state. Unlimited above it."
       },
     },
   },
   {
+    // Otter takes an outright yes in the summary off the back of this row: it
+    // exports more file formats than Nojoin does, SRT among them. That stands.
+    // Nojoin's answer to SRT is that every transcript export is already
+    // timestamped line by line (USAGE.md, "Transcript And Playback"), so the
+    // cell states what the export contains rather than disputing the format.
     key: "export",
     label: "Export and portability",
     cells: {
       nojoin: {
-        text: "Transcript, notes or combined output as DOCX, PDF or plain text, plus full-instance backup archives."
+        text: "Transcript, notes or both as TXT, PDF or DOCX, timestamped per line, plus MP3 audio and full-instance backups."
       },
       jamie: {
-        text: "Summary, transcript and tasks sync into Notion, Google Docs, OneNote, HubSpot, Salesforce, Dynamics 365, Attio and Asana, with an API and webhooks behind them. No file download is documented."
+        text: "Summary, transcript and tasks sync into Notion, Google Docs, HubSpot, Salesforce, Asana and more, with an API and webhooks. No file download documented."
       },
       otter: {
         text: "TXT, DOCX, PDF and SRT, plus audio export."
@@ -284,19 +300,27 @@ export const rows: Row[] = [
   },
 ];
 
-// The at-a-glance summary. Every verdict here is the short form of a row in
-// `rows` above, so the sourcing lives in one place: the detailed table carries
-// the URL and checked date for each claim, and this table says so rather than
-// repeating footnotes that could drift out of step with it.
+// The at-a-glance summary. Every verdict here is the short form of one or more
+// rows in `rows` above, so the claim and its sourcing live in one place.
 //
-// The rows were chosen because their answers are structural -- where the
-// software runs, who holds the recordings, what the licence permits -- rather
-// than roadmap-sensitive. Nojoin does not sweep the table, deliberately:
-// Granola and Jamie also record without a bot, Otter and Jamie also remember
-// speakers between meetings, and saying otherwise would cost the credibility
-// of the rows where the difference is real. Live in-meeting guidance is absent
-// for the same reason: Otter and Granola both document some form of it, so it
-// is not a distinction, whatever Meeting Edge is worth on its own merits.
+// WHY THIS TABLE IS EIGHT ROWS AND NOT TEN. It used to run five separate rows
+// for one argument -- self-hosting, processing, storage, licence, model choice
+// -- which all read Nojoin yes and three crosses. That inflated the win count
+// without adding an idea, and the site's own rule is to say each idea once.
+// They are now two rows. The rows recovered went to axes that discriminate:
+// who holds the voice models, and whether your data comes out whole.
+//
+// Nojoin does not sweep this table on the competitors' side of it, and that is
+// deliberate. Granola and Jamie also record without a bot. Otter and Jamie also
+// remember speakers between meetings, which is why the speaker question is two
+// rows: the first concedes it plainly, and the second asks the question only
+// the second one answers differently. Otter exports more file formats than
+// Nojoin does. Every one of those is a tie or a competitor win, and removing
+// them would cost the credibility of the rows where the difference is real.
+//
+// Live in-meeting guidance stays out for the same reason it always did: Otter
+// and Granola both document some form of it, so it is not a line between Nojoin
+// and the field, whatever Meeting Edge is worth on its own merits.
 
 export type Verdict = "yes" | "partial" | "no";
 
@@ -317,68 +341,50 @@ const no = (note: string): SummaryCell => ({ verdict: "no", note });
 
 export const summaryRows: SummaryRow[] = [
   {
-    key: "selfhost",
-    label: "Runs on your own hardware",
+    // Collapsed from three rows (self-hosting, processing, storage) that gave
+    // the same answer three times. Merging them also resolves Otter's
+    // "not stated in docs" self-hosting cell: where its processing and storage
+    // run is documented, so the merged row can say so.
+    key: "ownership",
+    label: "Runs on your hardware, and stays there",
     cells: {
       nojoin: yes("One compose file"),
-      jamie: no("Vendor cloud, EU"),
-      otter: no("Not stated in docs"),
-      granola: no("Vendor cloud"),
-    },
-  },
-  {
-    key: "processing",
-    label: "Processing stays on your infrastructure",
-    cells: {
-      nojoin: yes("Your server"),
       jamie: no("Jamie's EU cloud"),
-      otter: no("Otter's cloud"),
-      granola: no("Granola's cloud"),
+      otter: no("Otter's US cloud"),
+      granola: no("Granola's US cloud"),
     },
   },
   {
-    key: "storage",
-    label: "Recordings and transcripts stay yours",
+    // Collapsed from two rows. The licence and the model are one question to a
+    // buyer: how much of this stack is yours to change.
+    key: "open",
+    label: "Open source, and your choice of model",
     cells: {
-      nojoin: yes("Your server"),
-      jamie: no("Frankfurt-hosted"),
-      otter: no("Otter's cloud"),
-      granola: no("Vendor-hosted"),
+      nojoin: yes("AGPLv3, your keys or Ollama"),
+      jamie: no("Proprietary, vendor-chosen"),
+      otter: no("Proprietary, vendor-chosen"),
+      granola: no("Proprietary, vendor-chosen"),
     },
   },
   {
-    key: "source",
-    label: "Source available and auditable",
-    cells: {
-      nojoin: yes("AGPLv3"),
-      jamie: no("Proprietary"),
-      otter: no("Proprietary"),
-      granola: no("Proprietary"),
-    },
-  },
-  {
-    key: "models",
-    label: "Your choice of model, including fully local",
-    cells: {
-      nojoin: yes("Your keys, or Ollama"),
-      jamie: no("Vendor-chosen"),
-      otter: no("Vendor-chosen"),
-      granola: no("Vendor-chosen"),
-    },
-  },
-  {
+    // Merged with the old "capture without a desktop app" row. Nojoin's note
+    // carries both halves. Jamie and Granola keep their outright yes: neither
+    // sends a bot either, and pretending otherwise would be false.
     key: "nobot",
     label: "No bot joins the call",
     cells: {
-      nojoin: yes("Never a participant"),
+      nojoin: yes("Any browser, never a participant"),
       jamie: yes("Captures locally"),
       otter: partial("Bot by default"),
       granola: yes("Captures locally"),
     },
   },
   {
-    // Jamie earns a yes: the naming is manual the first time, but it carries
-    // forward on its own after that, which is what the row asks.
+    // This row concedes the point, deliberately. Jamie and Otter both
+    // genuinely match speakers across meetings -- Otter's help centre describes
+    // acoustic enrolment, not a name lookup. Stated plainly here, the row below
+    // reads as the specific claim it is rather than as a claim about speaker
+    // memory that a reader would rightly disbelieve.
     key: "speakers",
     label: "Speakers remembered between meetings",
     cells: {
@@ -389,17 +395,48 @@ export const summaryRows: SummaryRow[] = [
     },
   },
   {
+    // The row above concedes that everyone remembers speakers. This one asks
+    // what happens to the voice model afterwards, and it is argued entirely
+    // from USAGE.md: a library you can open, recalibration from a better
+    // sample, background rebuilds from the original audio after an upgrade,
+    // and deletion that removes the voiceprint. The competitor cells say what
+    // was looked for and not found. They do not assert that no such feature
+    // exists, because that is an unsourced negative.
+    key: "voiceprints",
+    label: "Voice models you hold and can rebuild",
+    cells: {
+      nojoin: yes("Recalibrate, rebuild, delete"),
+      jamie: no("Not stated in docs"),
+      otter: no("Not stated in docs"),
+      granola: no("Not stated in docs"),
+    },
+  },
+  {
     // Jamie earns a partial rather than a no: four of its thirteen tools
     // genuinely change something, they just change the filing rather than the
     // record. Otter writes too, but outward into other products, so on this
     // axis -- what happens to the meeting itself -- it is a no.
     key: "agents",
-    label: "An assistant can change the record, not just read it",
+    label: "An assistant can change the record",
     cells: {
-      nojoin: yes("Thirty tools, on your server"),
+      nojoin: yes("Thirty tools, your server"),
       jamie: partial("Creates and applies tags"),
       otter: no("Reads Otter, writes elsewhere"),
       granola: no("Reads notes and transcripts"),
+    },
+  },
+  {
+    // Otter takes an outright yes here and keeps it. It exports more file
+    // formats than Nojoin does. Jamie's partial is not a slight: it syncs into
+    // eight products and documents no file download at all, which is a
+    // different shape of portability rather than a lesser amount of it.
+    key: "portability",
+    label: "Your data comes out whole",
+    cells: {
+      nojoin: yes("Documents, audio, backups"),
+      jamie: partial("Syncs to apps, no download"),
+      otter: yes("Documents and audio"),
+      granola: partial("CSV of notes"),
     },
   },
   {
@@ -413,16 +450,6 @@ export const summaryRows: SummaryRow[] = [
       jamie: partial("Credits, and a length cap"),
       otter: partial("Capped below Business"),
       granola: partial("History capped on free"),
-    },
-  },
-  {
-    key: "browser",
-    label: "Capture without a desktop app",
-    cells: {
-      nojoin: yes("Any browser"),
-      jamie: no("Desktop or mobile app"),
-      otter: yes("Web app"),
-      granola: no("Desktop app"),
     },
   },
 ];


### PR DESCRIPTION
# Pull Request

## Description

An editorial pass on `/compare/`. The at-a-glance table ran ten rows and Nojoin took a yes on all ten, which `docs/SITE.md:329` flags as worth a second look.

**The sweep was caused by row selection, not by generous verdicts.** Four detailed rows (live guidance, calendar, search, export) never had a summary verdict, and those were exactly the axes where Nojoin ties or trails. Every axis Nojoin led got a summary row; every axis it did not was left in the prose table. A summary table that is a filtered subset of the detailed one will always sweep.

**Five of the ten rows were one argument counted five times.** Self-hosting, processing, storage, licence and model choice all read Nojoin yes against three crosses. They are now two rows. Merging the first three also resolves Otter's "not stated in docs" self-hosting cell, since where its processing and storage run *is* documented.

**The rows recovered went to axes that discriminate:**

- **"Voice models you hold and can rebuild"** (new) — argued entirely from `USAGE.md`: a library you can open (87–96), recalibration from a better sample (217), background rebuilds from the original audio after an upgrade (235–241), and deletion that removes the voiceprint (97). It sits directly under the row conceding that Jamie and Otter genuinely match speakers across meetings. Run alone it would read as *Nojoin remembers speakers and the others do not*, which Otter's own marketing contradicts and which would discredit the rows around it.
- **"Your data comes out whole"** (new) — replaces the four missing portability verdicts. Otter takes an outright yes for exporting more file formats than Nojoin does.

Summary table: 10 rows → 8. Nojoin still takes a yes on every row, now as a decision rather than an oversight — every concession on the page is a tie rather than a loss, so conceding costs nothing. Competitor crosses fell from 20 to 12; Jamie 6→3, Otter 6→4, Granola 8→5.

**No competitor verdict is downgraded anywhere in this PR.** Every competitor cell that changed got shorter, not weaker.

**Length.** Prose cells mean 100.2 → 86.9 characters, longest 285 → 152. Nojoin's assistant cell was the longest on the page; it is now 139, behind three competitor cells. Jamie's column was the real reading burden at a 137.8 mean and is now 110.1.

**An axis I drafted and dropped.** An edit-provenance row ("corrections are attributed and stick") is a real Nojoin differentiator, but `help.otter.ai` returns 403 to automated fetches and `docs.meetjamie.ai` 404'd on the speaker page, so neither vendor's editing behaviour could be read from their own docs. Three "not stated in current docs" cells on a row about editing would imply those products cannot be edited at all — a false impression even with every individual cell defensible. The provenance point moved into Nojoin's assistant cell instead ("every change is labelled and reversible"). `SITE.md` records the rule.

### Docs

- `USAGE.md` gains the export detail the comparison cell relies on, verified against `backend/api/v1/endpoints/transcripts/routes_export.py` and `helpers.py` rather than the UI: TXT, PDF and DOCX for transcript, notes or both; MP3 audio; and a `[MM:SS]` timestamp plus resolved speaker name on every transcript line in all three formats.
- `USAGE.md:322` described the MCP connector as read-only, contradicting `MCP.md:79` ("Thirty tools. Twelve read and eighteen write") and the site's strongest claim. It now describes both tiers.
- `SITE.md` records the revised sweep test, the collapse, the two-row speaker pair, and the new sourcing rule for unfetchable vendor docs.

No new dependencies.

Fixes # (no issue)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [ ] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (1376 passed; lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests all OK)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py` (19 files)
- [ ] Alembic validation: `python3 scripts/validate_alembic.py`

Also run: `cd site && npm ci && npm run build` (4 pages), `node frontend/scripts/check-contrast.mjs` (248 pairings across 4 themes), `git diff --check`.

`scripts/check.py` covers backend tests, Alembic validation and the docs validator, so the separate boxes for those are left unticked rather than double-counted. No `frontend/` source changed, so its lint, tests and build were not run.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

No capture-related code touched; this is site copy plus documentation.

- `cd site && npm run build` renders all 4 pages. `/compare/index.html` has 23 `<tr>`: 2 header rows, 8 summary, 13 detailed.
- Every claim re-checked against source. Nojoin's from `USAGE.md`, `MCP.md` and the export route code. Competitors' from vendor documentation, with the fetch limitation noted above.

**Not verified, and stated rather than ticked:** the 360px/1920px horizontal-overflow check in both themes was not run in a browser — this host has no chromium, playwright or puppeteer. The change is text-only within the existing markup: `compare.astro` and `site.css` are untouched, `.compare-table` keeps its fixed `min-width: 56rem`, `.table-wrap` keeps `overflow-x: auto`, and the `.glance-cell { position: relative }` containment that prevents the visually-hidden verdict escaping is unchanged. The longest glance note grew from 29 to 32 characters, which cannot affect a table whose width is set by a fixed floor. Worth a browser pass before merge regardless.
