### PR TITLE
build(mcp): migrate the connector to MCP SDK v2

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1,6 +1,6 @@
 """MCP server core for Nojoin.
 
-Holds the FastMCP instance, the registration decorator, the scope guards,
+Holds the MCPServer instance, the registration decorator, the scope guards,
 and the recording/transcript read tools; the rest of the surface lives in
 the ``tools_*`` modules imported at the bottom of this file. Every tool
 delegates to the same endpoint coroutines and helpers the REST API uses
@@ -23,13 +23,14 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, Callable, Optional
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.context import CallNext, ServerRequestContext
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import CallToolResult, Icon, TextContent
-from mcp.types import Tool as MCPTool
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
+from starlette.applications import Starlette
 from starlette.types import ASGIApp
 
 from backend.core.security import MCP_READ_SCOPE, MCP_WRITE_SCOPE
@@ -108,39 +109,56 @@ def _authentication_challenge(tool_name: str) -> CallToolResult:
     )
 
 
-class _AuthGatedFastMCP(FastMCP):
-    """FastMCP that answers anonymous tool calls with an in-band challenge.
+class _AuthGatedMCPServer(MCPServer):
+    """MCPServer that answers anonymous tool calls with an in-band challenge.
 
     This override — not the mcp_tool decorator — is the tool gate, for a
-    mechanical reason: FastMCP validates whatever a tool function returns
-    against the tool's output schema, so a challenge CallToolResult
-    returned from inside the function is rejected before it reaches the
-    wire. call_tool runs before the tool manager, and the lowlevel server
-    forwards a ready-made CallToolResult verbatim. Registered here on the
-    instance, it covers every tool with no per-tool code.
+    mechanical reason: the tool manager validates whatever a tool function
+    returns against the tool's output schema, so a challenge
+    CallToolResult returned from inside the function is rejected before it
+    reaches the wire. call_tool runs before the tool manager, and the
+    lowlevel server forwards a ready-made CallToolResult verbatim.
+    Registered here on the instance, it covers every tool with no per-tool
+    code.
     """
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Optional[Context] = None,
+    ) -> Any:
         if current_mcp_user.get() is None:
             return _authentication_challenge(name)
-        return await super().call_tool(name, arguments)
-
-    async def list_tools(self) -> list[MCPTool]:
-        tools = await super().list_tools()
-        if is_mcp_anonymous_discovery_enabled():
-            # Advertises, pre-auth, that every tool needs OAuth and which
-            # scope — the tool-level metadata OAuth-challenged clients key
-            # off. Tool is an extra="allow" model, so the field serialises
-            # as-is.
-            for tool in tools:
-                scope = _TOOL_SCOPES.get(tool.name, MCP_READ_SCOPE)
-                setattr(
-                    tool, "securitySchemes", [{"type": "oauth2", "scopes": [scope]}]
-                )
-        return tools
+        return await super().call_tool(name, arguments, context)
 
 
-mcp = _AuthGatedFastMCP(
+async def _advertise_tool_scopes(ctx: ServerRequestContext, call_next: CallNext) -> Any:
+    """Attach each tool's OAuth scope to the tool listing, pre-auth.
+
+    Advertises that every tool needs OAuth and which scope — the tool-level
+    metadata OAuth-challenged clients key off. ``securitySchemes`` is not a
+    field of the SDK's Tool model: v1 carried it because Tool was
+    ``extra="allow"`` and the listing could be decorated by setattr on the
+    list_tools result, which v2 removed. Middleware is the replacement
+    because it is the last point that still sees the response as data. The
+    runner has already serialised the handler's result to the wire dict by
+    the time the chain runs, and sends a dict returned from here to the
+    transport without re-validating it against Tool, so the extra field
+    survives where a Tool subclass would be silently dropped.
+    """
+    result = await call_next(ctx)
+    if ctx.method != "tools/list" or not is_mcp_anonymous_discovery_enabled():
+        return result
+    if not isinstance(result, dict):  # pragma: no cover - defensive
+        return result
+    for tool in result.get("tools", []):
+        scope = _TOOL_SCOPES.get(tool.get("name"), MCP_READ_SCOPE)
+        tool["securitySchemes"] = [{"type": "oauth2", "scopes": [scope]}]
+    return result
+
+
+mcp = _AuthGatedMCPServer(
     name="Nojoin",
     instructions=MCP_SERVER_INSTRUCTIONS,
     # Surfaced by MCP clients next to the server name (e.g. Claude's
@@ -153,13 +171,7 @@ mcp = _AuthGatedFastMCP(
             sizes=["1024x1024"],
         )
     ],
-    stateless_http=True,
-    json_response=True,
-    streamable_http_path="/",
-    # The SDK's DNS-rebinding Host check only knows localhost defaults and
-    # would reject the deployment's public hostname. Nojoin's own
-    # TrustedHostMiddleware already validates Host for the whole app.
-    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    middleware=[_advertise_tool_scopes],
 )
 
 
@@ -703,9 +715,40 @@ class NormaliseMcpMountPathMiddleware:
         await self.app(scope, receive, send)
 
 
+_streamable_http_app: Optional[Starlette] = None
+
+
+def _build_streamable_http_app() -> Starlette:
+    """The MCP Starlette app, built exactly once.
+
+    Repeat calls must not reach ``mcp.streamable_http_app()``: it builds a
+    fresh StreamableHTTPSessionManager every time and rebinds
+    ``mcp.session_manager`` to it, so a second call would leave the mounted
+    app holding a manager that nothing ever runs and every request
+    answering 500. Caching here keeps the mount and the lifespan on one
+    manager. The transport settings live here rather than on the
+    constructor because that is where the SDK moved them.
+    """
+    global _streamable_http_app
+    if _streamable_http_app is None:
+        _streamable_http_app = mcp.streamable_http_app(
+            streamable_http_path="/",
+            stateless_http=True,
+            json_response=True,
+            # The SDK's DNS-rebinding Host check only knows localhost
+            # defaults and would reject the deployment's public hostname.
+            # Nojoin's own TrustedHostMiddleware already validates Host for
+            # the whole app.
+            transport_security=TransportSecuritySettings(
+                enable_dns_rebinding_protection=False
+            ),
+        )
+    return _streamable_http_app
+
+
 def build_mcp_asgi_app() -> ASGIApp:
     """The MCP Starlette app wrapped in bearer-token authentication."""
-    return MCPAuthMiddleware(mcp.streamable_http_app())
+    return MCPAuthMiddleware(_build_streamable_http_app())
 
 
 @asynccontextmanager
@@ -716,9 +759,9 @@ async def mcp_session_manager_context():
     returns 500s if requests arrive while the session manager is not
     running.
     """
-    # Ensure the session manager exists (created lazily by
-    # streamable_http_app, which create_app calls before the lifespan runs).
-    mcp.streamable_http_app()
+    # Ensure the session manager exists (created by the app build, which
+    # create_app calls before the lifespan runs).
+    _build_streamable_http_app()
     async with mcp.session_manager.run():
         yield
 

--- a/backend/mcp_server/tool_logging.py
+++ b/backend/mcp_server/tool_logging.py
@@ -13,7 +13,7 @@ import logging
 import time
 from typing import Any, Callable
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from backend.mcp_server.auth import current_mcp_user
 
@@ -79,7 +79,7 @@ def logged_tool(func: Callable) -> Callable:
     Emits one INFO line per successful call (tool, user, redacted args,
     result shape, duration), a WARNING for a ToolError (an expected,
     user-facing rejection), and an EXCEPTION for anything unexpected. The
-    signature is preserved via functools.wraps so FastMCP still builds the
+    signature is preserved via functools.wraps so the SDK still builds the
     tool's input schema from the original annotations.
     """
     signature = inspect.signature(func)

--- a/backend/mcp_server/tools_analytics.py
+++ b/backend/mcp_server/tools_analytics.py
@@ -358,7 +358,7 @@ async def get_meeting_analytics(recording_id: str) -> dict[str, Any]:
     Args:
         recording_id: The recording's string id from list_recordings.
     """
-    from mcp.server.fastmcp.exceptions import ToolError
+    from mcp.server.mcpserver.exceptions import ToolError
 
     from backend.api.v1.endpoints.transcripts.helpers import (
         _get_owned_recording,
@@ -485,7 +485,7 @@ async def analyse_meeting(recording_id: str) -> dict[str, Any]:
     Args:
         recording_id: The recording's string id from list_recordings.
     """
-    from mcp.server.fastmcp.exceptions import ToolError
+    from mcp.server.mcpserver.exceptions import ToolError
 
     from backend.api.v1.endpoints.transcripts.routes_analytics import (
         generate_recording_ai_analytics,

--- a/backend/mcp_server/tools_manage.py
+++ b/backend/mcp_server/tools_manage.py
@@ -12,7 +12,7 @@ the connector at all.
 import logging
 from typing import Any, Optional
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 from sqlmodel import select
 
 from backend.core.security import MCP_WRITE_SCOPE

--- a/backend/mcp_server/tools_people.py
+++ b/backend/mcp_server/tools_people.py
@@ -10,7 +10,7 @@ client.
 import logging
 from typing import Any, Literal, Optional
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload

--- a/backend/mcp_server/tools_search.py
+++ b/backend/mcp_server/tools_search.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Literal, Optional
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 

--- a/backend/mcp_server/tools_tasks.py
+++ b/backend/mcp_server/tools_tasks.py
@@ -10,7 +10,7 @@ Task deletion exists only in the web app.
 import logging
 from typing import Any, Literal, Optional
 
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from backend.core.security import MCP_WRITE_SCOPE
 from backend.mcp_server.auth import get_current_mcp_user

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -2,7 +2,7 @@
 
 Read tools (get_speakers, list_people, get_documents, get_person) and write
 tools (import_people, set_speaker_name, append_meeting_notes) are called
-directly as the plain coroutines registered on the FastMCP instance, with
+directly as the plain coroutines registered on the MCPServer instance, with
 the authenticated user and granted scopes injected through the same
 contextvars the auth middleware sets.
 """
@@ -14,7 +14,7 @@ from datetime import datetime
 
 import pytest
 from fastapi import HTTPException
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker

--- a/backend/tests/test_oauth_mcp_connector.py
+++ b/backend/tests/test_oauth_mcp_connector.py
@@ -933,7 +933,7 @@ async def test_mcp_protocol_tools_list_end_to_end(  # noqa: PLR0913 - one fixtur
     """Full stack: auth middleware -> MCP SDK streamable HTTP -> tools/list.
 
     Also hosts the anonymous-discovery protocol phases: the SDK allows one
-    session-manager .run() per FastMCP instance and therefore one such
+    session-manager .run() per MCPServer instance and therefore one such
     context per test process, so every phase that needs the real MCP app
     shares this test's context. The anonymous sweep below makes one
     tools/call per registered tool, so lift the per-IP anonymous limit out
@@ -1111,7 +1111,7 @@ async def test_mcp_protocol_tools_list_end_to_end(  # noqa: PLR0913 - one fixtur
     # A grant issued before mcp:write existed passes the endpoint gate but
     # the write tool refuses it with an instruction to reconnect. This must
     # share the session-manager context above: the SDK allows only one
-    # .run() per FastMCP instance and therefore one such context per test
+    # .run() per MCPServer instance and therefore one such context per test
     # process.
     assert import_refusal.status_code == 200, import_refusal.text
     result = import_refusal.json()["result"]

--- a/requirements/backend.txt
+++ b/requirements/backend.txt
@@ -1,7 +1,7 @@
 -r base.txt
 fastapi==0.141.1
 uvicorn[standard]==0.52.1
-mcp==1.28.1
+mcp==2.0.0
 # Backend specific dependencies
 docker==7.2.0
 celery[redis]==5.6.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,5 +15,5 @@ httpx==0.28.1
 #   CVE-2026-40192 (FITS decompression-bomb DoS), CVE-2026-42311.
 urllib3==2.7.0
 pillow==12.3.0
-alembic==1.18.5
+alembic==1.19.0
 pgvector==0.5.0


### PR DESCRIPTION
## Description

Supersedes #231, the grouped Dependabot bump. That PR failed `Backend tests` because `mcp` 2.0.0 removes the `mcp.server.fastmcp` package entirely, collapsing ten test modules at collection. The SDK migration is done here instead, and the `alembic` half of the group rides along as its own commit.

The auth gate survives largely intact: `MCPServer.call_tool` is still an overridable hook and the lowlevel server still forwards a ready-made `CallToolResult` verbatim, so the in-band OAuth challenge works unchanged (it gained a `context` parameter). Two v1 behaviours had no direct port:

- **`securitySchemes` on the anonymous tool listing.** v1 attached this non-standard field by `setattr`, relying on `Tool` being `extra="allow"`. v2 removed that. A `Tool` subclass does not work either: pydantic silently drops subclass fields when serialising the nested `list[Tool]`. It is now added by a `ServerMiddleware`, which is the last point that still sees the listing as a plain wire dict — the runner serialises the handler result before the chain runs and passes a returned dict to the transport without re-validating it against `Tool`. This is the field Codex Desktop keys off pre-OAuth, and `test_mcp_protocol_tools_list_end_to_end` covers it.
- **Session-manager lifetime.** v1 cached the `StreamableHTTPSessionManager`; v2 builds a new one per `streamable_http_app()` call and rebinds `mcp.session_manager`. This repo calls it from both the mount and the lifespan helper, so under v2 the mounted app would have held a manager nothing ever ran and every `/mcp` request would answer 500. The app is now built once and shared.

No behaviour change for operators or connected clients: same tools, same scopes, same OAuth flow, no configuration change.

New dependencies: `mcp` 2.0.0 pulls in `httpx2` (2.9.1) and `mcp-types` (2.0.0). `httpx2` is distinct from the pinned `httpx==0.28.1`, which stays for the rest of the codebase, so both now ship in the API image. Nothing is pinned against `httpx2`; worth a deliberate pin later if it should be held like `urllib3` and `pillow`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

`python scripts/check.py` passed in full: lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests (1490 passed). The frontend checks are not ticked because no path under `frontend/` changed.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

`alembic` moves 1.18.5 to 1.19.0, but no revision files change. The graph validates at head `f7a2c6d3b418`.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

`docs/MCP.md` describes connector behaviour, which is unchanged, including the anonymous-discovery contract that the end-to-end test still asserts.

## Security impact

- [ ] No security-sensitive change.
- [x] Touches auth, tokens, encryption, capture ownership, or exposure. `docs/SECURITY.md` boundaries preserved and updated where behaviour changed.

The MCP auth gate is re-implemented on the v2 base class, but the boundary is unchanged: anonymous tool calls still get the in-band challenge rather than executing, the write-scope guard still refuses pre-`mcp:write` grants, and `MCP_ANONYMOUS_DISCOVERY=false` still returns a strict 401. All three are asserted end to end through the real ASGI stack in `test_oauth_mcp_connector.py`. No `docs/SECURITY.md` change needed.

## Manual verification

None yet. The connector path is covered end to end in tests through the real MCP ASGI app (handshake, `tools/list`, authenticated and anonymous `tools/call`, write-scope refusal, discovery disabled), but a live smoke test against a deployed instance with a real client is still worth doing before merge.