### PR TITLE
fix(frontend): cap the live transcript card, not its inner window

### DIFF
--- a/frontend/src/components/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/LiveTranscriptPanel.tsx
@@ -138,21 +138,24 @@ export default function LiveTranscriptPanel({
         ) : null}
       </div>
 
-      {/* The window fills its column between a floor and a ceiling, and the
-          ceiling is measured against the viewport rather than in fixed rem.
+      {/* The window fills the card. The viewport-relative ceiling that keeps
+          this panel independent of its neighbour lives on the card instead --
+          see the order-1 wrapper in RecordingStatusDisplay.
 
-          That distinction is the whole fix. This panel is a grid item beside
-          the guidance column, so a plain `flex-1` takes its height from
-          whatever the neighbour's content happens to be: several screens tall
-          when the guidance is long, and back down toward the floor when its
-          sections are collapsed. Neither is about the transcript. Sizing the
-          ceiling from the window decouples the two, so the panel fills the
-          space the page actually has and scrolls past it, which is what a live
-          transcript does anyway.
+          That ceiling's purpose is unchanged: this panel is a grid item beside
+          the guidance column, so a plain `flex-1` would take its height from
+          whatever the neighbour's content happens to be, several screens tall
+          when the guidance is long and back down toward the floor when its
+          sections are collapsed. Neither is about the transcript.
 
-          The 18rem covers the toolbar above it, the workspace padding and the
-          gap, so the notes card underneath stays on screen. */}
-      <div className="relative mt-4 flex min-h-0 max-h-[calc(100dvh-18rem)] flex-1 flex-col">
+          What moved is where it applies. Capping this inner window while the
+          card around it still stretched to the grid row put the dead space
+          *inside* the card: whenever the guidance column outgrew the viewport,
+          the card followed the row down and the window stopped at its own
+          ceiling, leaving a gap between the transcript and the notes below.
+          Capping the card keeps the decoupling and lets the window fill
+          whatever the card actually is. */}
+      <div className="relative mt-4 flex min-h-0 flex-1 flex-col">
         {/* The transcript window is painted by this overlay rather than by the
             scrolling element, and stops short of the right edge by
             SCROLLBAR_GUTTER. A scroll container always draws its scrollbar

--- a/frontend/src/components/RecordingStatusDisplay.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.tsx
@@ -289,7 +289,15 @@ export default function RecordingStatusDisplay({
               attached. The transcript takes the height and scrolls; the notes
               sit under it at their own size. */}
           <div className="contents @min-[54rem]:col-start-1 @min-[54rem]:row-start-1 @min-[54rem]:flex @min-[54rem]:min-w-0 @min-[54rem]:flex-col @min-[54rem]:gap-[var(--workspace-gap)]">
-          <div className="order-1 flex min-h-0 flex-1 flex-col">
+          {/* The transcript card's viewport-relative ceiling. It sits here
+              rather than inside the panel so the card stops growing at the same
+              point its contents do: capping only the inner window let the card
+              follow the grid row down past it whenever the guidance column
+              outgrew the viewport, and the difference showed as dead space
+              between the transcript and the notes. 18rem covers the toolbar
+              above, the workspace padding and the gap, so the notes card below
+              stays on screen. */}
+          <div className="order-1 flex min-h-0 flex-1 flex-col @min-[54rem]:max-h-[calc(100dvh-18rem)]">
             {isActiveRecording ? (
               <LiveTranscriptPanel
                 segments={liveTranscript.segments}


### PR DESCRIPTION
## Description

The live transcript card on the recording page left a block of empty space between the transcript and the notes card below it, whenever Meeting Edge's column was taller than the viewport.

The panel is a grid item beside the guidance column, and its viewport-relative ceiling exists to keep the two independent: without it, a plain `flex-1` would take its height from whatever Meeting Edge's content happened to be — several screens tall when the guidance is long, back down toward the floor when its sections are collapsed. That reasoning is unchanged and still correct.

The bug was *where* the ceiling applied. It sat on the panel's inner scroll window while the card around it still stretched to the grid row. Once the guidance column outgrew the viewport the two disagreed: the card followed the row down, the window stopped at its own ceiling, and the difference showed as dead space inside the card.

This moves the ceiling onto the card's grid cell, so the card stops growing at the same point its contents do. The window then fills whatever the card actually is, and any leftover row height ends up below the notes card, where it reads as ordinary column slack rather than a hole in a card.

The same cell also carries the processing-state card, which is now capped the same way; it previously stretched to the row unbounded.

No new dependencies.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 1490 passed
- [x] Python quality: `python scripts/check.py` — OK (lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests)
- [x] Frontend lint: `cd frontend && npm run lint` — 0 errors (4 pre-existing `window.location` warnings, untouched by this PR)
- [x] Frontend unit tests: `cd frontend && npm run test` — 475 passed
- [x] Frontend build: `cd frontend && npm run build` — compiled successfully
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — head `f7a2c6d3b418`

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

No behaviour, setup, deployment or support change — this corrects the rendered height of an existing panel. `docs/USAGE.md` already describes the layout as "the live transcript with your notes under it on the left", which this makes true again.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Full stack rebuilt and run locally (`docker compose up -d --build`); all ten containers healthy, API migrations clean on boot.

Changed lines are two Tailwind class lists plus comments. No capture code, no recording actions, and no changes to the shared `useRecordingActions` hook, so the capture smoke set and the action-surface sync are not engaged by this diff.

**Pending before merge:** visual confirmation against a live in-flight capture with a tall Meeting Edge column — the gap only appears once the guidance column exceeds `100dvh - 18rem`, which needs a real recording in progress rather than a static page. Worth a glance at both states in that cell: the live transcript, and the processing/queued card after pressing Stop.
