### PR TITLE
fix(deps): patch nanoid in the site and telemetry lockfiles

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4546,9 +4546,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/telemetry/package-lock.json
+++ b/telemetry/package-lock.json
@@ -1090,9 +1090,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1100,6 +1100,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
## Description

Clears Dependabot alert 149 (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, high). `nanoid` before 3.3.18 loops forever in `customAlphabet` and `customRandom` when given a size of 0.

Lockfile-only change, `nanoid` 3.3.16 to 3.3.18 in `site/` and `telemetry/`. `postcss` already declares `nanoid: ^3.3.16`, so the patch release satisfies the existing constraint and nothing above it moves. The site diff is three lines; telemetry is three plus a `license` field npm backfilled.

**Neither package is actually exposed, and the PR does not pretend otherwise.** Worth stating explicitly so the severity is not read at face value:

- In `site/`, `nanoid` arrives via `astro` to `vite` to `postcss`. GitHub scopes it as runtime because `astro` sits in `dependencies`, but Astro is a build tool here: the deployed artefact is `site/dist` static assets plus `worker/index.js`, a 41-line redirect script with no imports. `nanoid` is not in `dist/` and never executes in production.
- In `telemetry/`, it is a dev dependency of `vitest`. GitHub reached the same conclusion and auto-dismissed the twin alert (150).
- In both cases `postcss` calls `nanoid` with its own fixed size. Nothing passes an attacker-controlled 0.

The fix is three lines and removes something that would otherwise need re-triaging every time it resurfaces, which is the whole argument for doing it.

`frontend/` was already on 3.3.18 and is untouched.

No new dependencies.

## Root cause worth noting

`.github/dependabot.yml` configures npm updates for `/frontend` only. `/site` and `/telemetry` have no `package-ecosystem: npm` entry, so neither lockfile ever receives a version-update PR. Security alerts still fire for them, since that is a separate channel, but no automated fix can arrive. That is why a July advisory was still open in August and had to be patched by hand.

Deliberately not fixed in this PR: adding those two entries changes ongoing PR volume and is a maintenance decision rather than part of clearing this alert.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest`
- [x] Python quality: `python scripts/check.py` (Ruff lint, format check, mypy, doc and Alembic validators)
- [ ] Frontend lint: `cd frontend && npm run lint`
- [ ] Frontend unit tests: `cd frontend && npm run test`
- [ ] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

`scripts/check.py` passed in full: 1492 tests, `OK: lint, format, whitespace, filesize, heldpins, typecheck, docs, alembic, tests`. `git diff --check` is clean.

The three `frontend/` boxes are unticked because nothing under `frontend/` changed. The checks that do cover the changed paths were run instead:

- `cd site && npm run build`: 4 pages built, no warnings
- `cd telemetry && npm run typecheck`: clean
- `cd telemetry && npm run test`: 23 tests passed
- `cd telemetry && npm run build`: worker bundles at 9.2kb
- `npm audit` in both directories: 0 vulnerabilities, down from 1 high

## Migration impact

- [x] No database migration in this PR.
- [ ] Adds an Alembic migration.

## Documentation impact

- [x] No documentation change required.
- [ ] Updated the relevant guide(s) in the same PR.

No held pin moved, so the "Held Pins and Unfixable Advisories" section of `docs/DEVELOPMENT.md` is unaffected. This advisory was fixable, so it does not belong in that record.

## Security impact

- [x] No security-sensitive change.
- [ ] Touches auth, tokens, encryption, capture ownership, or exposure.

Clears a high-severity advisory but changes no security boundary. No behaviour in `docs/SECURITY.md` is affected.

## Manual verification

The site build is the meaningful check, since `postcss` is what pulls `nanoid` and the build is the only place it runs. It completes and emits all four routes (`/`, `/compare`, `/managed`, `/404`) exactly as before. The telemetry worker bundles unchanged at 9.2kb.
