### PR TITLE
fix(capture): clear an interrupted capture that banked no audio

### DIFF
--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -113,13 +113,17 @@ Chrome on Android and iOS can start recording from the same **Start Meeting** bu
 - **Stop** finalizes the recording after all uploaded segments finish transcoding, then queues final processing. The microphone and any shared tab or screen are released as soon as the recorded audio has been handed off, so the browser recording indicator disappears while Nojoin waits for the last segments to be processed; the meeting button names the current stage during that wait (stopping the recorder, uploading the last segments, releasing the microphone, finalizing). Stop works on a paused recording too, and does not need the original browser capture session to still be active.
 - **Discard** permanently removes a recording in one step. It works for any recording that has not finished: uploading, paused, queued, or processing. Discard revokes any running processing task, releases the capture lock, deletes the captured audio and derived files, and removes the meeting. Nojoin asks you to confirm first because this cannot be undone.
 
-Discard is available from the live recording controls, the floating recording badge, the resume-or-discard modal, and the recordings menu.
+Discard is available from the live recording controls, the floating recording badge, the resume-or-discard modal, and the recordings menu. Wherever you discard from, the meeting leaves the recordings list and the dashboard immediately, and the recording page closes if you were on it.
 
 Closing the browser share picker with **Cancel** is different from Nojoin's in-app **Discard** action. Picker cancel simply backs out of starting or resuming capture without creating a visible error in the UI, and never deletes an existing recording.
 
 If you are recording in a shared-audio capture mode and click the browser's native **Stop sharing** button (or close the sharing indicator), Nojoin automatically detects that the sharing stream has ended. It will immediately stop and finalise the recording, saving all audio captured up to that point, and display a notification informing you that screen sharing ended and the recording was saved.
 
 Refreshing or closing the Nojoin tab (actual tab unload) during a recording moves that recording to `PAUSED`. Nojoin keeps uploaded segments, drops only the in-memory tail, and shows a mandatory resume-or-discard modal the next time you open the app.
+
+An interruption that happened before any audio reached the server is cleared instead of being put to you as a decision. There is nothing to resume and nothing to keep, so Nojoin discards the empty recording, releases the capture lock, and tells you the recording was interrupted and needs starting again. This only applies to a capture the same browser tab lost: a recording paused any other way, or one that banked even a single segment, always goes to the modal.
+
+The case this covers is an upgrade under an open tab. When the Nojoin server is updated while you have the app open, the browser is still running the previous version, so the next page transition reloads the whole app rather than moving within it. If that transition happens to be the one Nojoin makes after **Start Meeting**, the reload unloads the page a second into the recording and the guard pauses it. Nojoin now clears that recording rather than asking about a meeting you have only just started. Press **Start Meeting** again.
 
 Switching to another browser tab, changing the active window, using another application, or navigating between pages within the Nojoin app does not pause recording. The Nojoin tab only pauses automatically when it is actually unloaded. A floating recording badge remains visible at the top of the viewport on every page so you can always see the recording status and control it.
 
@@ -145,7 +149,7 @@ Nojoin allows one active browser capture per user. If a paused recording exists,
 - **Stop and process** to finalize the audio already uploaded and queue processing, without recording any more. Use this when the meeting is over, or when the browser capture session was lost and you only want to keep what was captured. It does not reopen the share picker.
 - **Discard recording** to remove the partial upload and start fresh.
 
-Paused recordings are retained indefinitely. They are not cleaned up automatically, and Nojoin never finalizes one on your behalf.
+Paused recordings are retained indefinitely. They are not cleaned up automatically, and Nojoin never finalizes one on your behalf. The one exception is a capture the tab lost before any audio reached the server, which is discarded rather than offered, because it holds nothing to resume or keep. See [Pause, Resume, Stop, And Discard](#pause-resume-stop-and-discard).
 
 ## Capture Settings
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -90,7 +90,7 @@ Live recording is initiated and controlled by the authenticated web app.
 - Unsafe cookie-authenticated requests still require the trusted Nojoin web origin through the origin checks described above.
 - Browser capture permissions are mediated by the browser. Nojoin cannot silently capture screen, tab, system audio, or microphone input without the user granting permission.
 - The browser share picker determines the visible surface and whether shared audio is included on desktop. Nojoin warns when the browser does not grant a shared-audio track and then records microphone audio only. Mobile Chrome capture is microphone-only and does not expose tab, app, or system audio to Nojoin.
-- A paused recording blocks new capture starts for that user until it is resumed or discarded, preventing overlapping segment streams.
+- A paused recording blocks new capture starts for that user until it is resumed or discarded, preventing overlapping segment streams. Nojoin resolves one case itself: a capture the same browser tab lost before the server acknowledged any segment holds no audio, so it is discarded rather than offered. The decision reads that tab's own capture context, and the discard goes through the same ownership-checked endpoint as a manual one, so it can never reach a recording belonging to another tab, device, or user.
 - Refreshing, closing, or navigating away from the Nojoin tab moves the recording to `PAUSED`; uploaded segments remain server-side and only the current in-memory tail is dropped.
 - Switching focus to another tab, window, or application does not pause recording.
 - WebM/Opus, Ogg/Opus, and MP4 audio browser segments are transcoded in worker tasks before final WAV concatenation and final processing.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -141,6 +141,8 @@ Discard is available from the live recording controls, the floating recording ba
 
 If the browser is closed, refreshed, or loses the active recording page during capture, Nojoin pauses the recording to protect already uploaded data. When you return, Nojoin requires you to deal with that recording before starting anything else, offering three choices: resume it, **Stop and process** to keep the audio already captured and start processing, or discard it. Stopping this way does not reopen the browser share picker, so it works even though the original capture session is gone.
 
+If the interruption happened before any audio reached the server, Nojoin discards that recording instead of asking, and tells you to start the meeting again. There is nothing in it to resume or keep, so there is nothing to decide. See [Pause, Resume, Stop, And Discard](CAPTURE.md#pause-resume-stop-and-discard).
+
 Paused recordings are retained indefinitely until you resume, stop, or discard them.
 
 ### Live Transcription

--- a/frontend/src/app/(dashboard)/recordings/[id]/_hooks/useRecordingDetail.ts
+++ b/frontend/src/app/(dashboard)/recordings/[id]/_hooks/useRecordingDetail.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_MEETING_EDGE_CONTEXT_LEVEL,
 } from "@/lib/meetingEdgeContext";
 import { getErrorMessage, getErrorStatus, isAbortError } from "@/lib/errors";
+import { subscribeRecordingRemoved } from "@/lib/recordingEvents";
 import {
   Recording,
   RecordingStatus,
@@ -494,6 +495,19 @@ export function useRecordingDetail({ params }: UseRecordingDetailParams) {
     window.addEventListener("recording-updated", handleUpdate);
     return () => window.removeEventListener("recording-updated", handleUpdate);
   }, [recording, isEditingTitle, refreshRecordingView]);
+
+  // Discarding the open recording deletes it, so this page has nothing left to
+  // show. Leaving centrally means every discard surface gets the redirect, not
+  // just the two that happened to wire up their own.
+  useEffect(
+    () =>
+      subscribeRecordingRemoved((removedId) => {
+        if (recording && removedId === recording.id) {
+          navigateToRecordings();
+        }
+      }),
+    [navigateToRecordings, recording],
+  );
 
   // Listen for tour events to switch panels
   useEffect(() => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -33,6 +33,7 @@ import {
   getRecordingsCalendar,
 } from "@/lib/api";
 import { useRecordingActions } from "./recordings/_hooks/useRecordingActions";
+import { subscribeRecordingRemoved } from "@/lib/recordingEvents";
 import MonthCalendar from "./MonthCalendar";
 import { getUserTimeZone, localDayRangeToUtc } from "@/lib/timezone";
 import { format, startOfMonth } from "date-fns";
@@ -371,6 +372,17 @@ export default function Sidebar() {
       window.removeEventListener("tags-updated", handleUpdate);
     };
   }, [fetchRecordings]);
+
+  // A discard from anywhere (live controls, floating badge, resume modal, the
+  // processing view) drops the row here immediately rather than leaving it on
+  // screen until the 15s poll comes round.
+  useEffect(
+    () =>
+      subscribeRecordingRemoved((id) => {
+        setRecordings((prev) => prev.filter((r) => r.id !== id));
+      }),
+    [],
+  );
 
   // Clear selection when view changes
   useEffect(() => {

--- a/frontend/src/components/dashboardRecordings/useDashboardRecordings.ts
+++ b/frontend/src/components/dashboardRecordings/useDashboardRecordings.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { getRecordings } from "@/lib/api";
+import { subscribeRecordingRemoved } from "@/lib/recordingEvents";
 import { Recording, RecordingStatus } from "@/types";
 
 /**
@@ -71,7 +72,15 @@ export function useDashboardRecordings(): DashboardRecordings {
 
     const handleUpdate = () => void load();
     window.addEventListener("recording-updated", handleUpdate);
-    return () => window.removeEventListener("recording-updated", handleUpdate);
+    // A discard is explicit and irreversible, so the row goes now rather than
+    // after the re-fetch a generic update would need.
+    const unsubscribeRemoved = subscribeRecordingRemoved((id) => {
+      setRecordings((prev) => prev.filter((recording) => recording.id !== id));
+    });
+    return () => {
+      window.removeEventListener("recording-updated", handleUpdate);
+      unsubscribeRemoved();
+    };
   }, [load]);
 
   const sorted = sortByNewest(recordings);

--- a/frontend/src/components/recordings/_hooks/useRecordingActions.ts
+++ b/frontend/src/components/recordings/_hooks/useRecordingActions.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/api";
 import { useCapture } from "@/lib/capture/CaptureProvider";
 import { useNotificationStore } from "@/lib/notificationStore";
+import { dispatchRecordingRemoved } from "@/lib/recordingEvents";
 import { RecordingId } from "@/types";
 
 /**
@@ -150,9 +151,12 @@ export function useRecordingActions(): RecordingActions {
             runtimeActive && captureRecordingId === id;
           const ownsPausedCapture = pausedRecording?.id === id;
           if (ownsLiveCapture || ownsPausedCapture) {
+            // The controller announces the removal itself once the capture is
+            // torn down, so this branch must not announce it a second time.
             await cancelCapture(id);
           } else {
             await discardRecordingCapture(id, "user_discarded");
+            dispatchRecordingRemoved(id);
           }
           addNotification({
             message: "Recording discarded.",

--- a/frontend/src/lib/capture/CaptureProvider.tsx
+++ b/frontend/src/lib/capture/CaptureProvider.tsx
@@ -87,6 +87,7 @@ export function useCapture() {
     stop: controller.stop,
     cancel: controller.cancel,
     refreshPausedRecording: controller.refreshPausedRecording,
+    discardEmptyInterruptedRecording: controller.discardEmptyInterruptedRecording,
     updateSettings: controller.updateSettings,
     dismissCoverageWarning: controller.dismissCoverageWarning,
     status: state.status,

--- a/frontend/src/lib/capture/controller.test.ts
+++ b/frontend/src/lib/capture/controller.test.ts
@@ -70,6 +70,10 @@ vi.mock("./lifecycle", () => ({
   sendPauseBeacon: vi.fn(() => false),
 }));
 
+const sharedMocks = vi.hoisted(() => ({
+  readPausedCaptureContext: vi.fn(() => null as unknown),
+}));
+
 vi.mock("./shared", () => ({
   clearPausedCaptureContext: vi.fn(),
   DEFAULT_CAPTURE_LEVELS: { system: 0, microphone: 0, mixed: 0 },
@@ -81,7 +85,7 @@ vi.mock("./shared", () => ({
     noiseSuppression: true,
     autoGainControl: true,
   })),
-  readPausedCaptureContext: vi.fn(() => null),
+  readPausedCaptureContext: sharedMocks.readPausedCaptureContext,
   writeCaptureSettings: vi.fn(),
   writePausedCaptureContext: vi.fn(),
 }));
@@ -170,6 +174,8 @@ describe("capture controller", () => {
     notificationMocks.addNotification.mockReset();
     apiMocks.getRecording.mockReset();
     apiMocks.getRecording.mockResolvedValue({ id: "rec-1" });
+    sharedMocks.readPausedCaptureContext.mockReset();
+    sharedMocks.readPausedCaptureContext.mockReturnValue(null);
     connectivityMocks.status = "online";
   });
 
@@ -973,5 +979,102 @@ describe("capture controller", () => {
     await controller.pollCapturedAudio();
 
     expect(controller.getState().coverageWarning).toBeNull();
+  });
+});
+
+describe("recovering an interrupted capture", () => {
+  const PAUSED = { id: "rec-1", name: "Meeting" };
+
+  const controllerWithPaused = () => {
+    const controller = new CaptureController() as any;
+    controller.state = { ...controller.getState(), pausedRecording: PAUSED };
+    return controller;
+  };
+
+  beforeEach(() => {
+    apiMocks.discardRecordingCapture.mockReset();
+    apiMocks.discardRecordingCapture.mockResolvedValue(undefined);
+    apiMocks.getPausedRecordings.mockReset();
+    apiMocks.getPausedRecordings.mockResolvedValue([]);
+    sharedMocks.readPausedCaptureContext.mockReset();
+    sharedMocks.readPausedCaptureContext.mockReturnValue(null);
+    notificationMocks.addNotification.mockReset();
+  });
+
+  it("discards a capture this tab lost before banking any audio", async () => {
+    // What a guarded exit leaves behind when the app's own post-start
+    // navigation unloads the page a second after the recording began.
+    sharedMocks.readPausedCaptureContext.mockReturnValue({
+      recordingId: "rec-1",
+      lastSequence: -1,
+      persistedAt: 1,
+    });
+    const controller = controllerWithPaused();
+
+    await expect(controller.discardEmptyInterruptedRecording()).resolves.toBe(
+      true,
+    );
+    expect(apiMocks.discardRecordingCapture).toHaveBeenCalledWith("rec-1");
+    expect(controller.getState().pausedRecording).toBeNull();
+    expect(notificationMocks.addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "warning" }),
+    );
+  });
+
+  it("keeps a capture that banked a segment for the user to decide about", async () => {
+    sharedMocks.readPausedCaptureContext.mockReturnValue({
+      recordingId: "rec-1",
+      lastSequence: 0,
+      persistedAt: 1,
+    });
+    const controller = controllerWithPaused();
+
+    await expect(controller.discardEmptyInterruptedRecording()).resolves.toBe(
+      false,
+    );
+    expect(apiMocks.discardRecordingCapture).not.toHaveBeenCalled();
+    expect(controller.getState().pausedRecording).toEqual(PAUSED);
+  });
+
+  it("leaves a paused recording this tab never owned alone", async () => {
+    // No persisted context: the pause came from another tab, another device, or
+    // an explicit pause, none of which this tab may resolve on the user's behalf.
+    const controller = controllerWithPaused();
+
+    await expect(controller.discardEmptyInterruptedRecording()).resolves.toBe(
+      false,
+    );
+    expect(apiMocks.discardRecordingCapture).not.toHaveBeenCalled();
+  });
+
+  it("ignores a context naming a different recording", async () => {
+    sharedMocks.readPausedCaptureContext.mockReturnValue({
+      recordingId: "rec-other",
+      lastSequence: -1,
+      persistedAt: 1,
+    });
+    const controller = controllerWithPaused();
+
+    await expect(controller.discardEmptyInterruptedRecording()).resolves.toBe(
+      false,
+    );
+    expect(apiMocks.discardRecordingCapture).not.toHaveBeenCalled();
+  });
+
+  it("announces the removal so every list drops the row at once", async () => {
+    const removed: string[] = [];
+    const listener = (event: Event) => {
+      removed.push((event as CustomEvent<{ id: string }>).detail.id);
+    };
+    window.addEventListener("recording-removed", listener);
+
+    try {
+      const controller = new CaptureController() as any;
+      await controller.cancel("rec-1");
+    } finally {
+      window.removeEventListener("recording-removed", listener);
+    }
+
+    expect(removed).toEqual(["rec-1"]);
   });
 });

--- a/frontend/src/lib/capture/controller.ts
+++ b/frontend/src/lib/capture/controller.ts
@@ -14,6 +14,7 @@ import {
 import { useConnectivityStore } from "@/lib/connectivity/monitor";
 import { isReachable } from "@/lib/connectivity/reducer";
 import { useNotificationStore } from "@/lib/notificationStore";
+import { dispatchRecordingRemoved } from "@/lib/recordingEvents";
 import type { Recording, RecordingId } from "@/types";
 
 import { detectCaptureSupport } from "./featureDetect";
@@ -773,7 +774,58 @@ export class CaptureController {
       stopStage: null,
     });
     this.lifecycle.updateRecordingId(null);
+    dispatchRecordingRemoved(targetRecordingId);
     await this.refreshPausedRecording().catch(() => {});
+  };
+
+  /**
+   * Discards a paused recording this tab lost before it banked any audio.
+   *
+   * A document unload during capture is guarded: `handleGuardedExit` pauses the
+   * recording so the audio already uploaded survives. That is right in the
+   * middle of a meeting and wrong immediately after one starts, which is where
+   * it kept landing. A `router.push` degrades to a full-document navigation
+   * whenever Next.js finds the tab running a different build from the server
+   * (any upgrade under an open tab does it), and the app performs exactly such
+   * a push a second after `start()` resolves. The guard then paused a recording
+   * that was seconds old and the reloaded page opened the resume-or-discard
+   * modal over a meeting the user had only just started.
+   *
+   * The guard itself has to stay: `beforeunload`/`pagehide` fire only for a real
+   * unload, so skipping the pause would strand the recording in `UPLOADING`
+   * with no client, where `POST /init` rejects every later start with
+   * `active_recording_exists` and no modal offers a way out.
+   *
+   * So the pause stands and the prompt goes. `lastSequence` in the persisted
+   * context is the uploader's own count of segments the server acknowledged;
+   * below zero means nothing was banked and there is nothing for the user to
+   * decide about. The context is per-tab `sessionStorage`, so this only ever
+   * acts on a capture this tab owned and lost. A recording paused any other way
+   * still goes to the modal.
+   */
+  discardEmptyInterruptedRecording = async (): Promise<boolean> => {
+    const paused = this.state.pausedRecording;
+    if (!paused || this.runtime) {
+      return false;
+    }
+
+    const context = readPausedCaptureContext();
+    if (
+      !context ||
+      context.recordingId !== paused.id ||
+      context.lastSequence >= 0
+    ) {
+      return false;
+    }
+
+    await this.cancel(paused.id);
+    useNotificationStore.getState().addNotification({
+      type: "warning",
+      message:
+        "The last recording was interrupted before any audio was captured, " +
+        "so it was discarded. Start the meeting again to record.",
+    });
+    return true;
   };
 
   private activateRuntime = async (options: {
@@ -1177,6 +1229,18 @@ export class CaptureController {
     const lastSequence = this.state.lastSequence;
     const wasAlreadyPaused = this.state.status === "paused";
 
+    // Written before anything is awaited. This runs during an unload, so the
+    // document can be torn down at the first yield and everything after it may
+    // never execute; the context used to be written in the `finally`, three
+    // awaits later. It is the only record of what this tab was capturing, and
+    // discardEmptyInterruptedRecording needs its sequence count on the next
+    // load to tell an interruption worth resuming from one worth clearing.
+    writePausedCaptureContext({
+      recordingId,
+      lastSequence,
+      persistedAt: Date.now(),
+    });
+
     try {
       await this.runtime.recorder.stop({ emitTail: false });
 
@@ -1194,11 +1258,6 @@ export class CaptureController {
         }
       }
     } finally {
-      writePausedCaptureContext({
-        recordingId,
-        lastSequence,
-        persistedAt: Date.now(),
-      });
       await this.disposeRuntime();
       this.setState({
         status: "paused",

--- a/frontend/src/lib/capture/usePausedRecordingGuard.ts
+++ b/frontend/src/lib/capture/usePausedRecordingGuard.ts
@@ -1,19 +1,41 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useCapture } from "./CaptureProvider";
 
 export function usePausedRecordingGuard() {
-  const { pausedRecording, refreshPausedRecording } = useCapture();
+  const {
+    pausedRecording,
+    refreshPausedRecording,
+    discardEmptyInterruptedRecording,
+  } = useCapture();
+  // The modal stays shut until the recovery pass has run, so an interruption
+  // that is about to be cleared automatically never flashes a decision at the
+  // user on the way past.
+  const [recovered, setRecovered] = useState(false);
 
   useEffect(() => {
-    void refreshPausedRecording().catch(() => {});
-  }, [refreshPausedRecording]);
+    let cancelled = false;
+
+    void (async () => {
+      const paused = await refreshPausedRecording().catch(() => null);
+      if (paused) {
+        await discardEmptyInterruptedRecording().catch(() => {});
+      }
+      if (!cancelled) {
+        setRecovered(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [discardEmptyInterruptedRecording, refreshPausedRecording]);
 
   return {
     pausedRecording,
-    hasPausedRecording: Boolean(pausedRecording),
+    hasPausedRecording: recovered && Boolean(pausedRecording),
     refreshPausedRecording,
   };
 }

--- a/frontend/src/lib/recordingEvents.ts
+++ b/frontend/src/lib/recordingEvents.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import type { RecordingId } from "@/types";
+
+/**
+ * The "this recording no longer exists" announcement.
+ *
+ * Discard is the one recording action that is both explicit and irreversible,
+ * and it can be triggered from five places: the recordings rail, the live
+ * transport controls, the floating badge, the resume-or-discard modal, and the
+ * processing view. Only the rail used to update itself afterwards, so a discard
+ * from any of the other four left the meeting on screen until the rail's 15s
+ * poll came round.
+ *
+ * `recording-updated` is not enough here. It carries no identity for a deletion
+ * and every listener answers it with a re-fetch, so the row survives the round
+ * trip. This event names the recording, which lets a list drop it from local
+ * state immediately and the open detail page navigate away from a meeting that
+ * has just been deleted underneath it.
+ */
+export const RECORDING_REMOVED_EVENT = "recording-removed";
+
+export interface RecordingRemovedDetail {
+  id: RecordingId;
+}
+
+/** Announces that `id` has been deleted server-side and should disappear now. */
+export const dispatchRecordingRemoved = (id: RecordingId) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<RecordingRemovedDetail>(RECORDING_REMOVED_EVENT, {
+      detail: { id },
+    }),
+  );
+};
+
+/**
+ * Subscribes to removals. Returns the unsubscribe function so a `useEffect`
+ * can return it directly.
+ */
+export const subscribeRecordingRemoved = (
+  handler: (id: RecordingId) => void,
+): (() => void) => {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const listener = (event: Event) => {
+    const detail = (event as CustomEvent<RecordingRemovedDetail>).detail;
+    if (detail?.id) {
+      handler(detail.id);
+    }
+  };
+
+  window.addEventListener(RECORDING_REMOVED_EVENT, listener);
+  return () => window.removeEventListener(RECORDING_REMOVED_EVENT, listener);
+};


### PR DESCRIPTION
## Description

Starting a meeting could immediately hand the user a resume-or-discard modal for the meeting they had just started, and discarding a meeting left it on screen until the next poll.

**The prompt.** `CaptureLifecycle` pauses the recording on `beforeunload`/`pagehide` so a tab close does not lose uploaded audio. `MeetingControls.handleStart` calls `router.push('/recordings/{id}')` as soon as `start()` resolves, and that push degrades to a full-document navigation whenever Next.js finds the tab running a different build from the server, which any upgrade under an open tab causes. The guard then fired on a recording one second old, and the reloaded page opened the modal over it.

Traced in the dev nginx log: `init` at 21:30:51, capture running at 21:30:53, a bare `GET /recordings/{id}` document load at 21:30:54 followed immediately by `POST /{id}/pause`, then the app re-booting and the paused-recordings query returning one row. It reproduced twice today, both times on the first meeting started after a frontend rebuild.

Suppressing the guard is not the fix and would be worse. `beforeunload`/`pagehide` fire only on a real unload, so skipping the pause leaves the recording in `UPLOADING` with no client, where `POST /init` rejects every later start with `active_recording_exists` and the modal, which queries `PAUSED` only, never appears. The pause therefore stays and the prompt goes: a capture this tab lost before the server acknowledged any segment holds nothing to resume or keep, so it is discarded and the user is told to start again. The decision reads `lastSequence` from the per-tab `sessionStorage` capture context, so it can only ever act on a capture this tab owned. Anything paused another way, or holding a single segment, still goes to the modal. The context write moved ahead of the first `await` in `handleGuardedExit`, because it ran three awaits deep in a `finally` during an unload that can be torn down at the first yield.

**The stale list.** `recording-updated` carries no identity for a deletion and every listener answers it with a re-fetch, so the row survived the round trip; only the recordings rail updated itself, and only when the discard started there. A new `recording-removed` event names the recording. It is dispatched from `CaptureController.cancel()` (live controls, floating badge, resume modal) and from the plain-discard branch of `useRecordingActions` (recordings menu, processing view), and consumed by the rail, the dashboard lists, and the recording detail page, which navigates away centrally rather than relying on the two surfaces that had wired their own redirect.

No new dependencies.

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1490 passed)
- [ ] Python quality: `python scripts/check.py` — not run; no Python changed in this PR, and CI's `scripts`/`backend` filters do not select it
- [x] Frontend lint: `cd frontend && npm run lint` (0 errors; the 4 warnings are pre-existing and in files this PR does not touch)
- [x] Frontend unit tests: `cd frontend && npm run test` (480 passed, including 5 new)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Also ran `npm run check:contrast` (302 pairings across 4 themes) and `git diff --check`.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR.

`docs/CAPTURE.md` gains the auto-clear behaviour under "Pause, Resume, Stop, And Discard", the exception under "Paused Recording Lock", and a note that a discard leaves every list at once. `docs/USAGE.md` mirrors the recovery behaviour. `docs/SECURITY.md` updates the paused-recording lock bullet, which previously said the lock clears only on resume or discard.

## Security impact

- [ ] No security-sensitive change.
- [x] Touches auth, tokens, encryption, capture ownership, or exposure.

Flagged because the change deletes a recording without asking. The scope is bounded on both sides: the client will only act when its own per-tab `sessionStorage` context names the paused recording and records no acknowledged segment, and the deletion goes through the existing `POST /{id}/discard`, which is ownership-checked and already restricted to in-flight states. No endpoint, auth path, or `docs/SECURITY.md` boundary changed.

## Manual verification

Browser smoke tested against the dev stack. All of the following passed:

1. Start a meeting, reload within ~2s (before segment 0 uploads). No modal; the warning that the recording was interrupted appears and the meeting leaves the rail.
2. Start a meeting, run it 10s, then reload. The resume-or-discard modal appears as before, with the elapsed audio intact.
3. Discard from each of the live controls, the floating badge, the resume modal, and the recordings menu. The row leaves the rail and dashboard immediately, and the recording page closes when open.
4. Regression pass over the untouched capture flows: share picker, selected microphone, waveform/live state, pause/resume, stop/finalize, unsupported-browser messaging.
