### PR TITLE
fix(startup): remove the companion app retirement notice

### DIFF
--- a/backend/alembic/versions/f7a2c6d3b418_drop_companion_retirement_notice.py
+++ b/backend/alembic/versions/f7a2c6d3b418_drop_companion_retirement_notice.py
@@ -1,0 +1,49 @@
+"""drop the companion retirement notice and its delivery flag
+
+The startup cutover used to hand every admin a one-time task announcing that the
+companion app had been replaced by browser capture. The announcement has served
+its purpose: the app was retired in the 2026-05-26 release, and the notice was
+only ever noise on installs created since. Nothing generates it any more, so the
+outstanding tasks and the column that tracked their delivery both go.
+
+Revision ID: f7a2c6d3b418
+Revises: c4a81f5d20b6
+Create Date: 2026-08-10 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f7a2c6d3b418"
+down_revision = "c4a81f5d20b6"
+branch_labels = None
+depends_on = None
+
+COMPANION_RETIREMENT_NOTICE_TITLE = (
+    "Companion app retired. Recording is now browser-only. See docs/CAPTURE.md."
+)
+
+
+def upgrade():
+    op.execute(
+        sa.text("DELETE FROM user_tasks WHERE title = :title").bindparams(
+            title=COMPANION_RETIREMENT_NOTICE_TITLE
+        )
+    )
+    op.drop_column("users", "has_seen_companion_retirement_notice")
+
+
+def downgrade():
+    # The notice tasks are not recreated: the column comes back as a delivery
+    # record for a notice that no longer exists in any released code path.
+    op.add_column(
+        "users",
+        sa.Column(
+            "has_seen_companion_retirement_notice",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -31,10 +31,6 @@ class User(BaseDBModel, table=True):
     token_version: int = Field(default=0, nullable=False)
     settings: Dict[str, Any] = Field(default={}, sa_column=Column(JSONB))
     has_seen_demo_recording: bool = Field(default=False)
-    # Durable record that the one-time companion-retirement notice was delivered.
-    # The notice task itself cannot carry this: deleting it is how a user dismisses
-    # it, which would otherwise erase the evidence and re-deliver on next boot.
-    has_seen_companion_retirement_notice: bool = Field(default=False)
 
     invitation_id: Optional[int] = Field(default=None, foreign_key="invitations.id")
 

--- a/backend/startup_canonical_cutover.py
+++ b/backend/startup_canonical_cutover.py
@@ -5,12 +5,10 @@ import os
 from contextlib import contextmanager
 from importlib import import_module
 
-from sqlalchemy import or_, text
-from sqlmodel import Session, select
+from sqlalchemy import text
+from sqlmodel import Session
 
 from backend.core.db import sync_engine
-from backend.models.task import UserTask
-from backend.models.user import User
 from backend.startup_migrations import wait_for_database_connection
 from backend.utils.canonical_pipeline import (
     list_pending_startup_cutover_recording_ids,
@@ -25,9 +23,6 @@ STARTUP_CANONICAL_CUTOVER_BATCH_SIZE_ENV_VAR = (
 )
 STARTUP_CANONICAL_CUTOVER_ADVISORY_LOCK_ID = 640_227_114_901_337_251
 TRUE_VALUES = {"1", "true", "yes", "on"}
-COMPANION_RETIREMENT_NOTICE_TITLE = (
-    "Companion app retired. Recording is now browser-only. See docs/CAPTURE.md."
-)
 MODEL_MODULES = (
     "backend.models.recording",
     "backend.models.speaker",
@@ -62,35 +57,6 @@ def _batch_size() -> int:
     except ValueError:
         return 100
     return max(parsed, 1)
-
-
-def _ensure_companion_retirement_notice(session: Session) -> int:
-    # Delivery is tracked on the user, not by looking for the notice task. The task
-    # is the message, not the receipt: dismissing it deletes the row outright, so
-    # keying off its presence re-delivered the notice on every subsequent boot.
-    admin_users = session.exec(
-        select(User).where(
-            or_(
-                User.role.in_(["owner", "admin"]),
-                User.is_superuser == True,
-            ),
-            User.has_seen_companion_retirement_notice == False,
-        )
-    ).all()
-
-    created = 0
-    for admin_user in admin_users:
-        session.add(
-            UserTask(
-                title=COMPANION_RETIREMENT_NOTICE_TITLE,
-                user_id=admin_user.id,
-            )
-        )
-        admin_user.has_seen_companion_retirement_notice = True
-        session.add(admin_user)
-        created += 1
-
-    return created
 
 
 @contextmanager
@@ -132,7 +98,6 @@ def run_startup_canonical_cutover() -> dict[str, int]:
         "already_reprocess_required": 0,
         "skipped_unified": 0,
         "missing": 0,
-        "retirement_notices": 0,
     }
 
     # The advisory lock is held on a dedicated autocommit connection so no
@@ -143,13 +108,6 @@ def run_startup_canonical_cutover() -> dict[str, int]:
         isolation_level="AUTOCOMMIT"
     ) as lock_connection:
         with _advisory_lock(lock_connection):
-            with Session(sync_engine) as session:
-                summary["retirement_notices"] = _ensure_companion_retirement_notice(
-                    session
-                )
-                if summary["retirement_notices"]:
-                    session.commit()
-
             processed_ids: set[int] = set()
             while True:
                 with Session(sync_engine) as session:

--- a/backend/tests/sqlite_schemas.py
+++ b/backend/tests/sqlite_schemas.py
@@ -20,7 +20,6 @@ CREATE TABLE users (
     token_version INTEGER NOT NULL,
     settings JSON,
     has_seen_demo_recording BOOLEAN NOT NULL,
-    has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
     invitation_id INTEGER
 )
 """

--- a/backend/tests/test_analytics_overlap_and_baselines.py
+++ b/backend/tests/test_analytics_overlap_and_baselines.py
@@ -54,9 +54,8 @@ def _seed_user(connection, user_id: int = 1, username: str = "alice") -> None:
         text(
             "INSERT INTO users (id, created_at, updated_at, username, "
             "hashed_password, is_active, is_superuser, force_password_change, "
-            "role, token_version, has_seen_demo_recording, "
-            "has_seen_companion_retirement_notice) VALUES "
-            "(:id, :ts, :ts, :name, 'x', 1, 0, 0, 'user', 0, 0, 0)"
+            "role, token_version, has_seen_demo_recording) VALUES "
+            "(:id, :ts, :ts, :name, 'x', 1, 0, 0, 'user', 0, 0)"
         ),
         {"id": user_id, "name": username, "ts": _now()},
     )

--- a/backend/tests/test_chat_cli_relay_api.py
+++ b/backend/tests/test_chat_cli_relay_api.py
@@ -32,7 +32,6 @@ CREATE TABLE users (
     username VARCHAR NOT NULL, hashed_password VARCHAR NOT NULL, is_active BOOLEAN NOT NULL,
     is_superuser BOOLEAN NOT NULL, force_password_change BOOLEAN NOT NULL, role VARCHAR NOT NULL,
     token_version INTEGER NOT NULL, settings JSON, has_seen_demo_recording BOOLEAN NOT NULL,
-    has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
     invitation_id INTEGER
 );
 CREATE TABLE recordings (

--- a/backend/tests/test_chat_tag_context_ownership.py
+++ b/backend/tests/test_chat_tag_context_ownership.py
@@ -30,7 +30,6 @@ CREATE TABLE users (
     username VARCHAR NOT NULL, hashed_password VARCHAR NOT NULL, is_active BOOLEAN NOT NULL,
     is_superuser BOOLEAN NOT NULL, force_password_change BOOLEAN NOT NULL, role VARCHAR NOT NULL,
     token_version INTEGER NOT NULL, settings JSON, has_seen_demo_recording BOOLEAN NOT NULL,
-    has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
     invitation_id INTEGER
 );
 CREATE TABLE recordings (

--- a/backend/tests/test_delivery_analytics_task.py
+++ b/backend/tests/test_delivery_analytics_task.py
@@ -88,9 +88,8 @@ def _seed(connection, *, audio_path: str, utterance_count: int = 6) -> None:
         text(
             "INSERT INTO users (id, created_at, updated_at, username, "
             "hashed_password, is_active, is_superuser, force_password_change, "
-            "role, token_version, has_seen_demo_recording, "
-            "has_seen_companion_retirement_notice) VALUES "
-            "(1, :ts, :ts, 'alice', 'x', 1, 0, 0, 'user', 0, 0, 0)"
+            "role, token_version, has_seen_demo_recording) VALUES "
+            "(1, :ts, :ts, 'alice', 'x', 1, 0, 0, 'user', 0, 0)"
         ),
         {"ts": _now()},
     )

--- a/backend/tests/test_generate_notes_task.py
+++ b/backend/tests/test_generate_notes_task.py
@@ -38,7 +38,6 @@ CREATE TABLE users (
     token_version INTEGER NOT NULL,
     settings JSON,
     has_seen_demo_recording BOOLEAN NOT NULL,
-    has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
     invitation_id INTEGER
 );
 

--- a/backend/tests/test_infer_speakers_task.py
+++ b/backend/tests/test_infer_speakers_task.py
@@ -32,7 +32,6 @@ CREATE TABLE users (
     token_version INTEGER NOT NULL,
     settings JSON,
     has_seen_demo_recording BOOLEAN NOT NULL,
-    has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
     invitation_id INTEGER
 );
 

--- a/backend/tests/test_inference_work_remediation.py
+++ b/backend/tests/test_inference_work_remediation.py
@@ -33,7 +33,6 @@ SCHEMA_STATEMENTS = [
         token_version INTEGER,
         settings JSON,
         has_seen_demo_recording BOOLEAN,
-        has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
         invitation_id INTEGER
     )
     """,

--- a/backend/tests/test_jwt_revocation_service.py
+++ b/backend/tests/test_jwt_revocation_service.py
@@ -37,7 +37,6 @@ SCHEMA_STATEMENTS = [
         token_version INTEGER NOT NULL DEFAULT 0,
         settings JSON,
         has_seen_demo_recording BOOLEAN NOT NULL DEFAULT 0,
-        has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
         invitation_id INTEGER
     )
     """,

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -85,7 +85,6 @@ SCHEMA_STATEMENTS = [
         token_version INTEGER NOT NULL DEFAULT 0,
         settings JSON,
         has_seen_demo_recording BOOLEAN NOT NULL DEFAULT 0,
-        has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
         invitation_id INTEGER
     )
     """,

--- a/backend/tests/test_meeting_analysis_task.py
+++ b/backend/tests/test_meeting_analysis_task.py
@@ -139,9 +139,8 @@ def _seed(connection, *, analytics_payload: str | None = None) -> None:
         text(
             "INSERT INTO users (id, created_at, updated_at, username, "
             "hashed_password, is_active, is_superuser, force_password_change, "
-            "role, token_version, has_seen_demo_recording, "
-            "has_seen_companion_retirement_notice) VALUES "
-            "(1, :ts, :ts, 'alice', 'x', 1, 0, 0, 'user', 0, 0, 0)"
+            "role, token_version, has_seen_demo_recording) VALUES "
+            "(1, :ts, :ts, 'alice', 'x', 1, 0, 0, 'user', 0, 0)"
         ),
         {"ts": _now()},
     )

--- a/backend/tests/test_meeting_chat_task.py
+++ b/backend/tests/test_meeting_chat_task.py
@@ -29,7 +29,6 @@ CREATE TABLE users (
     token_version INTEGER NOT NULL,
     settings JSON,
     has_seen_demo_recording BOOLEAN NOT NULL,
-    has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
     invitation_id INTEGER
 );
 CREATE TABLE recordings (

--- a/backend/tests/test_oauth_mcp_connector.py
+++ b/backend/tests/test_oauth_mcp_connector.py
@@ -44,7 +44,6 @@ SCHEMA_STATEMENTS = [
         token_version INTEGER NOT NULL DEFAULT 0,
         settings JSON,
         has_seen_demo_recording BOOLEAN NOT NULL DEFAULT 0,
-        has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
         invitation_id INTEGER
     )
     """,

--- a/backend/tests/test_startup_canonical_cutover.py
+++ b/backend/tests/test_startup_canonical_cutover.py
@@ -4,11 +4,11 @@ The driver previously bound its sessions to the same connection that held
 the Postgres advisory lock. Acquiring the lock autobegan a connection-level
 transaction, every session then joined it via savepoints, and the whole
 sweep was rolled back when the connection closed on exit -- classifications
-and retirement notices never persisted, so each boot re-ran the entire
-sweep. These tests run the driver end to end against a file-backed SQLite
-database, patch the advisory lock helper so it executes a statement on the
-lock connection exactly like the Postgres implementation does, and assert
-durability from fresh connections after the driver returns.
+never persisted, so each boot re-ran the entire sweep. These tests run the
+driver end to end against a file-backed SQLite database, patch the advisory
+lock helper so it executes a statement on the lock connection exactly like
+the Postgres implementation does, and assert durability from fresh
+connections after the driver returns.
 """
 
 from __future__ import annotations
@@ -155,7 +155,6 @@ def test_cutover_results_survive_connection_close(tmp_path, monkeypatch) -> None
     summary = cutover.run_startup_canonical_cutover()
 
     assert summary["backfilled"] == 1
-    assert summary["retirement_notices"] == 1
 
     # Read back through fresh connections: the driver has fully returned, so
     # anything visible now genuinely committed.
@@ -163,18 +162,11 @@ def test_cutover_results_survive_connection_close(tmp_path, monkeypatch) -> None
         generation = connection.execute(
             text("SELECT pipeline_generation FROM recordings WHERE id = 1")
         ).scalar_one()
-        notices = connection.execute(
-            text(
-                "SELECT COUNT(*) FROM user_tasks "
-                "WHERE title LIKE 'Companion app retired%'"
-            )
-        ).scalar_one()
         utterances = connection.execute(
             text("SELECT COUNT(*) FROM transcript_utterances WHERE recording_id = 1")
         ).scalar_one()
 
     assert generation == "legacy_backfilled"
-    assert notices == 1
     assert utterances == 1
 
 
@@ -189,86 +181,20 @@ def test_cutover_second_run_is_a_noop(tmp_path, monkeypatch) -> None:
     assert first_summary["backfilled"] == 1
     assert second_summary["backfilled"] == 0
     assert second_summary["already_canonical"] == 0
-    assert second_summary["retirement_notices"] == 0
-
-    with engine.connect() as connection:
-        notices = connection.execute(
-            text(
-                "SELECT COUNT(*) FROM user_tasks "
-                "WHERE title LIKE 'Companion app retired%'"
-            )
-        ).scalar_one()
-
-    assert notices == 1
 
 
-def _count_notices(engine: Engine) -> int:
-    with engine.connect() as connection:
-        return connection.execute(
-            text(
-                "SELECT COUNT(*) FROM user_tasks "
-                "WHERE title LIKE 'Companion app retired%'"
-            )
-        ).scalar_one()
-
-
-def test_dismissed_retirement_notice_is_not_redelivered(tmp_path, monkeypatch) -> None:
-    # Dismissing a task hard-deletes the row, so the notice's own presence cannot
-    # be the record that it was delivered -- the boot after a dismissal used to
-    # recreate it, and it came back on every rebuild thereafter.
-    engine = _build_engine(tmp_path)
-    _seed_admin_and_legacy_recording(engine)
-    _patch_driver(monkeypatch, engine)
-
-    assert cutover.run_startup_canonical_cutover()["retirement_notices"] == 1
-    assert _count_notices(engine) == 1
-
-    with engine.begin() as connection:
-        connection.execute(
-            text("DELETE FROM user_tasks WHERE title LIKE 'Companion app retired%'")
-        )
-
-    summary = cutover.run_startup_canonical_cutover()
-
-    assert summary["retirement_notices"] == 0
-    assert _count_notices(engine) == 0
-
-
-def test_retirement_notice_delivery_is_recorded_on_the_user(
-    tmp_path, monkeypatch
-) -> None:
+def test_cutover_creates_no_tasks(tmp_path, monkeypatch) -> None:
+    # The sweep used to hand admins a companion-retirement notice at every boot
+    # until they had been marked as having seen it. That announcement is gone;
+    # booting must not put anything in anybody's task list.
     engine = _build_engine(tmp_path)
     _seed_admin_and_legacy_recording(engine)
     _patch_driver(monkeypatch, engine)
 
     cutover.run_startup_canonical_cutover()
+    cutover.run_startup_canonical_cutover()
 
     with engine.connect() as connection:
-        seen = connection.execute(
-            text("SELECT has_seen_companion_retirement_notice FROM users WHERE id = 1")
-        ).scalar_one()
+        tasks = connection.execute(text("SELECT COUNT(*) FROM user_tasks")).scalar_one()
 
-    assert seen
-
-
-def test_completed_retirement_notice_is_not_duplicated(tmp_path, monkeypatch) -> None:
-    # Completing rather than deleting leaves the row in place; the notice must not
-    # be delivered a second time alongside the completed one.
-    engine = _build_engine(tmp_path)
-    _seed_admin_and_legacy_recording(engine)
-    _patch_driver(monkeypatch, engine)
-
-    cutover.run_startup_canonical_cutover()
-    with engine.begin() as connection:
-        connection.execute(
-            text(
-                "UPDATE user_tasks SET completed_at = :now "
-                "WHERE title LIKE 'Companion app retired%'"
-            ),
-            {"now": "2026-05-20 00:00:00"},
-        )
-
-    summary = cutover.run_startup_canonical_cutover()
-
-    assert summary["retirement_notices"] == 0
-    assert _count_notices(engine) == 1
+    assert tasks == 0

--- a/backend/tests/test_task_ownership_security.py
+++ b/backend/tests/test_task_ownership_security.py
@@ -28,7 +28,6 @@ SCHEMA_STATEMENTS = [
         token_version INTEGER NOT NULL DEFAULT 0,
         settings JSON,
         has_seen_demo_recording BOOLEAN NOT NULL DEFAULT 0,
-        has_seen_companion_retirement_notice BOOLEAN NOT NULL DEFAULT 0,
         invitation_id INTEGER
     )
     """,


### PR DESCRIPTION
## Description

Booting the API used to create a task titled "Companion app retired. Recording is now browser-only. See docs/CAPTURE.md." for every owner, admin or superuser whose `has_seen_companion_retirement_notice` flag was false, then set the flag. #110 made the flag the delivery record so dismissing the task could not resurrect it, but it never asked whether the account had any business being told.

New accounts get the flag's default of false, so the notice was delivered to installs that postdate the companion app entirely: the dev database's owner registered on 2026-08-07 and was handed the notice at the next boot, three months after the app was removed in the 2026-05-26 release. Resetting that database and rebuilding produced it again, which reads as a task recreating itself.

The announcement has served its purpose, so this removes it rather than narrowing who receives it:

- `backend/startup_canonical_cutover.py` loses `_ensure_companion_retirement_notice`, the title constant, the `retirement_notices` summary key and the model imports it needed. Boot now runs the canonical sweep and nothing else.
- Migration `f7a2c6d3b418` deletes any `user_tasks` row whose title is exactly that notice, then drops `users.has_seen_companion_retirement_notice`. The column existed only to gate the announcement.
- `has_seen_companion_retirement_notice` is removed from `backend/models/user.py`, eleven SQLite test schemas and three test seed inserts.
- The four notice-specific cutover tests are replaced by `test_cutover_creates_no_tasks`, which runs the sweep twice and asserts the task table stays empty.

No new dependencies.

Note for deployment: the migration drops a column the previous release's code still selects, so the new image must be the one running when it applies. The entrypoint runs migrations inside the same image at boot, so an ordinary container upgrade sequences this correctly; a rolling deployment that keeps an old API container alongside the new one would not.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1490 passed)
- [x] Python quality: `python scripts/check.py` (OK: lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests)
- [x] Frontend lint: `cd frontend && npm run lint` (0 errors, 4 pre-existing warnings, no frontend files changed)
- [x] Frontend unit tests: `cd frontend && npm run test` (62 files, 475 tests passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py` (via `scripts/check.py`)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (via `scripts/check.py`)

Frontend checks required Node 26 to match CI; the host's default Node 20 cannot run the pinned jsdom/undici.

## Migration impact

- [ ] No database migration in this PR.
- [x] Adds an Alembic migration. Single checked-in head preserved; no committed revisions deleted or renamed. Upgrade and downgrade behaviour described above.

`f7a2c6d3b418` sits on head `c4a81f5d20b6` and is the only head after this change. Upgrade deletes the notice tasks and drops the column. Downgrade re-adds the column with `server_default false` and does not recreate the tasks, since no released code path would consume them.

The upgrade deletes rows from `user_tasks`. It matches on the exact notice title, so a hand-written task would have to be a character-for-character copy to be affected.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

No guide documents the notice; `docs/CAPTURE.md` describes browser capture and never mentioned it.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

The dropped column is a UI delivery marker with no bearing on auth or ownership.

## Manual verification

- Ran the full migration chain against a throwaway database on the dev Postgres instance: `alembic upgrade head` applied cleanly and the column was gone.
- `alembic downgrade -1` restored the column, then seeded a user plus a notice task and ran `alembic upgrade head` again: the task count went to 0 and the column was dropped. Throwaway database deleted afterwards; the dev and production databases were not modified.
- Confirmed the original diagnosis against both live databases: the dev owner (created 2026-08-07, post-retirement) held the notice, while the production owner (created 2026-01-11, pre-retirement) had dismissed it and never saw it return.

No browser capture, recording action or context-menu code is touched, so no capture smoke testing applies.
