### PR TITLE
fix(frontend): position floating panels against the viewport

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -27,6 +27,12 @@ const nextConfig: NextConfig = {
   output: "standalone",
   poweredByHeader: false,
   reactCompiler: true,
+  // `next dev` writes AGENTS.md and CLAUDE.md into frontend/ on every start
+  // when it detects an AI coding agent, to point that agent at the docs bundled
+  // in node_modules. This repository does not carry agent rules files, so the
+  // only thing that arrives is two untracked files in the working tree of
+  // whoever happened to run the dev server.
+  agentRules: false,
   turbopack: {
     root: __dirname,
   },

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -512,6 +512,14 @@ html[data-ui-density="compact"] .density-body-copy {
   border-color: var(--contrast-icon-muted);
 }
 
+/* ModernDatePicker measures the room on the side the popover was placed and
+   publishes it here. Without the cap a calendar taller than that room is drawn
+   off the top of the screen, which a narrow phone in landscape can reach. */
+.react-datepicker-popper .react-datepicker {
+  max-height: var(--nj-picker-max-height, none);
+  overflow-y: auto;
+}
+
 /* The popover form of the picker, on a screen too narrow to hold the month and
    the time list side by side. The library floats them, and a float does not
    wrap gracefully: below about 340px of usable width the time column drops past

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -512,6 +512,82 @@ html[data-ui-density="compact"] .density-body-copy {
   border-color: var(--contrast-icon-muted);
 }
 
+/* The popover form of the picker, on a screen too narrow to hold the month and
+   the time list side by side. The library floats them, and a float does not
+   wrap gracefully: below about 340px of usable width the time column drops past
+   the calendar's own box, leaving a tall void beside the weeks and pushing the
+   whole popover off the top of the screen (issue #242). Stack them instead.
+
+   Scoped to the popper, so the inline calendar below -- laid out by its own
+   container, in a modal that already sized itself for it -- is untouched. The
+   breakpoint sits under the common 360px phone on purpose: at that width the
+   library's own layout fits once ModernDatePicker positions it against the
+   viewport, and the side-by-side calendar is the better of the two. */
+@media (max-width: 22rem) {
+  .react-datepicker-popper .react-datepicker {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* width:auto, not 100%: the popper is shrink-to-fit, so a percentage width
+     resolves against a container whose width depends on it and collapses the
+     calendar. The column's stretch alignment already gives both panels the
+     full width the month asks for. */
+  .react-datepicker-popper .react-datepicker__month-container {
+    float: none;
+    width: auto;
+  }
+
+  .react-datepicker-popper .react-datepicker__time-container {
+    float: none;
+    width: auto;
+    border-left: 0;
+    border-top: 1px solid var(--surface-divider);
+  }
+
+  .react-datepicker-popper
+    .react-datepicker__time-container
+    .react-datepicker__time
+    .react-datepicker__time-box {
+    width: auto;
+  }
+
+  /* The library sizes the time list to the month's height from JS, and writes
+     it inline, which is right beside the calendar and doubles the popover when
+     it is underneath. !important is the only thing an inline style loses to,
+     and this file already reaches for it against this vendor. */
+  .react-datepicker-popper .react-datepicker__time-list {
+    height: 4rem !important;
+  }
+
+  /* The next-month arrow is inset by the width of the time column, which is
+     only where it belongs while the column is beside the calendar. Stacked, the
+     arrow lands on top of the month name. */
+  .react-datepicker-popper
+    .react-datepicker__navigation--next--with-time:not(
+      .react-datepicker__navigation--next--with-today-button
+    ) {
+    right: 2px;
+  }
+
+  .react-datepicker-popper .react-datepicker__day-names,
+  .react-datepicker-popper .react-datepicker__week {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  /* The grid lets a day fill its column, but a column is only as wide as its
+     content and the popper is shrink-to-fit: without a floor the calendar
+     collapses to the width of two digits. The floor is also a larger tap
+     target than the library's 1.7rem cell. */
+  .react-datepicker-popper .react-datepicker__day-name,
+  .react-datepicker-popper .react-datepicker__day {
+    width: auto;
+    min-width: 2.25rem;
+    margin: 0.166rem 0;
+  }
+}
+
 .task-deadline-calendar.react-datepicker {
   width: 100%;
   border: 0;

--- a/frontend/src/components/ColorPicker.tsx
+++ b/frontend/src/components/ColorPicker.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Check } from 'lucide-react';
 import { COLOR_PALETTE, ColorOption } from '@/lib/constants';
+import { useAnchoredPanel } from '@/components/ui/useAnchoredPanel';
 
 interface ColorPickerProps {
   selectedColor?: string;
@@ -19,6 +20,10 @@ export default function ColorPicker({
 }: ColorPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Anchored to the window rather than to the trigger's scroll box. PersonModal
+  // puts this near the foot of a long form, where an absolutely positioned panel
+  // renders into the part the modal clips and reads as not having opened.
+  const { panelRef, panelStyle } = useAnchoredPanel<HTMLDivElement>(isOpen, containerRef);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -71,7 +76,11 @@ export default function ColorPicker({
       )}
 
       {isOpen && (
-        <div className="absolute z-[var(--z-dropdown)] mt-2 p-3 bg-surface-card rounded-xl shadow-float border border-surface-border min-w-[280px]">
+        <div
+          ref={panelRef}
+          style={panelStyle}
+          className="z-[var(--z-dropdown)] overflow-y-auto p-3 bg-surface-card rounded-xl shadow-float border border-surface-border min-w-[280px]"
+        >
           <div className="grid grid-cols-6 gap-2">
             {COLOR_PALETTE.map((color) => (
               <button
@@ -108,6 +117,9 @@ interface InlineColorPickerProps {
 export function InlineColorPicker({ selectedColor, onColorSelect }: InlineColorPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Same reason as above, a different enclosure: this one opens from rows in the
+  // tag rail and the speaker panel, both of which scroll and clip.
+  const { panelRef, panelStyle } = useAnchoredPanel<HTMLDivElement>(isOpen, containerRef);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -141,7 +153,9 @@ export function InlineColorPicker({ selectedColor, onColorSelect }: InlineColorP
 
       {isOpen && (
         <div
-          className="absolute left-0 top-full mt-1 z-[var(--z-dropdown)] p-2 bg-surface-card rounded-lg shadow-float border border-surface-border min-w-max"
+          ref={panelRef}
+          style={panelStyle}
+          className="z-[var(--z-dropdown)] overflow-y-auto p-2 bg-surface-card rounded-lg shadow-float border border-surface-border min-w-max"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="grid grid-cols-6 gap-2">

--- a/frontend/src/components/people/PersonModal.tsx
+++ b/frontend/src/components/people/PersonModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { X, Plus, Users, Fingerprint, ArrowRight } from "lucide-react";
 import Button from "@/components/ui/Button";
 import Modal from "@/components/ui/Modal";
@@ -14,6 +14,7 @@ import {
   deleteGlobalSpeakerEmbedding,
 } from "@/lib/api";
 import ConfirmationModal from "@/components/ConfirmationModal";
+import { useAnchoredPanel } from "@/components/ui/useAnchoredPanel";
 import { useNotificationStore } from "@/lib/notificationStore";
 
 interface PersonModalProps {
@@ -58,6 +59,13 @@ export function PersonModal({
   const [showMerge, setShowMerge] = useState(false);
   const [mergeTarget, setMergeTarget] = useState<GlobalSpeaker | null>(null);
   const [speakerSearch, setSpeakerSearch] = useState("");
+  // The merge section is the last thing in this modal, so its results list opens
+  // into the region the modal's panel clips. Anchor it to the window instead.
+  const speakerSearchRef = useRef<HTMLDivElement>(null);
+  const { panelRef: speakerResultsRef, panelStyle: speakerResultsStyle } =
+    useAnchoredPanel<HTMLDivElement>(Boolean(speakerSearch), speakerSearchRef, {
+      matchAnchorWidth: true,
+    });
   const [availableSpeakers, setAvailableSpeakers] = useState<GlobalSpeaker[]>(
     [],
   );
@@ -465,7 +473,7 @@ interface TagNode extends PeopleTag {
                           Target Person (Recipient)
                         </label>
                         {!mergeTarget ? (
-                          <div className="relative">
+                          <div className="relative" ref={speakerSearchRef}>
                             <input
                               type="text"
                               value={speakerSearch}
@@ -474,7 +482,11 @@ interface TagNode extends PeopleTag {
                               placeholder="Search person..."
                             />
                             {speakerSearch && (
-                              <div className="absolute z-10 mt-1 w-full bg-control-bg rounded-md shadow-float border border-surface-border max-h-48 overflow-y-auto">
+                              <div
+                                ref={speakerResultsRef}
+                                style={speakerResultsStyle}
+                                className="z-10 bg-control-bg rounded-md shadow-float border border-surface-border overflow-y-auto"
+                              >
                                 {filteredSpeakers.length === 0 ? (
                                   <div className="px-3 py-2 text-sm text-contrast-helper">
                                     No people found

--- a/frontend/src/components/ui/ModernDatePicker.test.tsx
+++ b/frontend/src/components/ui/ModernDatePicker.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import Modal from "./Modal";
+import ModernDatePicker from "./ModernDatePicker";
+
+/**
+ * The picker's usual home is inside a modal, and that is where its positioning
+ * used to fail: a modal panel hides its own overflow and scrolls its body, so
+ * an absolutely positioned popper is a child of that scroll box. The library
+ * measured the free space inside the box rather than in the window, flipped the
+ * calendar upwards for want of room, and the panel clipped everything that
+ * crossed its header (issue #242). Asking for the fixed strategy is what takes
+ * the popper out of the box, so that is what is asserted here. jsdom does no
+ * layout, so the rest of the fix -- the viewport bounds and the stacked mobile
+ * layout -- lives in globals.css and is verified in a browser.
+ */
+describe("ModernDatePicker", () => {
+  it("positions the calendar against the viewport rather than its scroll box", () => {
+    render(<ModernDatePicker selected={null} onChange={vi.fn()} placeholderText="Pick one" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Pick one" }));
+
+    const popper = document.querySelector(".react-datepicker-popper");
+    expect(popper).not.toBeNull();
+    expect((popper as HTMLElement).style.position).toBe("fixed");
+  });
+
+  it("keeps the calendar inside the modal, where the focus trap can reach it", () => {
+    render(
+      <Modal open onClose={vi.fn()} title="Import Audio">
+        <ModernDatePicker selected={null} onChange={vi.fn()} placeholderText="Pick one" />
+      </Modal>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Pick one" }));
+
+    // Portalling the popper to the body would escape the clipping too, and take
+    // it outside the dialog: Headless UI would read a click on a day as a click
+    // outside the panel and close the modal under the user.
+    const popper = document.querySelector(".react-datepicker-popper");
+    expect(popper).not.toBeNull();
+    const dialogs = screen.getAllByRole("dialog");
+    expect(dialogs.some((dialog) => dialog.contains(popper))).toBe(true);
+  });
+});

--- a/frontend/src/components/ui/ModernDatePicker.tsx
+++ b/frontend/src/components/ui/ModernDatePicker.tsx
@@ -63,6 +63,14 @@ export default function ModernDatePicker({
           onChange={(date: Date | null) => onChange(date)}
           customInput={<CustomInput placeholder={placeholderText} className={inputClassName} />}
           wrapperClassName="w-full"
+          // Position against the viewport, not the nearest scroll box. Every
+          // modal panel hides its own overflow and scrolls its body, so an
+          // absolutely positioned popper is a child of that box: the library
+          // measures the free space inside it, flips the calendar upwards for
+          // want of room, and the panel then clips whatever crosses its header.
+          // The fixed strategy takes the popper out of that box; globals.css
+          // bounds it against the viewport instead.
+          popperProps={{ strategy: "fixed" }}
           // react-datepicker renders its own DOM, so the calendar is themed by
           // overriding its classes here and in the vendor block in globals.css
           // rather than by composing tokens the way the rest of the UI does.

--- a/frontend/src/components/ui/ModernDatePicker.tsx
+++ b/frontend/src/components/ui/ModernDatePicker.tsx
@@ -39,6 +39,49 @@ const CustomInput = forwardRef<HTMLButtonElement, CustomInputProps>(
 
 CustomInput.displayName = "CustomInput";
 
+/**
+ * Caps the calendar to the space on the side the popover was actually placed,
+ * so it scrolls inside itself rather than off the top of a short window.
+ *
+ * floating-ui ships `size` for this, but importing it here would bind a second
+ * copy of the library: react-datepicker resolves its own nested
+ * @floating-ui/react at 0.27 while the tree hoists 0.26 for Headless UI, and
+ * middleware from the wrong instance is not something to rely on. A middleware
+ * is a plain object, and the rule is one line once the placement is known.
+ *
+ * It reads the trigger's own rect rather than the rects floating-ui passes,
+ * because those are expressed relative to the offset parent while this needs
+ * window coordinates. It runs last, so the placement it sees is final. Writing
+ * a custom property rather than a height keeps the value where the stylesheet
+ * can use it and leaves the popover's own box to the library.
+ */
+const boundToViewport = {
+  name: "nojoinBoundToViewport",
+  fn({
+    placement,
+    elements,
+  }: {
+    placement: string;
+    elements: {
+      // Widened from DOMRect: floating-ui's reference may be a virtual element,
+      // whose rect type is structural rather than a DOMRect.
+      reference: { getBoundingClientRect: () => { top: number; bottom: number } };
+      floating: HTMLElement;
+    };
+  }) {
+    const anchor = elements.reference.getBoundingClientRect();
+    const gap = 16;
+    const available = placement.startsWith("top")
+      ? anchor.top - gap
+      : window.innerHeight - anchor.bottom - gap;
+    elements.floating.style.setProperty(
+      "--nj-picker-max-height",
+      `${Math.max(200, Math.round(available))}px`,
+    );
+    return {};
+  },
+};
+
 export default function ModernDatePicker({
   label,
   className,
@@ -71,6 +114,7 @@ export default function ModernDatePicker({
           // The fixed strategy takes the popper out of that box; globals.css
           // bounds it against the viewport instead.
           popperProps={{ strategy: "fixed" }}
+          popperModifiers={[boundToViewport]}
           // react-datepicker renders its own DOM, so the calendar is themed by
           // overriding its classes here and in the vendor block in globals.css
           // rather than by composing tokens the way the rest of the UI does.

--- a/frontend/src/components/ui/useAnchoredPanel.test.tsx
+++ b/frontend/src/components/ui/useAnchoredPanel.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ColorPicker from "@/components/ColorPicker";
+
+/**
+ * The panels this hook positions live inside modals and scrolling rails, both
+ * of which hide their own overflow. Positioned the ordinary way they render
+ * into the clipped region and read as not having opened at all. So the two
+ * things worth asserting are that the panel leaves that box -- fixed, not
+ * absolute -- and that it flips above its trigger when below cannot hold it.
+ *
+ * jsdom lays nothing out, so the measurements the hook reads are stubbed.
+ */
+
+const ORIGINAL_HEIGHT = window.innerHeight;
+const ORIGINAL_RECT = HTMLElement.prototype.getBoundingClientRect;
+
+function stubLayout({ triggerTop, panelHeight }: { triggerTop: number; panelHeight: number }) {
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 600 });
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 360 });
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    value: panelHeight,
+  });
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    return {
+      top: triggerTop,
+      bottom: triggerTop + 40,
+      left: 20,
+      right: 120,
+      width: 100,
+      height: 40,
+      x: 20,
+      y: triggerTop,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+}
+
+const panelOf = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>('[style*="position: fixed"]');
+
+afterEach(() => {
+  HTMLElement.prototype.getBoundingClientRect = ORIGINAL_RECT;
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: ORIGINAL_HEIGHT });
+  vi.restoreAllMocks();
+});
+
+describe("useAnchoredPanel", () => {
+  it("takes the panel out of the scroll box that would clip it", () => {
+    stubLayout({ triggerTop: 100, panelHeight: 200 });
+    const { container } = render(<ColorPicker onColorSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select color/i }));
+
+    expect(panelOf(container)).not.toBeNull();
+  });
+
+  it("opens below the trigger when there is room", () => {
+    stubLayout({ triggerTop: 100, panelHeight: 200 });
+    const { container } = render(<ColorPicker onColorSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select color/i }));
+
+    // trigger bottom 140, plus the 8px gap.
+    expect(panelOf(container)?.style.top).toBe("148px");
+  });
+
+  it("flips above the trigger when below cannot hold the panel", () => {
+    stubLayout({ triggerTop: 500, panelHeight: 300 });
+    const { container } = render(<ColorPicker onColorSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select color/i }));
+
+    // 44px below against 484 above, so above: 500 - 8 gap - 300 tall.
+    expect(panelOf(container)?.style.top).toBe("192px");
+  });
+
+  it("caps the panel to the side it chose rather than letting it run off screen", () => {
+    stubLayout({ triggerTop: 20, panelHeight: 900 });
+    const { container } = render(<ColorPicker onColorSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select color/i }));
+
+    const panel = panelOf(container);
+    // Neither side fits 900; below is the roomier, so it is capped and scrolls:
+    // 600 viewport less the trigger's 60 bottom, the 8px gap and the 8px margin.
+    expect(panel?.style.maxHeight).toBe("524px");
+    expect(panel?.style.top).toBe("68px");
+  });
+});

--- a/frontend/src/components/ui/useAnchoredPanel.ts
+++ b/frontend/src/components/ui/useAnchoredPanel.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { type RefObject, useCallback, useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Anchors a floating panel to a trigger with viewport-relative positioning.
+ *
+ * A panel positioned the ordinary way -- `absolute`, inside the element that
+ * opened it -- belongs to whatever scroll box encloses it. Inside a modal that
+ * box is the panel body, and the modal hides its own overflow, so a dropdown
+ * opened near the foot of a long form renders into the region the modal clips
+ * and appears not to have opened at all. It is still there, and scrolling
+ * reaches it, but the user has no way to know that. A panel wider than the
+ * modal's content box loses its right edge outright, with no scroll to recover
+ * it.
+ *
+ * `position: fixed` takes the panel out of that box and measures it against the
+ * window instead, which is the same reason ModernDatePicker asks react-datepicker
+ * for the fixed strategy. The panel stays where it is in the DOM, so a focus
+ * trap still contains it and Headless UI does not read a click inside it as a
+ * click outside the dialog -- both of which portalling to the body would break.
+ *
+ * The arithmetic is the one SpeakerAssignmentPopover arrived at: prefer below
+ * the trigger, flip above when below cannot hold the panel and above is roomier,
+ * cap the height to whichever side was chosen so the content scrolls inside the
+ * panel rather than off the screen, and clamp both axes to the viewport.
+ */
+
+const GAP = 8; // between trigger and panel
+const MARGIN = 8; // smallest gap to a viewport edge
+const MIN_HEIGHT = 120; // below this a panel is not worth showing shorter
+
+export interface AnchoredPanelStyle {
+  position: "fixed";
+  top: number;
+  left: number;
+  /** Absent on the measuring pass, which has to see the panel's natural size. */
+  maxHeight?: number;
+  maxWidth?: number;
+  /** Only when matchAnchorWidth is asked for. */
+  width?: number;
+  visibility: "hidden" | "visible";
+}
+
+interface AnchoredPanelOptions {
+  /** Size the panel to its trigger, for a dropdown that used to be `w-full`
+   *  inside it. Fixed positioning takes that percentage away. */
+  matchAnchorWidth?: boolean;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), Math.max(min, max));
+
+export function useAnchoredPanel<Panel extends HTMLElement = HTMLElement>(
+  open: boolean,
+  anchorRef: RefObject<HTMLElement | null>,
+  { matchAnchorWidth = false }: AnchoredPanelOptions = {},
+) {
+  const panelRef = useRef<Panel>(null);
+  const [style, setStyle] = useState<AnchoredPanelStyle | null>(null);
+
+  const reposition = useCallback(() => {
+    const anchor = anchorRef.current;
+    const panel = panelRef.current;
+    if (!anchor || !panel) return;
+
+    const rect = anchor.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    // scrollHeight, not offsetHeight: once a max-height is applied the panel
+    // stops reporting what it actually wants, and the placement would then
+    // oscillate between the two sides on every reposition.
+    const wantedHeight = panel.scrollHeight;
+    const width = Math.min(
+      matchAnchorWidth ? rect.width : panel.offsetWidth,
+      viewportWidth - MARGIN * 2,
+    );
+
+    const availableBelow = Math.max(0, viewportHeight - rect.bottom - GAP - MARGIN);
+    const availableAbove = Math.max(0, rect.top - GAP - MARGIN);
+    const placeAbove = availableBelow < wantedHeight && availableAbove > availableBelow;
+
+    const maxHeight = Math.max(
+      MIN_HEIGHT,
+      placeAbove ? availableAbove : availableBelow,
+    );
+    const renderedHeight = Math.min(wantedHeight, maxHeight);
+
+    setStyle({
+      position: "fixed",
+      top: clamp(
+        placeAbove ? rect.top - GAP - renderedHeight : rect.bottom + GAP,
+        MARGIN,
+        viewportHeight - renderedHeight - MARGIN,
+      ),
+      left: clamp(rect.left, MARGIN, viewportWidth - width - MARGIN),
+      maxHeight,
+      maxWidth: viewportWidth - MARGIN * 2,
+      ...(matchAnchorWidth ? { width } : {}),
+      visibility: "visible",
+    });
+  }, [anchorRef, matchAnchorWidth]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setStyle(null);
+      return;
+    }
+    reposition();
+    window.addEventListener("resize", reposition);
+    // Capture phase: the scroll that moves the trigger is the modal body's, not
+    // the window's, and a scroll event does not bubble.
+    window.addEventListener("scroll", reposition, true);
+    return () => {
+      window.removeEventListener("resize", reposition);
+      window.removeEventListener("scroll", reposition, true);
+    };
+  }, [open, reposition]);
+
+  return {
+    panelRef,
+    /** Spread onto the panel. The measuring pass is hidden and deliberately
+     *  unconstrained: capping it there would have the panel measure the size it
+     *  was given rather than the size it wants. useLayoutEffect replaces this
+     *  before the browser paints, so nothing flashes. */
+    panelStyle: style ?? {
+      position: "fixed" as const,
+      top: 0,
+      left: 0,
+      visibility: "hidden" as const,
+    },
+    reposition,
+  };
+}


### PR DESCRIPTION
# Pull Request

## Description

On a mobile viewport the date-time picker in the Import Audio modal opened upwards, over the modal header, with its top rows cut off.

A modal panel hides its own overflow and scrolls its body, so an absolutely positioned popover is a child of that scroll box. react-datepicker measured the free space inside the box rather than in the window: it found no room below the field, flipped the calendar upwards, and the panel clipped everything that crossed its header. The picker was also confined to the modal's 288px of content width, which is narrower than its own side-by-side layout needs, so the time column wrapped past the calendar and left the void in the issue screenshot.

The fix is the fixed positioning strategy, which measures the popover against the viewport instead. At 360px the calendar now opens below the field, whole and unclipped, and the library's own layout fits. Below 22rem the month and time list are stacked, because they genuinely cannot sit side by side there. The picker also measures the room on the side it was placed and caps its height to it, so on a short window it scrolls inside itself rather than off the top of the screen.

A sweep for the same pattern found three more floating panels with the same fault: `ColorPicker` and `InlineColorPicker`, and the merge-target search in `PersonModal`. They open into the part their container clips, so they read as controls that do nothing until you happen to scroll; at 320px the colour panel also lost its right edge with no scroll able to recover it. All three now anchor to the window through a new `useAnchoredPanel` hook, which is `SpeakerAssignmentPopover`'s existing arithmetic extracted rather than written a fourth time.

The panels stay where they are in the DOM. Portalling them to the body, which the context menus do, would escape the clipping too but would put them outside the dialog's focus trap and make a click on a swatch read as a click outside the modal, closing it under the user. There is a test for that.

No new dependencies. floating-ui ships a `size` middleware that does what the height cap does, but importing it would bind a second copy of the library: react-datepicker resolves its own nested `@floating-ui/react` at 0.27 while the tree hoists 0.26 for Headless UI. A middleware is a plain object, so the rule is stated directly instead.

One unrelated commit rides along, `chore(frontend): stop next dev writing agent rules files`. `next dev` writes `AGENTS.md` and `CLAUDE.md` into `frontend/` on every start; this repository tracks neither, so all it did was leave two untracked files in the working tree. It is a single config line and separable if it would rather go on its own.

Fixes #242

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 1490 passed
- [x] Python quality: `python scripts/check.py` — OK
- [x] Frontend lint: `cd frontend && npm run lint` — 0 errors (4 pre-existing warnings in untouched files)
- [x] Frontend unit tests: `cd frontend && npm run test` — 492 passed across 64 files
- [x] Frontend build: `cd frontend && npm run build` — compiled successfully
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

Also run: `npm run check:contrast` (302 pairings across 4 themes), `npx tsc --noEmit`, `git diff --check`.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

No user-facing workflow changed. The picker and the dropdowns do what the docs already say they do; they now do it where the user can see them.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

## Manual verification

Driven in headless Chromium against a dev build, measuring the rendered geometry rather than eyeballing it. No capture paths are touched, so the browser capture smoke set does not apply.

Date picker in a modal, with `showTimeSelect`:

| Viewport | Before | After |
| --- | --- | --- |
| 360 x 740 | flipped up, clipped by the header, time column wrapped | opens below the field, fully visible, time list scrolled to the selection |
| 320 x 740 | 158px off the top of the screen | stacked layout, fully inside the viewport |
| 320 x 600 | 60px off the top | fully inside, calendar scrolls internally |
| 768 x 900 | unaffected | unchanged, opens below |

Colour picker opened from the foot of a modal:

| Viewport | Before | After |
| --- | --- | --- |
| 360 x 740 | invisible until the modal body was scrolled | flips above the trigger, fully visible |
| 320 x 740 | 13px of the panel clipped, unrecoverable | nothing clipped, all swatches reachable |

Also checked that the inline calendar in `TaskDeadlineModal` is unaffected: every new CSS rule is scoped to `.react-datepicker-popper`, and that calendar renders inline with no popper.

Not covered by automation: `InlineColorPicker`'s other two homes, the tag rail and the speaker panel, were reasoned about from the same hook rather than measured individually. Worth a click in each before merge.
