### PR TITLE
feat(notes): drop the ID columns from the decisions and actions tables

### DIFF
--- a/backend/tests/test_meeting_intelligence.py
+++ b/backend/tests/test_meeting_intelligence.py
@@ -186,8 +186,8 @@ def test_notes_body_spec_prescribes_tables_for_decisions_and_actions() -> None:
     actions = NOTES_BODY_SPEC.index("## Action Items / Tasks")
     detail = NOTES_BODY_SPEC.index("## Detailed Notes")
 
-    assert "| ID | Decision | Rationale |" in NOTES_BODY_SPEC[decisions:actions]
-    assert "| ID | Action | Owner | Due |" in NOTES_BODY_SPEC[actions:detail]
+    assert "| Decision | Rationale |" in NOTES_BODY_SPEC[decisions:actions]
+    assert "| Action | Owner | Due |" in NOTES_BODY_SPEC[actions:detail]
     # Both tables need the delimiter row or they are not tables at all.
     assert NOTES_BODY_SPEC.count("| --- |") >= 1
 

--- a/backend/utils/meeting_notes.py
+++ b/backend/utils/meeting_notes.py
@@ -30,7 +30,7 @@ NOTES_SPEC_PREAMBLE = """Structure the notes for fast follow-through, not verbat
 
 # The editable half. Bump NOTES_SECTIONS_VERSION whenever this changes so
 # templates forked from an older wording can tell the user their copy is stale.
-NOTES_SECTIONS_VERSION = 1
+NOTES_SECTIONS_VERSION = 2
 
 DEFAULT_NOTES_SECTIONS = """## Summary
 Two to four sentences the reader can scan first: why the meeting happened and what came out of it. Lead with outcomes, not chronology.
@@ -38,20 +38,20 @@ Two to four sentences the reader can scan first: why the meeting happened and wh
 ## Key Decisions
 Each decision the meeting actually reached, one row per decision, paired with the reasoning behind it so it is not re-litigated later. Use exactly this Markdown table, keeping the header row and the delimiter row:
 
-| ID | Decision | Rationale |
-| --- | --- | --- |
-| DEC-001 | The decision that was reached | The reasoning or trade-off behind it |
+| Decision | Rationale |
+| --- | --- |
+| The decision that was reached | The reasoning or trade-off behind it |
 
-Number the IDs sequentially from DEC-001. Omit this entire section if no decisions were reached. Never record a decision that was not made.
+Omit this entire section if no decisions were reached. Never record a decision that was not made.
 
 ## Action Items / Tasks
 Every task, commitment, or follow-up that was actually raised, one row per item. Use exactly this Markdown table, keeping the header row and the delimiter row:
 
-| ID | Action | Owner | Due |
-| --- | --- | --- | --- |
-| ACT-001 | The task that was committed to | A single named person, or Unassigned | A date, or TBD |
+| Action | Owner | Due |
+| --- | --- | --- |
+| The task that was committed to | A single named person, or Unassigned | A date, or TBD |
 
-Number the IDs sequentially from ACT-001. Give each item exactly one owner; never assign a task to the team as a whole. If none were raised, omit the table and write a single line stating that no action items were identified.
+Give each item exactly one owner; never assign a task to the team as a whole. If none were raised, omit the table and write a single line stating that no action items were identified.
 
 ## Detailed Notes
 One ### subsection per major topic, in the order discussed, with the subheading naming the topic. Under each, include only what applies:


### PR DESCRIPTION
## Description

`DEFAULT_NOTES_SECTIONS` in `backend/utils/meeting_notes.py` is the editable half of the shared notes spec, embedded by both note-generation paths: the unified meeting-intelligence prompt and the standalone regeneration prompt. Both of its tables lose their ID column.

- Key Decisions becomes `| Decision | Rationale |`, and the instruction to number IDs sequentially from DEC-001 is gone.
- Action Items / Tasks becomes `| Action | Owner | Due |`, and the instruction to number IDs sequentially from ACT-001 is gone.

The IDs were never referenced by anything. No parser reads them, no export path keys on them, and no other section of the notes cites a decision or an action by its ID, so the column bought a narrower Decision and Action cell for nothing.

`NOTES_SECTIONS_VERSION` moves from 1 to 2, as the comment above it requires when the shipped structure changes. The visible consequence: any saved notes template forked from the old default is now reported stale in Settings > Notes and live assistance, with the existing reset control offered against it. Templates written from scratch carry a null `builtin_version` and are unaffected.

The remaining `DEC-001` and `ACT-001` strings in the repository are fixtures in the editor and export table tests. They exercise Markdown table rendering and are independent of the prompt, so they stay as they are.

No new dependencies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1490 passed)
- [x] Python quality: `python scripts/check.py` (lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests all OK)
- [x] Frontend lint: `cd frontend && npm run lint` (0 errors, 4 pre-existing warnings)
- [x] Frontend unit tests: `cd frontend && npm run test` (62 files, 486 tests passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py` (20 files)
- [x] Alembic validation: `python3 scripts/validate_alembic.py` (head f7a2c6d3b418)

The frontend set was run for completeness; no file under `frontend/` changed.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration. Single checked-in head preserved; no committed revisions deleted or renamed. Upgrade and downgrade behaviour described above.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

`docs/USAGE.md` describes the default structure at the level of "key decisions and action items are presented as tables" and never mentions the ID columns, so it is still accurate. No other guide describes the table shape.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Pending. Nothing was exercised against a running instance. Before merge:

- Regenerate notes on an existing recording and confirm both tables render in the editor with the narrower headers and no ID column.
- Export those notes to DOCX and PDF and confirm the tables survive at the new column counts.
- Open Settings > Notes and live assistance and confirm a template forked from the old default now shows the stale badge, and that its reset control restores the new structure.
