### PR TITLE
fix(frontend): bound the live view's columns to the window

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -284,6 +284,18 @@ than re-laying out the page. The second, slightly wider, is guidance. This is al
 moved off the 64rem feature cap: it is a console, not a page of prose, and a reading measure is
 what forced five panels into one long scroll.
 
+This is the one surface where *which* module absorbs the leftover height changes with the state,
+rather than being fixed as it is on the dashboard. While recording the transcript absorbs, because
+it scrolls and there is always more of it. Once recording stops the transcript is replaced by a
+progress bar and two lines of status, which cannot use height at all, so the notes editor absorbs
+instead and the progress card keeps its own size. Guidance absorbs in its own column in both states,
+scrolling inside its cell from 54rem, and that is what stops however much guidance has accumulated
+from setting the grid row for the whole surface. Below 54rem it is one item in a stack and the page
+scrolls, so it keeps its natural height there. The alternative was tried twice and does not work: a
+`max-height` on the transcript module capped it against the viewport, which relocated the surplus
+row height rather than removing it, first inside the transcript card and then below it. See the rule
+on capping below.
+
 The meeting view's Analytics tab is the third surface that spends width on columns, and it does so
 entirely through container queries on its own scroll region, because it lives inside a resizable
 panel between two collapsible rails and its width is the window minus two numbers it cannot see. It

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -291,10 +291,21 @@ progress bar and two lines of status, which cannot use height at all, so the not
 instead and the progress card keeps its own size. Guidance absorbs in its own column in both states,
 scrolling inside its cell from 54rem, and that is what stops however much guidance has accumulated
 from setting the grid row for the whole surface. Below 54rem it is one item in a stack and the page
-scrolls, so it keeps its natural height there. The alternative was tried twice and does not work: a
-`max-height` on the transcript module capped it against the viewport, which relocated the surplus
-row height rather than removing it, first inside the transcript card and then below it. See the rule
-on capping below.
+scrolls, so it keeps its natural height there.
+
+**This is the one surface whose shell hands down a definite height rather than a floor**, and that
+is what the rest of it rests on. `Workspace` is given `h-full` instead of the dashboard's
+`min-h-full`, with `min-h-0` down the chain to the grid and `grid-template-rows: minmax(0, 1fr)` on
+the row itself, because an `auto` row takes the max-content of its items whatever height the grid
+has. Without all four, whichever column holds the most content sizes the row and drags the other
+with it, and no panel can scroll, because a scroll container needs a height to scroll against.
+Deciding which module absorbs is only meaningful once there is a bounded amount to absorb.
+
+Two things do *not* work here and have both been tried. A `max-height` on the transcript module caps
+it against the viewport, which relocates the surplus row height rather than removing it, first
+inside the transcript card and then below it; see the rule on capping below. Removing that cap
+without bounding the row is the same defect pointing the other way, and the transcript grows without
+limit instead of Meeting Edge.
 
 The meeting view's Analytics tab is the third surface that spends width on columns, and it does so
 entirely through container queries on its own scroll region, because it lives inside a resizable

--- a/frontend/src/components/LiveTranscriptPanel.test.tsx
+++ b/frontend/src/components/LiveTranscriptPanel.test.tsx
@@ -174,4 +174,33 @@ describe("LiveTranscriptPanel", () => {
 
     expect(container.scrollTop).toBe(500);
   });
+
+  it("follows a provisional line that grows without adding a line", () => {
+    const { rerender } = renderPanel([
+      buildLine("a", 0, "first"),
+      buildLine("b", 5, "second"),
+    ]);
+    const container = screen.getByTestId("live-transcript-scroll");
+
+    setScrollGeometry(container, {
+      scrollTop: 0,
+      scrollHeight: 500,
+      clientHeight: 300,
+    });
+
+    // An utterance is rewritten in place as it finalises, so the text wraps to
+    // more rows while the count stays put. Keying the follow on the line count
+    // missed this and let the tail drift below the fold.
+    rerender(
+      <LiveTranscriptPanel
+        segments={[
+          buildLine("a", 0, "first"),
+          buildLine("b", 5, "second, and then a good deal more of it"),
+        ]}
+        hasLoaded
+      />,
+    );
+
+    expect(container.scrollTop).toBe(500);
+  });
 });

--- a/frontend/src/components/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/LiveTranscriptPanel.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ArrowDown, Radio } from "lucide-react";
 
 import { CaptureSourceChannel, TranscriptSegment } from "@/types";
@@ -111,11 +117,23 @@ export default function LiveTranscriptPanel({
 
   // Follow new text only while the user has not scrolled away. Reading back
   // through the meeting must never be yanked out from under them.
-  useEffect(() => {
+  //
+  // Before the paint, not after it. On a plain effect the browser painted the
+  // grown transcript at the old scroll position and corrected it a frame later,
+  // which reads as the text spilling past the bottom of the window and then
+  // snapping back into it. The finished transcript's scroll hook uses a layout
+  // effect for the same reason.
+  //
+  // Keyed on `lines` rather than `lines.length`, because a provisional
+  // utterance is rewritten in place as it finalises: the text grows, it wraps
+  // to more rows, and the count never changes, so a length-keyed effect never
+  // ran and the tail drifted out of view. `lines` is memoised on `segments`, so
+  // a poll that returned nothing new still does nothing here.
+  useLayoutEffect(() => {
     if (isPinnedToBottom) {
       scrollToBottom();
     }
-  }, [lines.length, isPinnedToBottom, scrollToBottom]);
+  }, [lines, isPinnedToBottom, scrollToBottom]);
 
   const jumpToLatest = useCallback(() => {
     setIsPinnedToBottom(true);

--- a/frontend/src/components/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/LiveTranscriptPanel.tsx
@@ -138,23 +138,22 @@ export default function LiveTranscriptPanel({
         ) : null}
       </div>
 
-      {/* The window fills the card. The viewport-relative ceiling that keeps
-          this panel independent of its neighbour lives on the card instead --
-          see the order-1 wrapper in RecordingStatusDisplay.
+      {/* The window fills the card, and the card fills what the column has
+          left. Neither carries a ceiling any more.
 
-          That ceiling's purpose is unchanged: this panel is a grid item beside
-          the guidance column, so a plain `flex-1` would take its height from
-          whatever the neighbour's content happens to be, several screens tall
-          when the guidance is long and back down toward the floor when its
-          sections are collapsed. Neither is about the transcript.
+          One used to sit here, then on the card in RecordingStatusDisplay. It
+          existed to keep this panel independent of the guidance column beside
+          it, which would otherwise have set the height: several screens tall
+          while the guidance was long, back toward the floor once its sections
+          were collapsed, neither of them anything to do with the transcript.
+          That independence is worth having, but a fixed ceiling was the wrong
+          way to buy it. A capped module in an items-stretch grid has to leave
+          the surplus row height somewhere, so both attempts only moved the dead
+          space around, first inside this window and then below the card.
 
-          What moved is where it applies. Capping this inner window while the
-          card around it still stretched to the grid row put the dead space
-          *inside* the card: whenever the guidance column outgrew the viewport,
-          the card followed the row down and the window stopped at its own
-          ceiling, leaving a gap between the transcript and the notes below.
-          Capping the card keeps the decoupling and lets the window fill
-          whatever the card actually is. */}
+          Meeting Edge scrolls inside its own cell now, so it absorbs height
+          rather than dictating it, and the row comes from the window instead.
+          This panel can just take what is left. */}
       <div className="relative mt-4 flex min-h-0 flex-1 flex-col">
         {/* The transcript window is painted by this overlay rather than by the
             scrolling element, and stops short of the right edge by

--- a/frontend/src/components/MeetingEdgePanel.tsx
+++ b/frontend/src/components/MeetingEdgePanel.tsx
@@ -260,7 +260,7 @@ function MeetingEdgePanel({
           : "Autosaves";
 
   return (
-    <section className="@container density-surface flex min-h-0 flex-col border border-surface-border bg-surface-card shadow-card">
+    <section className="@container density-surface flex h-full min-h-0 flex-col border border-surface-border bg-surface-card shadow-card">
       <div className="flex items-center justify-between gap-3">
         <div className="inline-flex items-center gap-2 rounded-full border border-action-border bg-action-tint px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-action-text">
           {status === "updating" ? (
@@ -277,82 +277,98 @@ function MeetingEdgePanel({
         ) : null}
       </div>
 
-      {hasPayload ? (
-        <div className="mt-5 space-y-4">
-          {payload?.summary ? (
-            <div className="density-surface-panel bg-surface-inset p-4">
-              <div className="text-xs font-semibold uppercase tracking-[0.2em] text-contrast-helper">
-                Current Read
+      {/* Everything below the badge scrolls as one region, which is what lets
+          this panel fill the height it is given rather than set it. The badge
+          stays put, so the card keeps its own border and header at the edges of
+          the cell.
+
+          `flex-auto` rather than `flex-1`, and the distinction is load-bearing:
+          `flex-1` sets a basis of zero, and in the single-column layout below
+          54rem the parent has no definite height to distribute, so a zero basis
+          collapses this to nothing and the panel renders as a badge over an
+          empty card. A basis of auto takes the content height when there is
+          nothing to distribute and shrinks to the cell when there is. */}
+      <div className="mt-5 min-h-0 flex-auto overflow-y-auto">
+        {hasPayload ? (
+          <div className="space-y-4">
+            {payload?.summary ? (
+              <div className="density-surface-panel bg-surface-inset p-4">
+                <div className="text-xs font-semibold uppercase tracking-[0.2em] text-contrast-helper">
+                  Current Read
+                </div>
+                <p className="mt-2 text-sm leading-6 text-contrast-muted">
+                  {payload.summary}
+                </p>
               </div>
-              <p className="mt-2 text-sm leading-6 text-contrast-muted">
-                {payload.summary}
-              </p>
+            ) : null}
+
+            {/* Side by side only when this panel is wide enough to carry two
+                columns of prose, which is a question about the panel and not
+                about the window. On `xl:` these split at a 1280px viewport even
+                when the panel itself was 400px, which is what wrapped these
+                lists to three words a line. */}
+            {/* These two fold together. They are grid siblings, so collapsing
+                one alone leaves its cell hollow while the other still sets the
+                row height: the space is not recovered, it just moves. They are
+                also one thought, read across rather than down. */}
+            <div className="grid gap-4 @min-[34rem]:grid-cols-2">
+              <EdgeSection
+                title="Questions to Ask"
+                icon={<MessageSquareQuote className="h-4 w-4 shrink-0 text-action-text" />}
+                open={isGuidanceOpen}
+                onToggle={toggleGuidance}
+              >
+                <ul className="space-y-2 text-sm leading-6 text-contrast-muted">
+                  {questions.length > 0 ? (
+                    questions.map((question, index) => (
+                      <li key={`${question}-${index}`} className="rounded-xl bg-action-tint px-3 py-2">
+                        {question}
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-contrast-helper">
+                      Meeting Edge is still gathering enough context to suggest questions.
+                    </li>
+                  )}
+                </ul>
+              </EdgeSection>
+
+              <EdgeSection
+                title="Points to Raise"
+                icon={<Lightbulb className="h-4 w-4 shrink-0 text-action-text" />}
+                open={isGuidanceOpen}
+                onToggle={toggleGuidance}
+              >
+                <ul className="space-y-2 text-sm leading-6 text-contrast-muted">
+                  {points.length > 0 ? (
+                    points.map((point, index) => (
+                      <li key={`${point}-${index}`} className="rounded-xl bg-status-warning-bg px-3 py-2">
+                        {point}
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-contrast-helper">
+                      No overlooked points identified yet.
+                    </li>
+                  )}
+                </ul>
+              </EdgeSection>
             </div>
-          ) : null}
 
-          {/* Side by side only when this panel is wide enough to carry two
-              columns of prose, which is a question about the panel and not
-              about the window. On `xl:` these split at a 1280px viewport even
-              when the panel itself was 400px, which is what wrapped these
-              lists to three words a line. */}
-          {/* These two fold together. They are grid siblings, so collapsing one
-              alone leaves its cell hollow while the other still sets the row
-              height: the space is not recovered, it just moves. They are also
-              one thought, read across rather than down. */}
-          <div className="grid gap-4 @min-[34rem]:grid-cols-2">
-            <EdgeSection
-              title="Questions to Ask"
-              icon={<MessageSquareQuote className="h-4 w-4 shrink-0 text-action-text" />}
-              open={isGuidanceOpen}
-              onToggle={toggleGuidance}
-            >
-              <ul className="space-y-2 text-sm leading-6 text-contrast-muted">
-                {questions.length > 0 ? (
-                  questions.map((question, index) => (
-                    <li key={`${question}-${index}`} className="rounded-xl bg-action-tint px-3 py-2">
-                      {question}
-                    </li>
-                  ))
-                ) : (
-                  <li className="text-contrast-helper">
-                    Meeting Edge is still gathering enough context to suggest questions.
-                  </li>
-                )}
-              </ul>
-            </EdgeSection>
-
-            <EdgeSection
-              title="Points to Raise"
-              icon={<Lightbulb className="h-4 w-4 shrink-0 text-action-text" />}
-              open={isGuidanceOpen}
-              onToggle={toggleGuidance}
-            >
-              <ul className="space-y-2 text-sm leading-6 text-contrast-muted">
-                {points.length > 0 ? (
-                  points.map((point, index) => (
-                    <li key={`${point}-${index}`} className="rounded-xl bg-status-warning-bg px-3 py-2">
-                      {point}
-                    </li>
-                  ))
-                ) : (
-                  <li className="text-contrast-helper">
-                    No overlooked points identified yet.
-                  </li>
-                )}
-              </ul>
-            </EdgeSection>
-          </div>
-
-          {conceptHistory.length > 0 ? (
-            <EdgeSection
-              title="Technical Context"
-              meta={
-                <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-contrast-helper">
-                  {conceptHistory.length} term{conceptHistory.length === 1 ? "" : "s"} tracked
-                </span>
-              }
-            >
-              <div className="max-h-[22rem] overflow-y-auto pr-1">
+            {conceptHistory.length > 0 ? (
+              <EdgeSection
+                title="Technical Context"
+                meta={
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-contrast-helper">
+                    {conceptHistory.length} term{conceptHistory.length === 1 ? "" : "s"} tracked
+                  </span>
+                }
+              >
+                {/* No inner scroller. This list used to cap itself at 22rem and
+                    scroll, which was the only way it could stop growing the
+                    card. The card scrolls as a whole now, so a second scroll
+                    region inside the first would only make the list harder to
+                    read than the sections above it. */}
                 <div className="grid gap-3 @min-[34rem]:grid-cols-2">
                   {conceptHistory.map((concept, index) => (
                     <div
@@ -368,91 +384,91 @@ function MeetingEdgePanel({
                     </div>
                   ))}
                 </div>
+              </EdgeSection>
+            ) : null}
+          </div>
+        ) : (
+          <div className="density-surface-panel border border-dashed border-action-border bg-surface-inset px-4 py-5 text-sm leading-6 text-contrast-helper">
+            {status === "updating"
+              ? "Meeting Edge is building the first guidance pass from the live meeting."
+              : "Meeting Edge will start suggesting questions and overlooked points once the meeting has enough signal."}
+          </div>
+        )}
+
+        <div className="mt-5 rounded-[1.5rem] border border-action-border bg-action-tint p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Target className="h-4 w-4 text-action-text" />
+              Guide Meeting Edge
+            </div>
+            <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-contrast-helper">
+              {saveMessage}
+            </span>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-contrast-helper">
+            Add a short goal, concern, or angle you want this guidance to optimize for.
+          </p>
+          <textarea
+            value={draftFocus}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            placeholder="Example: Help me ask sharper timeline questions and flag hidden risks or missing owners."
+            className="mt-3 min-h-[6rem] w-full resize-none rounded-[1.25rem] border border-surface-border bg-surface-card px-4 py-3 text-sm leading-6 text-foreground outline-none transition focus:border-action focus:ring-2 focus:ring-action"
+          />
+        </div>
+
+        {/* Last, and closed. It is a setting rather than guidance: once it is
+            set for a recording it is rarely touched again, and it was sitting
+            between the guidance and the box you type into. */}
+        {onSaveContextLevel ? (
+          <div className="mt-5">
+            <EdgeSection
+              title="Meeting Edge Technical Context"
+              tone="tint"
+              defaultOpen={false}
+            >
+              <p className="text-xs leading-5 text-contrast-helper">
+                Adjust how readily live guidance explains technical language on this recording page.
+              </p>
+
+              <input
+                type="range"
+                min={1}
+                max={5}
+                step={1}
+                value={draftContextLevel}
+                onChange={(event) => {
+                  void handleContextLevelChange(event);
+                }}
+                aria-label="Meeting Edge Technical Context sensitivity"
+                className="mt-5 w-full accent-action"
+              />
+
+              <div className="relative mt-5 h-4 text-[11px] font-medium text-contrast-helper">
+                {MEETING_EDGE_CONTEXT_OPTIONS.map((option, index) => {
+                  const position = `${(index / contextStepCount) * 100}%`;
+                  const alignmentClass =
+                    index === 0
+                      ? "-translate-x-0 text-left"
+                      : index === contextStepCount
+                        ? "-translate-x-full text-right"
+                        : "-translate-x-1/2 text-center";
+
+                  return (
+                    <span
+                      key={option.value}
+                      className={`absolute top-0 whitespace-nowrap ${alignmentClass}`}
+                      style={{ left: position }}
+                    >
+                      {option.label}
+                    </span>
+                  );
+                })}
               </div>
             </EdgeSection>
-          ) : null}
-        </div>
-      ) : (
-        <div className="density-surface-panel mt-5 border border-dashed border-action-border bg-surface-inset px-4 py-5 text-sm leading-6 text-contrast-helper">
-          {status === "updating"
-            ? "Meeting Edge is building the first guidance pass from the live meeting."
-            : "Meeting Edge will start suggesting questions and overlooked points once the meeting has enough signal."}
-        </div>
-      )}
-
-      <div className="mt-5 rounded-[1.5rem] border border-action-border bg-action-tint p-4">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-            <Target className="h-4 w-4 text-action-text" />
-            Guide Meeting Edge
           </div>
-          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-contrast-helper">
-            {saveMessage}
-          </span>
-        </div>
-        <p className="mt-2 text-sm leading-6 text-contrast-helper">
-          Add a short goal, concern, or angle you want this guidance to optimize for.
-        </p>
-        <textarea
-          value={draftFocus}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          placeholder="Example: Help me ask sharper timeline questions and flag hidden risks or missing owners."
-          className="mt-3 min-h-[6rem] w-full resize-none rounded-[1.25rem] border border-surface-border bg-surface-card px-4 py-3 text-sm leading-6 text-foreground outline-none transition focus:border-action focus:ring-2 focus:ring-action"
-        />
+        ) : null}
       </div>
-
-      {/* Last, and closed. It is a setting rather than guidance: once it is set
-          for a recording it is rarely touched again, and it was sitting between
-          the guidance and the box you type into. */}
-      {onSaveContextLevel ? (
-        <div className="mt-5">
-          <EdgeSection
-            title="Meeting Edge Technical Context"
-            tone="tint"
-            defaultOpen={false}
-          >
-            <p className="text-xs leading-5 text-contrast-helper">
-              Adjust how readily live guidance explains technical language on this recording page.
-            </p>
-
-            <input
-            type="range"
-            min={1}
-            max={5}
-            step={1}
-            value={draftContextLevel}
-            onChange={(event) => {
-              void handleContextLevelChange(event);
-            }}
-              aria-label="Meeting Edge Technical Context sensitivity"
-              className="mt-5 w-full accent-action"
-            />
-
-            <div className="relative mt-5 h-4 text-[11px] font-medium text-contrast-helper">
-              {MEETING_EDGE_CONTEXT_OPTIONS.map((option, index) => {
-                const position = `${(index / contextStepCount) * 100}%`;
-                const alignmentClass =
-                  index === 0
-                    ? "-translate-x-0 text-left"
-                    : index === contextStepCount
-                      ? "-translate-x-full text-right"
-                      : "-translate-x-1/2 text-center";
-
-                return (
-                  <span
-                    key={option.value}
-                    className={`absolute top-0 whitespace-nowrap ${alignmentClass}`}
-                    style={{ left: position }}
-                  >
-                    {option.label}
-                  </span>
-                );
-              })}
-            </div>
-          </EdgeSection>
-        </div>
-      ) : null}
     </section>
   );
 }

--- a/frontend/src/components/RecordingStatusDisplay.test.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.test.tsx
@@ -323,6 +323,28 @@ describe("RecordingStatusDisplay", () => {
       );
     });
 
+    it("bounds the grid row against the window", () => {
+      render(
+        <RecordingStatusDisplay
+          recording={buildRecording({
+            status: RecordingStatus.UPLOADING,
+            client_status: ClientStatus.RECORDING,
+          })}
+          onSaveProcessingNotes={vi.fn()}
+          onSaveMeetingEdgeFocus={vi.fn()}
+        />,
+      );
+
+      // Neither column can bound the other without this. A scroll container
+      // needs a definite height to scroll against, and an auto grid row takes
+      // the max-content of its items, so removing the ceiling on one column
+      // without bounding the row just moves which panel grows without limit.
+      const grid = wrapperOf("meeting-edge-panel").parentElement as HTMLElement;
+
+      expect(grid.className).toContain("@min-[54rem]:min-h-0");
+      expect(grid.className).toContain("@min-[54rem]:grid-rows-[minmax(0,1fr)]");
+    });
+
     it("caps no module against the viewport", () => {
       render(
         <RecordingStatusDisplay

--- a/frontend/src/components/RecordingStatusDisplay.test.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.test.tsx
@@ -259,4 +259,90 @@ describe("RecordingStatusDisplay", () => {
 
     expect(screen.getByTestId("live-transcript-panel")).toBeInTheDocument();
   });
+
+  // DESIGN.md gives every column exactly one module that absorbs the leftover
+  // height. On the left, which module that is changes with the state, and
+  // getting it wrong is what stretched a progress bar and two lines of status
+  // into a box most of a screen tall. Asserted against the class rather than a
+  // measurement because jsdom lays nothing out, and the class is the contract.
+  describe("column height absorption", () => {
+    const wrapperOf = (testId: string) =>
+      screen.getByTestId(testId).parentElement as HTMLElement;
+
+    it("gives the transcript the leftover height while recording", () => {
+      render(
+        <RecordingStatusDisplay
+          recording={buildRecording({
+            status: RecordingStatus.UPLOADING,
+            client_status: ClientStatus.RECORDING,
+          })}
+          onSaveProcessingNotes={vi.fn()}
+          onSaveMeetingEdgeFocus={vi.fn()}
+        />,
+      );
+
+      expect(wrapperOf("live-transcript-panel").className).toContain("flex-1");
+      expect(wrapperOf("processing-notes-panel").className).not.toContain(
+        "flex-1",
+      );
+    });
+
+    it("hands it to the notes editor once recording stops", () => {
+      render(
+        <RecordingStatusDisplay
+          recording={buildRecording({
+            status: RecordingStatus.PROCESSING,
+            client_status: undefined,
+          })}
+          onSaveProcessingNotes={vi.fn()}
+          onSaveMeetingEdgeFocus={vi.fn()}
+        />,
+      );
+
+      expect(wrapperOf("processing-notes-panel").className).toContain("flex-1");
+      // The progress card cannot use height: it is a bar and two lines.
+      expect(
+        screen.getByText("Progress").closest("section")?.parentElement
+          ?.className,
+      ).not.toContain("flex-1");
+    });
+
+    it("lets Meeting Edge absorb rather than set the row", () => {
+      render(
+        <RecordingStatusDisplay
+          recording={buildRecording()}
+          onSaveProcessingNotes={vi.fn()}
+          onSaveMeetingEdgeFocus={vi.fn()}
+        />,
+      );
+
+      // Only from 54rem: below it this is one item in a stack, and the page
+      // scrolls rather than the panel.
+      expect(wrapperOf("meeting-edge-panel").className).toContain(
+        "@min-[54rem]:flex-1",
+      );
+    });
+
+    it("caps no module against the viewport", () => {
+      render(
+        <RecordingStatusDisplay
+          recording={buildRecording({
+            status: RecordingStatus.UPLOADING,
+            client_status: ClientStatus.RECORDING,
+          })}
+          onSaveProcessingNotes={vi.fn()}
+          onSaveMeetingEdgeFocus={vi.fn()}
+        />,
+      );
+
+      // A max-height on a module in an items-stretch grid relocates the surplus
+      // row height instead of removing it, which is the dead corner the column
+      // model exists to prevent.
+      expect(wrapperOf("live-transcript-panel").className).not.toMatch(/max-h-/);
+      expect(wrapperOf("meeting-edge-panel").className).not.toMatch(/max-h-/);
+      expect(wrapperOf("processing-notes-panel").className).not.toMatch(
+        /max-h-/,
+      );
+    });
+  });
 });

--- a/frontend/src/components/RecordingStatusDisplay.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.tsx
@@ -286,18 +286,34 @@ export default function RecordingStatusDisplay({
             of the page. Notes moves under the transcript, which scrolls. */}
         <section className="flex grow flex-col gap-[var(--workspace-gap)] @min-[54rem]:grid @min-[54rem]:grid-cols-[minmax(0,1fr)_minmax(24rem,1.1fr)] @min-[54rem]:items-stretch">
           {/* The meeting's record: what was said, what you wrote, what you
-              attached. The transcript takes the height and scrolls; the notes
-              sit under it at their own size. */}
+              attached. */}
           <div className="contents @min-[54rem]:col-start-1 @min-[54rem]:row-start-1 @min-[54rem]:flex @min-[54rem]:min-w-0 @min-[54rem]:flex-col @min-[54rem]:gap-[var(--workspace-gap)]">
-          {/* The transcript card's viewport-relative ceiling. It sits here
-              rather than inside the panel so the card stops growing at the same
-              point its contents do: capping only the inner window let the card
-              follow the grid row down past it whenever the guidance column
-              outgrew the viewport, and the difference showed as dead space
-              between the transcript and the notes. 18rem covers the toolbar
-              above, the workspace padding and the gap, so the notes card below
-              stays on screen. */}
-          <div className="order-1 flex min-h-0 flex-1 flex-col @min-[54rem]:max-h-[calc(100dvh-18rem)]">
+          {/* Exactly one module in this column absorbs the leftover height, and
+              which one it is depends on the state. While recording it is the
+              transcript, because it scrolls and there is always more of it.
+              Once recording stops the transcript is replaced by a progress bar
+              and two lines of status, which cannot use height at all, so the
+              notes editor absorbs instead and the progress card keeps its own
+              size. Stretched, that card was most of a screen tall around three
+              lines of content.
+
+              What was here instead was a max-height on this module, sized as
+              `calc(100dvh-18rem)`. DESIGN.md rules that out: a max-height on a
+              module in an items-stretch grid makes one column's cards end above
+              the other's, which is the dead corner the column model exists to
+              remove. The 18rem was a budget for the toolbar, the workspace
+              padding and the gap, and none of the three hold still. The toolbar
+              carries an extra row of controls while recording, compact density
+              moves the gap and the padding and the root font size while 100dvh
+              does not move with them, and the documents card was never in the
+              budget at all. */}
+          <div
+            className={
+              isActiveRecording
+                ? "order-1 flex min-h-0 flex-1 flex-col"
+                : "order-1 flex min-w-0 flex-col"
+            }
+          >
             {isActiveRecording ? (
               <LiveTranscriptPanel
                 segments={liveTranscript.segments}
@@ -305,7 +321,7 @@ export default function RecordingStatusDisplay({
                 isPaused={isPaused}
               />
             ) : (
-              <section className="density-surface flex h-full min-h-0 flex-col border border-surface-border bg-surface-card shadow-card">
+              <section className="density-surface flex flex-col border border-surface-border bg-surface-card shadow-card">
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
                   <Loader2 className="h-5 w-5 shrink-0 animate-spin text-action-text" />
                   {/* Not "Processing": the console beside this already carries
@@ -355,7 +371,18 @@ export default function RecordingStatusDisplay({
             )}
           </div>
 
-            <div className="order-2 flex min-w-0 flex-col">
+            {/* The other half of the swap above. The editor is already built to
+                absorb, `h-full min-h-0` on the card with `flex-1` on the
+                textarea, it was simply never given any height to absorb. A
+                taller box to type into while a meeting processes is worth
+                having; a taller progress bar is not. */}
+            <div
+              className={
+                isActiveRecording
+                  ? "order-2 flex min-w-0 flex-col"
+                  : "order-2 flex min-h-0 min-w-0 flex-1 flex-col"
+              }
+            >
               <ProcessingNotesPanel
                 value={recording.transcript?.user_notes}
                 onSave={onSaveProcessingNotes}
@@ -375,9 +402,23 @@ export default function RecordingStatusDisplay({
 
           {/* Guidance takes the wider column. It is two lists of prose that
               subdivide again internally, so it is the panel that suffers most
-              from a narrow one. */}
+              from a narrow one.
+
+              It is also this column's absorbing module, which it was not
+              before. Sitting alone in a stretched column at its own content
+              height, it set the grid row for the whole surface, and the column
+              beside it had to find something to do with the surplus. Given a
+              definite height here it scrolls inside its own cell instead, so
+              the row comes from the window rather than from how much guidance
+              has accumulated. Collapsing its sections stops resizing the
+              transcript as a side effect, which is what the ceiling opposite
+              was there to prevent.
+
+              Only from 54rem, where the two columns exist. Below that this is
+              one item in a stack and the page scrolls, so a scroll box inside
+              a scrolling page would be the wrong shape. */}
           {showMeetingEdge ? (
-            <div className="order-4 flex min-h-0 flex-1 flex-col @min-[54rem]:col-start-2 @min-[54rem]:row-start-1">
+            <div className="order-4 flex min-w-0 flex-col @min-[54rem]:col-start-2 @min-[54rem]:row-start-1 @min-[54rem]:min-h-0 @min-[54rem]:flex-1">
               <MeetingEdgePanel
                 payload={recording.transcript?.meeting_edge_payload}
                 focusText={recording.transcript?.meeting_edge_focus}

--- a/frontend/src/components/RecordingStatusDisplay.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.tsx
@@ -156,12 +156,26 @@ export default function RecordingStatusDisplay({
     // The dense shell, not the feature one. This is a console rather than a
     // page of prose: it has a waveform, a transcript, a guidance panel and two
     // editors, and capping it at a reading measure is what forced all five into
-    // one long scroll. The `grow` chain hands the window's leftover height down
-    // to the grid, exactly as the dashboard does.
+    // one long scroll.
+    //
+    // `h-full` rather than the dashboard's `min-h-full`, and that one word is
+    // what makes the two-column layout below a console at all. `min-h-full`
+    // hands down a floor, so the grid row is still sized by whichever column
+    // has the most content and the taller one drags the shorter one with it.
+    // A definite height means the row is the window's leftover and neither
+    // column can push it, which is the only arrangement in which a panel can
+    // decide to scroll: a scroll container needs a height to scroll against.
+    //
+    // The `min-h-0` chain below it is the other half. Without it every flex
+    // item keeps `min-height: auto` and refuses to shrink to that height, so
+    // the definite height is inherited and then ignored. It stops at the grid
+    // section, which takes it only from 54rem: below that this is one stacked
+    // column that should overflow and let the page scroll, so its content is
+    // allowed to push past the bottom rather than being squeezed into it.
     <Workspace
-      wrapperClassName="flex min-h-full flex-col overflow-visible"
-      backgroundClassName="bg-transparent flex grow flex-col"
-      contentClassName="workspace-shell workspace-shell-dense grow"
+      wrapperClassName="flex h-full min-h-0 flex-col overflow-visible"
+      backgroundClassName="bg-transparent flex grow min-h-0 flex-col"
+      contentClassName="workspace-shell workspace-shell-dense grow min-h-0"
     >
       {showMobileBackButton && onBack ? (
         <div className="pointer-events-none fixed left-4 top-[calc(env(safe-area-inset-top)+0.75rem)] z-[var(--z-sticky)] lg:hidden">
@@ -189,7 +203,7 @@ export default function RecordingStatusDisplay({
           it; guidance takes the second and slightly wider one, since it
           subdivides again internally. */}
       <div
-        className={`@container flex grow flex-col gap-[var(--workspace-gap)] ${
+        className={`@container flex min-h-0 grow flex-col gap-[var(--workspace-gap)] ${
           showMobileBackButton && onBack
             ? "pt-[calc(env(safe-area-inset-top)+4.75rem)] lg:pt-0"
             : ""
@@ -284,10 +298,10 @@ export default function RecordingStatusDisplay({
             three too narrow to read comfortably: Meeting Edge subdivides again
             internally, so it was carrying four columns of text inside a third
             of the page. Notes moves under the transcript, which scrolls. */}
-        <section className="flex grow flex-col gap-[var(--workspace-gap)] @min-[54rem]:grid @min-[54rem]:grid-cols-[minmax(0,1fr)_minmax(24rem,1.1fr)] @min-[54rem]:items-stretch">
+        <section className="flex grow flex-col gap-[var(--workspace-gap)] @min-[54rem]:grid @min-[54rem]:min-h-0 @min-[54rem]:grid-cols-[minmax(0,1fr)_minmax(24rem,1.1fr)] @min-[54rem]:grid-rows-[minmax(0,1fr)] @min-[54rem]:items-stretch">
           {/* The meeting's record: what was said, what you wrote, what you
               attached. */}
-          <div className="contents @min-[54rem]:col-start-1 @min-[54rem]:row-start-1 @min-[54rem]:flex @min-[54rem]:min-w-0 @min-[54rem]:flex-col @min-[54rem]:gap-[var(--workspace-gap)]">
+          <div className="contents @min-[54rem]:col-start-1 @min-[54rem]:row-start-1 @min-[54rem]:flex @min-[54rem]:min-h-0 @min-[54rem]:min-w-0 @min-[54rem]:flex-col @min-[54rem]:gap-[var(--workspace-gap)]">
           {/* Exactly one module in this column absorbs the leftover height, and
               which one it is depends on the state. While recording it is the
               transcript, because it scrolls and there is always more of it.


### PR DESCRIPTION
# Pull Request

## Description

The live recording view's two columns sized each other rather than the window, so one of them always ended up holding height it could not use.

Meeting Edge sat alone in a stretched column at its own content height, which made it set the grid row for the whole surface. The ceiling opposite it, a `max-height: calc(100dvh - 18rem)` on the transcript module, existed to stop that dictating the transcript's height. `docs/DESIGN.md` already rules that out: a max-height on a module in an `items-stretch` grid relocates the surplus row height rather than removing it. #234 moved it from inside the transcript card to below the card; this removes it.

The `18rem` was also a budget for the toolbar, the workspace padding and the gap, and none of the three hold still. The toolbar carries an extra row of controls while recording, compact density moves the gap, the padding and the root font size while `100dvh` does not move with them, and the documents card was never in the budget at all.

Three commits, each fixing what the one before it exposed.

**1. Meeting Edge absorbs height instead of setting it.** Everything below its badge becomes one scroll region, so the panel fills the height it is given rather than dictating it, and collapsing its sections stops resizing the transcript as a side effect. The left column's absorbing module now follows the state: the transcript while recording, the notes editor once recording stops, because a progress bar and two lines of status cannot use height. Stretched, that card was most of a screen tall around three lines of content. The `max-h-[22rem]` inner scroller on Technical Context goes too, since it would otherwise be a scroll region inside a scroll region.

**2. The grid row is bound to the window.** Removing the ceiling left nothing sizing the row, so the transcript simply took over from Meeting Edge as the column that grows without limit. The `grow` chain hands down a floor, not a height, and an `auto` grid row takes the max-content of its items regardless of the grid's own height. The shell now takes `h-full` rather than `min-h-full`, `min-h-0` down the chain so each flex item will shrink to it, and an explicit `minmax(0, 1fr)` row. A scroll container needs a height to scroll against, so this is what lets either panel decide to scroll at all.

**3. The transcript sticks before the paint.** The follow-the-conversation scroll ran in a plain effect, so the browser painted the grown transcript at the old scroll position and corrected it a frame later, which read as the text spilling past the bottom of the window and snapping back. Now a layout effect, matching what `useTranscriptScroll` already does for the finished transcript. Keyed on the lines rather than their count while there: a provisional utterance is rewritten in place as it finalises, so its text wraps to more rows without changing how many rows there are, and the length-keyed effect never ran for it.

The height behaviour is scoped to 54rem and above. Below that this is one stacked column that should overflow and let the page scroll, and it still does.

No new dependencies.

Context: #234.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1490 passed)
- [x] Python quality: `python scripts/check.py` (lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests)
- [x] Frontend lint: `cd frontend && npm run lint` (0 errors, 4 pre-existing warnings)
- [x] Frontend unit tests: `cd frontend && npm run test` (486 passed, 62 files)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Also `git diff --check`, clean.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration. Single checked-in head preserved; no committed revisions deleted or renamed. Upgrade and downgrade behaviour described above.

## Documentation impact

- [ ] No documentation change required.
- [x] Updated the relevant guide(s) in the same PR (behaviour, setup, deployment, or support changes must update their guide — see CONTRIBUTING.md "Documentation Ownership").

`docs/DESIGN.md` gains the live capture view's state-dependent absorbing module, and the requirement that this surface's shell hands down a definite height rather than a floor. Both dead ends are recorded there explicitly, including the one this PR created and then fixed, so the next change to this area does not repeat either.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure. `docs/SECURITY.md` boundaries preserved and updated where behaviour changed.

## Manual verification

Smoke-tested on the live recording view and passing. The transcript stops at the bottom of the guidance column and scrolls inside itself rather than growing, and the overflow flash spotted against the second commit is gone.

No paths under `frontend/src/lib/capture/` changed, so capture behaviour itself is untouched here: the share picker, selected microphone, waveform and live state, pause and resume, stop and finalize, discard, and unsupported-browser messaging all run the same code as on `main`.

## Notes for review

`MeetingEdgePanel.tsx` reports 324 changed lines but 40 under `git diff -w`. The rest is re-indentation from the new scroll wrapper, so `-w` is the better read.

Six of the new tests assert class names rather than measurements, because jsdom performs no layout. They catch the layout contract being dropped, which is what went wrong twice here, not a layout that is wrong for some other reason. Each was checked against the previous markup to confirm it fails without its fix. The layout-effect change in the third commit has no test that distinguishes it from a plain effect, for the same reason, and rests on the mechanism and on matching the existing hook.
