### PR TITLE
fix(codex): resolve the binary path when compose sets it empty

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -7,7 +7,11 @@ logger = logging.getLogger(__name__)
 def setup_secure_umask():
     # Default secure umask (owner only)
     default_umask_str = "0077"
-    umask_env = os.getenv("NOJOIN_UMASK", default_umask_str).strip()
+    # Compose declares NOJOIN_UMASK on every service, so an operator who leaves
+    # it blank sends an empty string rather than nothing at all. Treat that as
+    # unset: read as a get() default it reached int() and logged an "invalid
+    # value" warning on every start of an otherwise correctly configured stack.
+    umask_env = os.getenv("NOJOIN_UMASK", "").strip() or default_umask_str
 
     try:
         # Support octal strings (e.g. "0077" or "0o077") or decimal integers

--- a/backend/processing/cli/codex_driver.py
+++ b/backend/processing/cli/codex_driver.py
@@ -48,7 +48,11 @@ from backend.utils.vision import VisionImage
 logger = logging.getLogger(__name__)
 
 # Absolute path to the codex binary in the worker-io image (CX-6 installs it).
-CODEX_PATH = os.environ.get("NOJOIN_CODEX_PATH", "/usr/local/bin/codex")
+# Read with ``or`` rather than a get() default: compose declares the variable on
+# the worker lanes so an operator can override it, which means it arrives set but
+# empty whenever they have not, and an empty string is a path the default would
+# otherwise never replace.
+CODEX_PATH = os.environ.get("NOJOIN_CODEX_PATH", "").strip() or "/usr/local/bin/codex"
 DEFAULT_TIMEOUT_SECONDS = 300
 
 _RATE_LIMIT_TOKENS = (
@@ -220,9 +224,14 @@ class CodexExecDriver:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
             )
-        except FileNotFoundError as exc:
+        except OSError as exc:
+            # Not just FileNotFoundError: a path that exists but is not
+            # executable raises PermissionError, and letting that propagate put
+            # a bare errno in front of the user instead of naming the setting
+            # that produced it.
             raise CliOAuthUnavailableError(
-                f"Codex CLI not found at {CODEX_PATH}."
+                f"Codex CLI could not be run at {CODEX_PATH!r} ({exc}). "
+                "Check NOJOIN_CODEX_PATH."
             ) from exc
         try:
             stdout, stderr = await asyncio.wait_for(

--- a/backend/processing/cli/codex_login.py
+++ b/backend/processing/cli/codex_login.py
@@ -30,7 +30,9 @@ logger = logging.getLogger(__name__)
 
 # Path to the codex binary (kept in sync with codex_driver.CODEX_PATH; duplicated
 # as a literal to avoid importing the driver — and its manager import — here).
-CODEX_PATH = os.environ.get("NOJOIN_CODEX_PATH", "/usr/local/bin/codex")
+# The empty-string guard matters for the same reason it does there: compose sets
+# the variable on every worker lane whether or not the operator filled it in.
+CODEX_PATH = os.environ.get("NOJOIN_CODEX_PATH", "").strip() or "/usr/local/bin/codex"
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 _URL = re.compile(r"https://auth\.openai\.com/\S*device\S*")

--- a/backend/tests/test_compose_env_plumbing.py
+++ b/backend/tests/test_compose_env_plumbing.py
@@ -33,6 +33,7 @@ ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
 SHARED_ANCHOR = "x-shared-app-environment"
 
 _ENV_KEY_RE = re.compile(r"^(\s+)([A-Z][A-Z0-9_]*):")
+_BLANK_DEFAULT_RE = re.compile(r"^\s+([A-Z][A-Z0-9_]*):\s*\$\{\1:-\}\s*$", re.MULTILINE)
 
 
 def _shared_anchor_env_keys(text: str) -> set[str]:
@@ -54,6 +55,35 @@ def _shared_anchor_env_keys(text: str) -> set[str]:
         if match:
             keys.add(match.group(2))
     return keys
+
+
+def _blank_default_keys(text: str) -> set[str]:
+    """Variables the compose file declares with no fallback of its own.
+
+    ``FOO: ${FOO:-}`` is the template's way of saying "the code owns this
+    default". Compose still sets the variable, so the process sees an empty
+    string rather than nothing, anywhere in the file — not only in the shared
+    anchor, since the worker lanes carry their own.
+    """
+    return set(_BLANK_DEFAULT_RE.findall(text))
+
+
+def _code_default_reads(key: str) -> list[str]:
+    """Files reading ``key`` with a non-empty fallback passed to get()/getenv().
+
+    That form is only reached when the variable is absent, which under compose
+    it never is, so the fallback is dead and the empty string wins.
+    """
+    pattern = re.compile(
+        r"os\.(?:environ\.get|getenv)\(\s*[\"']"
+        + re.escape(key)
+        + r"[\"']\s*,\s*[\"'][^\"']+[\"']"
+    )
+    return sorted(
+        str(path.relative_to(REPO_ROOT))
+        for path in sorted((REPO_ROOT / "backend").rglob("*.py"))
+        if pattern.search(path.read_text(encoding="utf-8"))
+    )
 
 
 def _env_example_keys(text: str) -> set[str]:
@@ -80,6 +110,35 @@ def test_env_overrides_reach_the_containers() -> None:
         f"{missing} are read by config_manager but no service passes them in. "
         f"Add them to the {SHARED_ANCHOR} anchor in docker-compose.example.yml, "
         "or an operator who sets them gets the application default and no warning."
+    )
+
+
+def test_blank_defaults_are_parsed_at_all() -> None:
+    """Guard the parser: an empty set would make the test below vacuous."""
+    keys = _blank_default_keys(COMPOSE_PATH.read_text(encoding="utf-8"))
+    assert "NOJOIN_CODEX_PATH" in keys
+    assert "OLLAMA_CONTEXT_WINDOW" in keys
+
+
+def test_blank_compose_defaults_do_not_shadow_code_defaults() -> None:
+    """The other half of the plumbing problem, and the more expensive half.
+
+    Passing a variable through fixed the silent-discard failure above but
+    created its mirror image: ``${FOO:-}`` puts an empty string in the
+    environment, so ``os.environ.get("FOO", "a-default")`` stops returning its
+    default the moment the variable is plumbed through. That is how
+    ``NOJOIN_CODEX_PATH`` turned into an empty binary path and took Codex note
+    generation down with it. Read these with ``or`` instead.
+    """
+    offenders = {
+        key: files
+        for key in sorted(_blank_default_keys(COMPOSE_PATH.read_text(encoding="utf-8")))
+        if (files := _code_default_reads(key))
+    }
+    assert not offenders, (
+        f"{offenders} are declared empty in docker-compose.example.yml but read "
+        "with a get() fallback, which compose makes unreachable. Use "
+        'os.environ.get("VAR", "").strip() or "<default>" instead.'
     )
 
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -79,6 +79,10 @@ x-worker-environment: &worker-environment
   # io image carry the binary. Declared for all four rather than merged into
   # those two separately: it is inert where codex is absent, and a single
   # declaration cannot drift.
+  # No default here on purpose, as with the context windows above: the codex
+  # modules own /usr/local/bin/codex and skip an empty value, so an unset
+  # variable falls through to them. Repeating the path here would create a
+  # second default to keep in step with the image that installs the binary.
   NOJOIN_CODEX_PATH: ${NOJOIN_CODEX_PATH:-}
   XDG_CACHE_HOME: /home/appuser/.cache
   HF_HOME: /home/appuser/.cache/huggingface


### PR DESCRIPTION
# Pull Request

## Description

Codex note generation fails on a default Docker Compose deployment with `PermissionError: [Errno 13] Permission denied: ''`, and the Codex model catalogue refresh fails the same way.

#205 plumbed `NOJOIN_CODEX_PATH` through to the worker lanes so an operator could override the binary path. Compose has no way to declare a variable without also setting it, so `${NOJOIN_CODEX_PATH:-}` puts an empty string in the environment of every deployment that did not fill it in. An empty string is a value: `os.environ.get(name, default)` returns it and the default is never reached, so the worker executed `""`.

Both modules that own the path now read it with `or`, so an empty value falls through to `/usr/local/bin/codex` the way an absent one already did. The Compose entry keeps its blank default and gains the comment the context-window entries carry: putting the path there instead would create a second copy to keep in step with the image that installs the binary, which is the convention the neighbouring `OLLAMA_CONTEXT_WINDOW` entry argues against in as many words.

Three related changes ride with it:

- `NOJOIN_UMASK` has the same shape and a milder symptom. An empty value reached `int()`, so every service in a default deployment logged an invalid-value warning at startup before falling back to 0077. It now treats empty as unset.
- The driver's launch handler caught `FileNotFoundError` only, which is why the underlying `PermissionError` reached the user as a bare errno rather than something naming the setting. It now catches `OSError`.
- `test_compose_env_plumbing` gains the mirror of the test it already carried. That file exists because a variable missing from Compose is read by nobody; this failure is what fixing that introduced. The new test walks every `${VAR:-}` declaration in the template and fails if any module reads it with a `get()` fallback that Compose has made unreachable.

No new dependencies.

Fixes #241

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` — 1490 passed
- [x] Python quality: `python scripts/check.py` — OK (lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests)
- [x] Frontend lint: `cd frontend && npm run lint` — 0 errors (4 pre-existing warnings in untouched files)
- [x] Frontend unit tests: `cd frontend && npm run test` — 486 passed
- [x] Frontend build: `cd frontend && npm run build` — compiled successfully
- [x] Docs validation: `python3 scripts/validate_docs.py` — 20 Markdown files
- [x] Alembic validation: `python3 scripts/validate_alembic.py` — head `f7a2c6d3b418`

Also run: `git diff --check`.

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

`docs/DEPLOYMENT.md` already documents `/usr/local/bin/codex` as the default and `NOJOIN_CODEX_PATH` as the override. The behaviour now matches what it says; nothing in the documented contract changed.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

The umask change is adjacent to a security control but does not move it: the effective umask was already 0077 in the failing case, via the exception handler. The change removes the spurious warning, not the fallback.

## Manual verification

- Confirmed the resolution directly, with the variable set empty as Compose sets it and with an override, in the project venv:
  - `NOJOIN_CODEX_PATH= ` resolves to `/usr/local/bin/codex`
  - `NOJOIN_CODEX_PATH=/opt/codex` resolves to `/opt/codex`
- Confirmed the umask path: an empty value now logs `Configured process umask to 0o0077` with no warning, and `NOJOIN_UMASK=0027` still applies 0o0027.
- Confirmed the new test fails on the bug it guards. Reverting `codex_driver.py` to the `get()` form makes it fail with `{'NOJOIN_CODEX_PATH': ['backend/processing/cli/codex_driver.py']}`, and it passes again once restored.

Not covered: the fix has not been exercised against a live Codex CLI in `worker-io`, since that needs a connected ChatGPT subscription. The failure was in resolving the path before the CLI is reached, and the reporter confirmed the binary itself runs correctly at the default path.
