### PR TITLE
feat(frontend): queue document uploads and repair the live meeting view

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -332,6 +332,14 @@ The web client is responsible for:
 
 The web client is the only live capture surface. Unsupported browsers retain review, playback, admin, and settings capabilities, but cannot start live recording.
 
+#### Connectivity Monitor
+
+Backend reachability is a state machine in `frontend/src/lib/connectivity/`, and the thing it exists to avoid is claiming an outage that is not happening. Every observed success is proof of life, whether it came from real API traffic, a health poll or an idle liveness probe, so a page doing steady work never probes at all. Only the dedicated prober can escalate, and only after the last success has gone stale and three of its probes have failed.
+
+Two rules keep that threshold meaning what it says. **Probes are serialised**: a tick will not start one while another is in flight. Without that the driver stacked them, because a tick awaiting its probe holds no timer, so every failing request scheduled another tick 500ms later, and each of those started another probe. A tab whose connection stalls fails a burst of requests at once, which is how one production capture put seven probes in flight together, all aborted in the same instant: three times the threshold delivered in one go rather than confirmed over fifteen seconds. **A probe that outlasts its own timeout by a wide margin is not counted**, because a frozen tab suspends the abort timer along with the request and thaws them together, cancelling the fetch without ever having raced it against the network. Returning to the foreground clears the failure streak for the same reason: evidence gathered while the page was not being run is not evidence. The `resume` event cannot be used for any of this, since it is advisory and not dispatched on every Chromium build (issue #166), so the elapsed wall clock is the signal.
+
+This matters beyond the toast. A false `unreachable` also mislabels an audio-coverage shortfall as `backend-unreachable`, which promises the queued audio will upload on reconnect, when the real cause was the suspension that lost it.
+
 ### Browser Capture Stack
 
 The browser capture stack is responsible for:
@@ -349,7 +357,9 @@ The browser capture stack is responsible for:
 
 The captured figure comes from the backend, on `captured_audio_seconds` in the recording detail payload, summed from the transcoded segments and polled every 15 seconds while capture is open. The client cannot derive it: a segment carries slightly more than the nominal timeslice, because each roll flushes whatever accumulated while the recorder was stopping, and multiplying the sequence number by the timeslice under-counts by around 10% over an hour. That estimate produced coverage warnings on recordings that had lost nothing. The backend figure carries the opposite bias, running 2-3% high because each decoded segment includes codec priming that concatenation later trims, which is left uncorrected on purpose: it can only make a shortfall look smaller, never invent one.
 
-The warning also carries a cause, because a shortfall means opposite things depending on why. `backend-unreachable` when the connectivity monitor reports the API down, and the queued audio will upload on reconnect. `tab-suspended` when the page was seen to thaw or the recorder watchdog caught it stalled, and the audio is gone. `unknown` when neither signal is present, with copy that describes the gap without diagnosing it. It is dismissible, and re-arms only when the shortfall grows materially past the value dismissed.
+The shortfall is net of the uploader's own queue. Segments recorded but not yet acknowledged are audio the browser is holding, not audio that has been lost, and a server that stops answering for two minutes leaves exactly two minutes of them; counting that as missing told a user their meeting was being lost while it sat in memory waiting to upload. The queue is estimated from its length rather than measured, which biases the warning towards firing rather than towards silence, and it is named separately in the copy so a queue that never drains is still visible.
+
+The warning also carries a cause, because a shortfall means opposite things depending on why. `backend-unreachable` when the connectivity monitor reports the API down, and the queued audio will upload on reconnect. `tab-suspended` when the page was seen to thaw or the recorder watchdog caught it stalled, and the audio is gone. `unknown` when neither signal is present, with copy that describes the gap without diagnosing it. An outage that has just ended still counts, for five minutes: the check polls every fifteen seconds and the shortfall persists while the queue drains, so classifying on the live status alone answered `unknown` for the very case the classifier exists to name. It ranks below a freeze, which is direct evidence the browser stopped recording where an outage is evidence it did not. It is dismissible, and re-arms only when the shortfall grows materially past the value dismissed.
 
 ## Recording Flow
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -223,6 +223,10 @@ The warning can be dismissed with the close control. It stays dismissed unless t
 
 Nojoin reports this conservatively. The captured figure it compares against is measured from the audio segments the server has decoded, and that measurement runs slightly high, so a small shortfall may be reported as none at all. It will not report a shortfall that is not there.
 
+Audio still queued in the browser is not counted as missing, and the warning names it separately when there is any. A server that stops answering for two minutes leaves two minutes in the queue, and reporting that as lost would send someone to check a tab and a device over audio that was never at risk. A shortfall that persists after the queue drains is the part that is genuinely gone.
+
+An outage also keeps explaining a shortfall for a few minutes after the server answers again, because the check runs every fifteen seconds and the queue takes longer than that to drain, so the connection has usually recovered by the time the warning appears.
+
 ### Chrome Memory Saver
 
 Chrome's Memory Saver puts inactive tabs to sleep to reclaim memory. **You should not normally need to do anything about this for Nojoin.** Memory Saver exempts tabs that are actively using the microphone or camera or sharing a screen, and Nojoin holds those for the whole of a recording, so a recording tab is exempt for as long as it is recording.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -307,6 +307,14 @@ inside the transcript card and then below it; see the rule on capping below. Rem
 without bounding the row is the same defect pointing the other way, and the transcript grows without
 limit instead of Meeting Edge.
 
+A `min-height` inside the absorbing module is the same mistake in miniature. The transcript's scroll
+window carried a 14rem floor, and on a short window the notes and documents cards left the module
+less than that: the window overflowed its own card, the frame drawn behind it stayed at the card's
+height, and the overspill painted across the notes card below. **A child of an absorbing module
+takes the height its card was given**, so from 54rem the window is `min-h-0` and the card clips what
+it cannot hold. The floor survives only in the stacked layout below 54rem, where the page scrolls
+and there is no height to refuse.
+
 The meeting view's Analytics tab is the third surface that spends width on columns, and it does so
 entirely through container queries on its own scroll region, because it lives inside a resizable
 panel between two collapsible rails and its width is the window minus two numbers it cannot see. It

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -116,7 +116,7 @@ Mobile Chrome does not capture meeting tab, app, headset, or system audio. It is
 
 While recording, Nojoin shows recording state, duration, upload state, a live waveform, a live transcript panel, Meeting Edge guidance, your live notes panel, and collapsed processing visibility.
 
-The recording workspace lays these out so that on a wide display everything is visible at once rather than down a long scroll. The capture controls sit in a toolbar across the top, carrying the meeting's working name, the transport, **Upload** for attaching a document, and the speaker limit. Below it are two columns: the live transcript with your notes under it on the left, and Meeting Edge on the right. It collapses to a single stack on smaller screens. When you press **Stop**, the transcript becomes pipeline progress and the rest of the layout stays where it is.
+The recording workspace lays these out so that on a wide display everything is visible at once rather than down a long scroll. The capture controls sit in a toolbar across the top, carrying the meeting's working name, the transport, **Attach Docs** for attaching one or more documents, and the speaker limit. Below it are two columns: the live transcript with your notes under it on the left, and Meeting Edge on the right. It collapses to a single stack on smaller screens. When you press **Stop**, the transcript becomes pipeline progress and the rest of the layout stays where it is.
 
 Documents you attach are listed under your notes. The panel appears only once something is attached, since uploading is done from the toolbar.
 
@@ -347,13 +347,15 @@ No warning does not mean the attribution is certainly right, only that nothing o
 
 Upload PDF, PowerPoint, Word, Excel, CSV, text, Markdown, or image files, up to 250 MB each. Documents can be attached at any point: from the Documents tab of a processed meeting, or from the Documents panel that appears below the live transcript while a meeting is still recording or processing.
 
+Several files can be attached at once. Browse to them or drag them onto the dialog, in one go or a few at a time, and each queued file is listed with its own **Analyse visually with AI** switch, so a deck can be read visually while the plain-text agenda beside it is not. Uploads run one after another rather than all at once, and the documents panel fills as they land. If one fails the rest still go through, and the dialog stays open with the failed files listed so they can be retried without re-sending what already uploaded.
+
 Timing matters. Meeting notes are generated once, at the end of processing, and they use every document that has finished parsing by then. A document attached during the meeting is normally ready in time to be included on the first pass. A document attached afterwards cannot be, so the Notes tab shows a banner offering to regenerate. Regenerating is never automatic: it uses your AI provider and overwrites any edits you have made to the notes.
 
 #### Visual Analysis
 
 Text extraction alone misses most of what a slide deck or a scanned report actually carries. **Analyse visually with AI** is therefore on by default: each page is sent to your configured AI model, which transcribes the text, reconstructs tables, and describes charts and diagrams including their values.
 
-- Turn it off per upload for a document that is genuinely plain text, or to avoid using AI provider quota. The file is still parsed, just without visual analysis.
+- Turn it off per file for a document that is genuinely plain text, or to avoid using AI provider quota. The file is still parsed, just without visual analysis. When several files are queued, one control turns it off for all of them.
 - It cannot be turned off for image uploads, which have no text to extract without it.
 - Your model must accept images. Every current hosted model from Anthropic, OpenAI, and Google does. If you use **Ollama**, you must select a vision-capable model (such as a `llava` or `-vision` variant) in **Settings > AI**; a text-only model cannot read images and Nojoin will fall back to text extraction.
 - If visual analysis is unavailable, Nojoin falls back to local OCR before giving up. OCR runs on your own server, costs nothing, and sends nothing anywhere, so a scanned page stays searchable even with no AI configured at all. What it cannot do is describe a chart or a diagram, only transcribe the words, and the document card says so when it was used.

--- a/frontend/src/components/DocumentUploadModal.test.tsx
+++ b/frontend/src/components/DocumentUploadModal.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "@/test/renderWithProviders";
+
+const addNotification = vi.fn();
+const uploadDocument = vi.fn();
+
+vi.mock("@/lib/notificationStore", () => ({
+  useNotificationStore: () => ({ addNotification }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  uploadDocument: (...args: unknown[]) => uploadDocument(...args),
+}));
+
+import DocumentUploadModal from "./DocumentUploadModal";
+
+const makeFile = (name: string, bytes = 1024) => {
+  const file = new File(["x"], name, { type: "application/octet-stream" });
+  Object.defineProperty(file, "size", { value: bytes });
+  return file;
+};
+
+const renderModal = (onSuccess = vi.fn()) => {
+  renderWithProviders(
+    <DocumentUploadModal
+      isOpen
+      onClose={vi.fn()}
+      onSuccess={onSuccess}
+      recordingId="rec_1"
+    />,
+  );
+  return { onSuccess };
+};
+
+const selectFiles = (files: File[]) => {
+  const input = screen.getByTestId("document-file-input");
+  fireEvent.change(input, { target: { files } });
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DocumentUploadModal", () => {
+  it("queues several files from one selection", () => {
+    renderModal();
+    selectFiles([makeFile("deck.pdf"), makeFile("notes.docx")]);
+
+    expect(screen.getAllByTestId("document-upload-row")).toHaveLength(2);
+    expect(screen.getByText("deck.pdf")).toBeInTheDocument();
+    expect(screen.getByText("notes.docx")).toBeInTheDocument();
+  });
+
+  it("accepts a second selection without dropping the first", () => {
+    renderModal();
+    selectFiles([makeFile("deck.pdf")]);
+    selectFiles([makeFile("notes.docx")]);
+
+    expect(screen.getAllByTestId("document-upload-row")).toHaveLength(2);
+  });
+
+  it("rejects an unsupported file and keeps the supported ones", () => {
+    renderModal();
+    selectFiles([makeFile("deck.pdf"), makeFile("archive.zip")]);
+
+    expect(screen.getAllByTestId("document-upload-row")).toHaveLength(1);
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
+  });
+
+  it("uploads each file with its own visual-analysis choice", async () => {
+    uploadDocument.mockResolvedValue({ id: 1 });
+    const { onSuccess } = renderModal();
+    selectFiles([makeFile("deck.pdf"), makeFile("plain.txt")]);
+
+    // Visual analysis off for the second file only.
+    fireEvent.click(
+      screen.getByLabelText("Analyse plain.txt visually with AI"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /upload 2 documents/i }));
+
+    await waitFor(() => expect(uploadDocument).toHaveBeenCalledTimes(2));
+    expect(uploadDocument.mock.calls[0][2]).toEqual({ deepParse: true });
+    expect(uploadDocument.mock.calls[1][2]).toEqual({ deepParse: false });
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(2));
+  });
+
+  it("cannot turn visual analysis off for an image, which has no text layer", () => {
+    renderModal();
+    selectFiles([makeFile("slide.png")]);
+
+    const checkbox = screen.getByLabelText(
+      "Analyse slide.png visually with AI",
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.disabled).toBe(true);
+  });
+
+  it("turns visual analysis off for every file that allows it", () => {
+    renderModal();
+    selectFiles([makeFile("deck.pdf"), makeFile("plain.txt"), makeFile("slide.png")]);
+
+    fireEvent.click(screen.getByRole("button", { name: /turn off for all/i }));
+
+    expect(
+      (screen.getByLabelText("Analyse deck.pdf visually with AI") as HTMLInputElement)
+        .checked,
+    ).toBe(false);
+    expect(
+      (screen.getByLabelText("Analyse plain.txt visually with AI") as HTMLInputElement)
+        .checked,
+    ).toBe(false);
+    expect(
+      (screen.getByLabelText("Analyse slide.png visually with AI") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+  });
+
+  it("retries only what failed, so a success is never uploaded twice", async () => {
+    uploadDocument
+      .mockResolvedValueOnce({ id: 1 })
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ id: 2 });
+    renderModal();
+    selectFiles([makeFile("deck.pdf"), makeFile("notes.docx")]);
+
+    fireEvent.click(screen.getByRole("button", { name: /upload 2 documents/i }));
+    await waitFor(() => expect(uploadDocument).toHaveBeenCalledTimes(2));
+
+    const retry = await screen.findByRole("button", { name: /retry 1 document/i });
+    fireEvent.click(retry);
+
+    await waitFor(() => expect(uploadDocument).toHaveBeenCalledTimes(3));
+    expect(uploadDocument.mock.calls[2][1].name).toBe("notes.docx");
+  });
+});

--- a/frontend/src/components/DocumentUploadModal.tsx
+++ b/frontend/src/components/DocumentUploadModal.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { useState, useRef, useCallback } from 'react';
-import { Upload, FileText, CheckCircle, Sparkles, AlertTriangle } from 'lucide-react';
+import {
+    Upload,
+    FileText,
+    CheckCircle,
+    Sparkles,
+    AlertTriangle,
+    Loader2,
+    X,
+} from 'lucide-react';
 import Button from './ui/Button';
 import Modal from './ui/Modal';
 import { uploadDocument } from '@/lib/api';
@@ -21,7 +29,15 @@ interface DocumentUploadModalProps {
     recordingId: RecordingId;
 }
 
-type UploadState = 'idle' | 'uploading' | 'success' | 'error';
+/** Per-file state. The queue is uploaded one file at a time, in order. */
+interface QueuedUpload {
+    /** Stable across re-renders and independent of the file's name. */
+    id: string;
+    file: File;
+    deepParse: boolean;
+    status: 'pending' | 'uploading' | 'success' | 'error';
+    error?: string;
+}
 
 const formatFileSize = (bytes: number): string => {
     if (bytes === 0) return '0 Bytes';
@@ -40,56 +56,96 @@ const supportedFormats = [...SUPPORTED_DOCUMENT_FORMATS];
 const visionOnlyFormats: readonly string[] = VISION_ONLY_DOCUMENT_FORMATS;
 const maxSizeMB = 250;
 
+const isVisionOnlyFile = (file: File): boolean =>
+    visionOnlyFormats.includes(getFileExtension(file.name));
+
 export default function DocumentUploadModal({ isOpen, onClose, onSuccess, recordingId }: DocumentUploadModalProps) {
-    const [selectedFile, setSelectedFile] = useState<File | null>(null);
-    const [uploadState, setUploadState] = useState<UploadState>('idle');
+    const [queue, setQueue] = useState<QueuedUpload[]>([]);
+    const [isUploading, setIsUploading] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
-    // Visual analysis is on by default: text-only extraction misses charts,
-    // diagrams and anything scanned, which is the common case for decks.
-    const [deepParse, setDeepParse] = useState(true);
     const { addNotification } = useNotificationStore();
 
     const fileInputRef = useRef<HTMLInputElement>(null);
     const dropZoneRef = useRef<HTMLDivElement>(null);
+    // Ids are only ever compared against each other, so a counter is enough and
+    // avoids depending on crypto.randomUUID being present.
+    const nextIdRef = useRef(0);
 
     const resetState = useCallback(() => {
-        setSelectedFile(null);
-        setUploadState('idle');
+        setQueue([]);
+        setIsUploading(false);
         setIsDragging(false);
-        setDeepParse(true);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
     }, []);
 
     const handleClose = useCallback(() => {
-        if (uploadState === 'uploading') return;
+        if (isUploading) return;
         resetState();
         onClose();
-    }, [uploadState, resetState, onClose]);
+    }, [isUploading, resetState, onClose]);
 
     const validateFile = (file: File): string | null => {
         const extension = getFileExtension(file.name);
         if (!supportedFormats.includes(extension as (typeof SUPPORTED_DOCUMENT_FORMATS)[number])) {
-            return `Unsupported format "${extension}". Supported: ${supportedFormats.join(', ')}`;
+            return `${file.name}: unsupported format "${extension}". Supported: ${supportedFormats.join(', ')}`;
         }
         if (file.size > maxSizeMB * 1024 * 1024) {
-            return `File too large (${formatFileSize(file.size)}). Maximum: ${maxSizeMB} MB`;
+            return `${file.name}: too large (${formatFileSize(file.size)}). Maximum: ${maxSizeMB} MB`;
         }
         return null;
     };
 
-    const handleFileSelect = (file: File) => {
-        const error = validateFile(file);
-        if (error) {
-            addNotification({ type: 'error', message: error });
-            setUploadState('idle');
-            return;
+    const handleFilesSelected = (files: FileList | File[]) => {
+        const incoming = Array.from(files);
+        if (incoming.length === 0) return;
+
+        const rejected: string[] = [];
+        const accepted: QueuedUpload[] = [];
+        // Selecting the same file twice is a slip, not an instruction to upload
+        // it twice, and the second copy would be indistinguishable in the
+        // documents list. Name and size is as much identity as a File gives
+        // without reading it.
+        //
+        // Sorted out here rather than inside the state updater, because an
+        // updater must stay pure: React invokes it twice in development, which
+        // would raise every rejection notification twice over.
+        const seen = new Set(queue.map((item) => `${item.file.name}:${item.file.size}`));
+
+        for (const file of incoming) {
+            const error = validateFile(file);
+            if (error) {
+                rejected.push(error);
+                continue;
+            }
+            const key = `${file.name}:${file.size}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            accepted.push({
+                id: `upload-${nextIdRef.current++}`,
+                file,
+                // Visual analysis is on by default: text-only extraction misses
+                // charts, diagrams and anything scanned, which is the common
+                // case for decks.
+                deepParse: true,
+                status: 'pending',
+            });
         }
 
-        setSelectedFile(file);
-        setUploadState('idle');
-        // An image has no text layer, so turning visual analysis off would
-        // leave nothing at all to index.
-        if (visionOnlyFormats.includes(getFileExtension(file.name))) {
-            setDeepParse(true);
+        if (accepted.length > 0) {
+            setQueue((current) => [...current, ...accepted]);
+        }
+
+        for (const message of rejected) {
+            addNotification({ type: 'error', message });
+        }
+
+        // Clearing the input means the same file can be picked again after it
+        // has been removed from the queue, which a browser otherwise suppresses
+        // because the value has not changed.
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
         }
     };
 
@@ -117,54 +173,118 @@ export default function DocumentUploadModal({ isOpen, onClose, onSuccess, record
         e.stopPropagation();
         setIsDragging(false);
 
-        const files = e.dataTransfer.files;
-        if (files.length > 0) {
-            handleFileSelect(files[0]);
-        }
+        if (isUploading) return;
+        handleFilesSelected(e.dataTransfer.files);
     };
 
     const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const files = e.target.files;
-        if (files && files.length > 0) {
-            handleFileSelect(files[0]);
+        if (e.target.files) {
+            handleFilesSelected(e.target.files);
         }
+    };
+
+    const setDeepParse = (id: string, deepParse: boolean) => {
+        setQueue((current) =>
+            current.map((item) =>
+                item.id === id && !isVisionOnlyFile(item.file)
+                    ? { ...item, deepParse }
+                    : item,
+            ),
+        );
+    };
+
+    const setDeepParseForAll = (deepParse: boolean) => {
+        setQueue((current) =>
+            current.map((item) =>
+                // An image has no text layer, so turning visual analysis off
+                // would leave nothing at all to index. It stays on whatever the
+                // bulk control says.
+                isVisionOnlyFile(item.file) ? item : { ...item, deepParse },
+            ),
+        );
+    };
+
+    const handleRemoveFile = (id: string) => {
+        setQueue((current) => current.filter((item) => item.id !== id));
     };
 
     const handleUpload = async () => {
-        if (!selectedFile) return;
+        // A retry after a partial failure re-sends only what failed; anything
+        // already uploaded exists on the server and would otherwise duplicate.
+        const pending = queue.filter((item) => item.status !== 'success');
+        if (pending.length === 0 || isUploading) return;
 
-        setUploadState('uploading');
+        setIsUploading(true);
+        setQueue((current) =>
+            current.map((item) =>
+                item.status === 'error' ? { ...item, status: 'pending', error: undefined } : item,
+            ),
+        );
 
-        try {
-            await uploadDocument(recordingId, selectedFile, { deepParse });
-            setUploadState('success');
+        let failures = 0;
 
-            setTimeout(() => {
+        // Sequential, not concurrent. The backend admits two document uploads
+        // per user at a time and rejects the rest, so a fan-out of a ten-file
+        // drop would fail most of it; one at a time also keeps the order of the
+        // documents list matching the order they were queued in.
+        for (const item of pending) {
+            setQueue((current) =>
+                current.map((entry) =>
+                    entry.id === item.id ? { ...entry, status: 'uploading' } : entry,
+                ),
+            );
+
+            try {
+                await uploadDocument(recordingId, item.file, { deepParse: item.deepParse });
+                setQueue((current) =>
+                    current.map((entry) =>
+                        entry.id === item.id ? { ...entry, status: 'success' } : entry,
+                    ),
+                );
+                // Refresh per file rather than once at the end, so a long queue
+                // fills the documents panel as it goes.
                 onSuccess?.();
-                handleClose();
+            } catch (error: unknown) {
+                failures += 1;
+                const message = getErrorMessage(error, 'Upload failed. Please try again.');
+                setQueue((current) =>
+                    current.map((entry) =>
+                        entry.id === item.id ? { ...entry, status: 'error', error: message } : entry,
+                    ),
+                );
+                addNotification({ type: 'error', message: `${item.file.name}: ${message}` });
+            }
+        }
+
+        setIsUploading(false);
+
+        // Everything landed, so the dialog has nothing left to say. A partial
+        // failure keeps it open with the failed rows in place to retry.
+        if (failures === 0) {
+            setTimeout(() => {
+                resetState();
+                onClose();
             }, 1500);
-
-        } catch (error: unknown) {
-            setUploadState('idle');
-            addNotification({
-                type: 'error',
-                message: getErrorMessage(error, 'Upload failed. Please try again.'),
-            });
         }
     };
 
-    const handleRemoveFile = () => {
-        setSelectedFile(null);
-        setUploadState('idle');
-        if (fileInputRef.current) {
-            fileInputRef.current.value = '';
-        }
-    };
+    const pendingCount = queue.filter((item) => item.status !== 'success').length;
+    const successCount = queue.filter((item) => item.status === 'success').length;
+    const failedCount = queue.filter((item) => item.status === 'error').length;
+    const allSucceeded = queue.length > 0 && successCount === queue.length;
+    const totalBytes = queue.reduce((sum, item) => sum + item.file.size, 0);
+    const nonVisionCount = queue.filter((item) => !isVisionOnlyFile(item.file)).length;
+    const allDeepParse =
+        nonVisionCount > 0 &&
+        queue.every((item) => isVisionOnlyFile(item.file) || item.deepParse);
 
-    const isVisionOnly = selectedFile
-        ? visionOnlyFormats.includes(getFileExtension(selectedFile.name))
-        : false;
-    const isLargeFile = !!selectedFile && selectedFile.size > DOCUMENT_SIZE_WARNING_BYTES;
+    const uploadLabel = isUploading
+        ? 'Uploading...'
+        : failedCount > 0
+            ? `Retry ${failedCount} ${failedCount === 1 ? 'document' : 'documents'}`
+            : pendingCount > 1
+                ? `Upload ${pendingCount} documents`
+                : 'Upload document';
 
     return (
         <Modal
@@ -172,26 +292,26 @@ export default function DocumentUploadModal({ isOpen, onClose, onSuccess, record
             onClose={handleClose}
             // An upload in flight cannot be cancelled, so the dialog stops
             // accepting a dismissal until it resolves.
-            dismissible={uploadState !== 'uploading'}
+            dismissible={!isUploading}
             size="md"
-            title="Upload Document"
+            title={queue.length > 1 ? 'Upload Documents' : 'Upload Document'}
             footer={
                 <>
                     <Button
                         variant="ghost"
                         onClick={handleClose}
-                        disabled={uploadState === 'uploading'}
+                        disabled={isUploading}
                     >
                         Cancel
                     </Button>
                     <Button
                         variant="primary"
                         onClick={handleUpload}
-                        disabled={!selectedFile || uploadState === 'uploading' || uploadState === 'success'}
-                        loading={uploadState === 'uploading'}
+                        disabled={pendingCount === 0 || isUploading}
+                        loading={isUploading}
                         iconLeft={<Upload aria-hidden="true" className="w-4 h-4" />}
                     >
-                        {uploadState === 'uploading' ? 'Uploading...' : 'Upload Document'}
+                        {uploadLabel}
                     </Button>
                 </>
             }
@@ -200,106 +320,191 @@ export default function DocumentUploadModal({ isOpen, onClose, onSuccess, record
                 {/* Drop Zone */}
                 <div
                     ref={dropZoneRef}
-                    onClick={() => uploadState !== 'uploading' && fileInputRef.current?.click()}
+                    onClick={() => !isUploading && fileInputRef.current?.click()}
                     onDragEnter={handleDragEnter}
                     onDragLeave={handleDragLeave}
                     onDragOver={handleDragOver}
                     onDrop={handleDrop}
                     className={`
-              relative cursor-pointer rounded-lg border-2 border-dashed p-8 text-center transition-colors
+              relative cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition-colors
               ${isDragging
                             ? 'border-action bg-action-tint'
-                            : selectedFile
+                            : queue.length > 0
                                 ? 'border-status-success-border bg-status-success-bg'
                                 : 'border-control-border hover:border-action-border'
                         }
-              ${uploadState === 'uploading' ? 'pointer-events-none opacity-75' : ''}
+              ${isUploading ? 'pointer-events-none opacity-75' : ''}
             `}
                 >
                     <input
                         ref={fileInputRef}
                         type="file"
+                        multiple
                         accept={supportedFormats.join(',')}
                         onChange={handleFileInputChange}
+                        data-testid="document-file-input"
                         className="hidden"
                     />
 
-                    {selectedFile ? (
-                        <div className="space-y-2">
-                            <FileText aria-hidden="true" className="mx-auto h-12 w-12 text-status-success-fg" />
-                            <p className="mx-auto max-w-xs truncate font-medium text-foreground">
-                                {selectedFile.name}
-                            </p>
-                            <p className="text-sm text-contrast-helper">
-                                {formatFileSize(selectedFile.size)}
-                            </p>
-                            {uploadState !== 'uploading' && (
-                                <button
-                                    onClick={(e) => { e.stopPropagation(); handleRemoveFile(); }}
-                                    className="text-sm text-danger-text underline hover:text-danger-text-hover"
-                                >
-                                    Remove
-                                </button>
-                            )}
-                        </div>
-                    ) : (
-                        <div className="space-y-2">
-                            <Upload aria-hidden="true" className="mx-auto h-12 w-12 text-contrast-icon-muted" />
-                            <p className="text-contrast-helper">
-                                <span className="font-medium text-action-text">Click to browse</span> or drag and drop
-                            </p>
-                            <p className="text-xs text-contrast-helper">
-                                PDF, PowerPoint, Word, Excel, CSV, text, Markdown or images, up to {maxSizeMB}MB
-                            </p>
-                        </div>
-                    )}
+                    <div className="space-y-2">
+                        <Upload
+                            aria-hidden="true"
+                            className={`mx-auto h-10 w-10 ${queue.length > 0 ? 'text-status-success-fg' : 'text-contrast-icon-muted'}`}
+                        />
+                        <p className="text-contrast-helper">
+                            <span className="font-medium text-action-text">Click to browse</span> or drag
+                            and drop
+                        </p>
+                        <p className="text-xs text-contrast-helper">
+                            {queue.length > 0
+                                ? `${queue.length} ${queue.length === 1 ? 'file' : 'files'} ready, ${formatFileSize(totalBytes)} in total. Add more or upload.`
+                                : `One file or many. PDF, PowerPoint, Word, Excel, CSV, text, Markdown or images, up to ${maxSizeMB}MB each.`}
+                        </p>
+                    </div>
                 </div>
 
-                {/* Visual analysis */}
-                <label
-                    className={`flex items-start gap-3 rounded-lg border p-3 transition-colors ${isVisionOnly
-                        ? 'cursor-not-allowed border-surface-border bg-surface-inset'
-                        : 'cursor-pointer border-surface-border hover:border-action-border'
-                        }`}
-                >
-                    <input
-                        type="checkbox"
-                        checked={deepParse}
-                        disabled={isVisionOnly || uploadState === 'uploading'}
-                        onChange={(e) => setDeepParse(e.target.checked)}
-                        className="mt-0.5 h-4 w-4 accent-action"
-                    />
-                    <span className="min-w-0 flex-1">
+                {/* Bulk visual-analysis control. Only worth the row once there
+                    is more than one file to flip, and only where at least one
+                    of them can actually be turned off. */}
+                {queue.length > 1 && nonVisionCount > 0 && (
+                    <div className="flex flex-wrap items-center justify-between gap-2 px-1">
                         <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
                             <Sparkles aria-hidden="true" className="h-4 w-4 text-action-text" />
                             Analyse visually with AI
                         </span>
-                        <span className="mt-1 block text-xs text-contrast-helper">
-                            {isVisionOnly
-                                ? 'Required for images: there is no text to extract without it.'
-                                : 'Reads charts, diagrams, tables and scanned pages that text extraction alone would miss. Uses your configured AI provider.'}
-                        </span>
-                    </span>
-                </label>
-
-                {/* Large-file cost warning */}
-                {isLargeFile && deepParse && (
-                    <div className="flex items-start gap-2 rounded-lg bg-status-warning-bg p-3 text-status-warning-fg">
-                        <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 flex-shrink-0" />
-                        <p className="text-xs">
-                            This file is {formatFileSize(selectedFile.size)}. With visual analysis on, every
-                            page is sent to your AI provider, so a document this size can take a while to
-                            parse and will use a noticeable amount of provider quota. Parsing runs in the
-                            background and you can keep working.
-                        </p>
+                        <button
+                            type="button"
+                            onClick={() => setDeepParseForAll(!allDeepParse)}
+                            disabled={isUploading}
+                            className="text-sm font-medium text-action-text underline disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                            {allDeepParse ? 'Turn off for all' : 'Turn on for all'}
+                        </button>
                     </div>
                 )}
 
+                {/* One row per file: what it is, whether it gets visual
+                    analysis, and where it got to. */}
+                {queue.length > 0 && (
+                    <ul className="max-h-[20rem] space-y-2 overflow-y-auto pr-1">
+                        {queue.map((item) => {
+                            const visionOnly = isVisionOnlyFile(item.file);
+                            const isLargeFile = item.file.size > DOCUMENT_SIZE_WARNING_BYTES;
+
+                            return (
+                                <li
+                                    key={item.id}
+                                    data-testid="document-upload-row"
+                                    className="rounded-lg border border-surface-border p-3"
+                                >
+                                    <div className="flex items-start gap-3">
+                                        <FileText
+                                            aria-hidden="true"
+                                            className="mt-0.5 h-5 w-5 flex-shrink-0 text-action-text"
+                                        />
+                                        <div className="min-w-0 flex-1">
+                                            <p className="truncate text-sm font-medium text-foreground">
+                                                {item.file.name}
+                                            </p>
+                                            <p className="text-xs text-contrast-helper">
+                                                {formatFileSize(item.file.size)}
+                                            </p>
+                                        </div>
+
+                                        {item.status === 'uploading' && (
+                                            <Loader2
+                                                aria-label="Uploading"
+                                                className="h-4 w-4 flex-shrink-0 animate-spin text-action-text"
+                                            />
+                                        )}
+                                        {item.status === 'success' && (
+                                            <CheckCircle
+                                                aria-label="Uploaded"
+                                                className="h-4 w-4 flex-shrink-0 text-status-success-fg"
+                                            />
+                                        )}
+                                        {item.status === 'error' && (
+                                            <AlertTriangle
+                                                aria-label="Failed"
+                                                className="h-4 w-4 flex-shrink-0 text-status-danger-fg"
+                                            />
+                                        )}
+                                        {!isUploading && item.status !== 'success' && (
+                                            <button
+                                                type="button"
+                                                onClick={() => handleRemoveFile(item.id)}
+                                                aria-label={`Remove ${item.file.name}`}
+                                                className="flex-shrink-0 text-contrast-icon-muted transition-colors hover:text-danger-text"
+                                            >
+                                                <X aria-hidden="true" className="h-4 w-4" />
+                                            </button>
+                                        )}
+                                    </div>
+
+                                    {item.status !== 'success' && (
+                                        <label
+                                            className={`mt-3 flex items-start gap-2 ${visionOnly || isUploading ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                checked={visionOnly ? true : item.deepParse}
+                                                disabled={visionOnly || isUploading}
+                                                onChange={(e) => setDeepParse(item.id, e.target.checked)}
+                                                aria-label={`Analyse ${item.file.name} visually with AI`}
+                                                className="mt-0.5 h-4 w-4 accent-action"
+                                            />
+                                            <span className="min-w-0 flex-1">
+                                                <span className="flex items-center gap-1.5 text-sm text-foreground">
+                                                    <Sparkles
+                                                        aria-hidden="true"
+                                                        className="h-3.5 w-3.5 text-action-text"
+                                                    />
+                                                    Analyse visually with AI
+                                                </span>
+                                                <span className="mt-1 block text-xs text-contrast-helper">
+                                                    {visionOnly
+                                                        ? 'Required for images: there is no text to extract without it.'
+                                                        : 'Reads charts, diagrams, tables and scanned pages that text extraction alone would miss. Uses your configured AI provider.'}
+                                                </span>
+                                            </span>
+                                        </label>
+                                    )}
+
+                                    {/* Large-file cost warning */}
+                                    {isLargeFile && item.deepParse && item.status !== 'success' && (
+                                        <div className="mt-3 flex items-start gap-2 rounded-lg bg-status-warning-bg p-3 text-status-warning-fg">
+                                            <AlertTriangle
+                                                aria-hidden="true"
+                                                className="mt-0.5 h-4 w-4 flex-shrink-0"
+                                            />
+                                            <p className="text-xs">
+                                                This file is {formatFileSize(item.file.size)}. With visual
+                                                analysis on, every page is sent to your AI provider, so a
+                                                document this size can take a while to parse and will use a
+                                                noticeable amount of provider quota. Parsing runs in the
+                                                background and you can keep working.
+                                            </p>
+                                        </div>
+                                    )}
+
+                                    {item.status === 'error' && item.error && (
+                                        <p className="mt-2 text-xs text-danger-text">{item.error}</p>
+                                    )}
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+
                 {/* Success Message */}
-                {uploadState === 'success' && (
+                {allSucceeded && (
                     <div className="flex items-center gap-2 rounded-lg bg-status-success-bg p-3 text-status-success-fg">
                         <CheckCircle aria-hidden="true" className="h-5 w-5 flex-shrink-0" />
-                        <span>Document uploaded successfully!</span>
+                        <span>
+                            {successCount === 1
+                                ? 'Document uploaded successfully!'
+                                : `${successCount} documents uploaded successfully!`}
+                        </span>
                     </div>
                 )}
             </div>

--- a/frontend/src/components/LiveMeetingControls.test.tsx
+++ b/frontend/src/components/LiveMeetingControls.test.tsx
@@ -20,6 +20,14 @@ const captureState = {
   status: "recording",
   recordingId: "rec-1" as string | null,
   stop: (...args: unknown[]) => stop(...args),
+  coverageWarning: null as {
+    capturedSeconds: number;
+    elapsedSeconds: number;
+    missingSeconds: number;
+    queuedSeconds: number;
+    cause: string;
+  } | null,
+  dismissCoverageWarning: vi.fn(),
 };
 
 vi.mock("@/lib/capture/CaptureProvider", () => ({
@@ -45,6 +53,40 @@ describe("LiveMeetingControls", () => {
     captureState.elapsedSeconds = 12;
     captureState.runtimeActive = true;
     captureState.status = "recording";
+    captureState.coverageWarning = null;
+  });
+
+  it("renders the captured figure as a clock, not as a float", () => {
+    // The server sums segment durations in milliseconds, so this arrives
+    // fractional and `seconds % 60` rendered "50:11.099999999999909".
+    captureState.coverageWarning = {
+      capturedSeconds: 3011.099999999999909,
+      elapsedSeconds: 3153,
+      missingSeconds: 142,
+      queuedSeconds: 0,
+      cause: "unknown",
+    };
+
+    render(<LiveMeetingControls size="full" />);
+
+    expect(screen.getByText("50:11 captured")).toBeInTheDocument();
+    expect(screen.queryByText(/\.\d/)).not.toBeInTheDocument();
+  });
+
+  it("says what is queued rather than letting it read as lost", () => {
+    captureState.coverageWarning = {
+      capturedSeconds: 3011,
+      elapsedSeconds: 3153,
+      missingSeconds: 20,
+      queuedSeconds: 122,
+      cause: "backend-unreachable",
+    };
+
+    render(<LiveMeetingControls size="full" />);
+
+    expect(
+      screen.getByText(/Another 02:02 is recorded and waiting to upload/),
+    ).toBeInTheDocument();
   });
 
   it("toasts pause failures instead of rendering them inline", async () => {

--- a/frontend/src/components/LiveMeetingControls.tsx
+++ b/frontend/src/components/LiveMeetingControls.tsx
@@ -25,10 +25,15 @@ interface LiveMeetingControlsProps {
 const DISCARD_CONFIRM_MESSAGE =
   "Discard this recording? This permanently deletes the in-progress meeting and its audio, and cannot be undone.";
 
+// Floored to whole seconds before anything is split out of it. The captured
+// figure comes from the server as a sum of segment durations in milliseconds,
+// so it arrives fractional, and `seconds % 60` on 3011.1 renders as
+// "50:11.099999999999909" in the coverage badge.
 function formatTime(seconds: number) {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
+  const whole = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(whole / 3600);
+  const m = Math.floor((whole % 3600) / 60);
+  const s = whole % 60;
   if (h > 0) {
     return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
   }
@@ -185,6 +190,12 @@ export default function LiveMeetingControls({
           {formatTime(coverageWarning.capturedSeconds)} captured
         </span>{" "}
         of {formatTime(coverageWarning.elapsedSeconds)} elapsed.{" "}
+        {coverageWarning.queuedSeconds > 0 ? (
+          <>
+            Another {formatTime(coverageWarning.queuedSeconds)} is recorded and
+            waiting to upload.{" "}
+          </>
+        ) : null}
         {coverageWarning.cause === "backend-unreachable"
           ? "Nojoin cannot reach the server at the moment. Recording is continuing, and queued audio uploads when the connection returns."
           : coverageWarning.cause === "tab-suspended"

--- a/frontend/src/components/LiveTranscriptPanel.test.tsx
+++ b/frontend/src/components/LiveTranscriptPanel.test.tsx
@@ -203,4 +203,24 @@ describe("LiveTranscriptPanel", () => {
 
     expect(container.scrollTop).toBe(500);
   });
+
+  it("lets the scroll window shrink to the card it is given", () => {
+    renderPanel([buildLine("a", 0, "first")]);
+    const container = screen.getByTestId("live-transcript-scroll");
+
+    // From 54rem this module absorbs whatever the notes and documents cards
+    // leave, which on a short window is under 14rem. A rigid floor there made
+    // the window taller than its own card: the frame stayed at the card's
+    // height and the overspill painted across the notes card below. The floor
+    // is kept for the stacked layout, where the page scrolls instead.
+    expect(container.className).toContain("min-h-[14rem]");
+    expect(container.className).toContain("@min-[54rem]:min-h-0");
+  });
+
+  it("keeps every line inside the card", () => {
+    const { container } = renderPanel([buildLine("a", 0, "first")]);
+    const card = container.querySelector("section");
+
+    expect(card?.className).toContain("overflow-hidden");
+  });
 });

--- a/frontend/src/components/LiveTranscriptPanel.tsx
+++ b/frontend/src/components/LiveTranscriptPanel.tsx
@@ -143,7 +143,12 @@ export default function LiveTranscriptPanel({
   const isEmpty = lines.length === 0;
 
   return (
-    <section className="density-surface flex h-full min-h-0 flex-col border border-surface-border bg-surface-card shadow-card">
+    // `overflow-hidden`, because the card is the boundary of this panel and
+    // nothing inside it may paint over the notes card below. The window sizes
+    // itself to whatever the card is given, so nothing should reach this, but
+    // the failure mode of a future rigid child is then a clipped transcript
+    // rather than text sitting loose on top of the next module.
+    <section className="density-surface flex h-full min-h-0 flex-col overflow-hidden border border-surface-border bg-surface-card shadow-card">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="inline-flex items-center gap-2 rounded-full border border-action-border bg-action-tint px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-action-text">
           <Radio className="h-3.5 w-3.5" />
@@ -188,7 +193,17 @@ export default function LiveTranscriptPanel({
           ref={scrollContainerRef}
           onScroll={handleScroll}
           data-testid="live-transcript-scroll"
-          className="relative min-h-[14rem] flex-1 overflow-y-auto"
+          // The floor holds only in the stacked layout, where the page scrolls
+          // and a short transcript would simply leave a gap. From 54rem the
+          // column has a definite height and this module absorbs whatever the
+          // notes and documents cards leave, which on a short window is less
+          // than 14rem. A floor there is a child refusing the height its own
+          // card was given: the window overflowed the card, the frame below
+          // stayed at the card's height, and the overspill painted across the
+          // notes card. `min-h-0` lets the window take the card exactly, so a
+          // squeezed transcript is a smaller scroll window rather than text
+          // outside its own panel.
+          className="relative min-h-[14rem] flex-1 overflow-y-auto @min-[54rem]:min-h-0"
         >
           <div className="flex min-h-full flex-col py-4 pl-4 pr-8">
             {isEmpty ? (

--- a/frontend/src/components/RecordingStatusDisplay.tsx
+++ b/frontend/src/components/RecordingStatusDisplay.tsx
@@ -137,7 +137,7 @@ export default function RecordingStatusDisplay({
       type="button"
       onClick={() => setIsUploadOpen(true)}
       className="inline-flex h-10 shrink-0 items-center gap-2 rounded-lg border border-control-border bg-surface-card px-4 text-sm font-semibold text-contrast-muted transition-colors hover:border-action-border hover:text-action-text"
-      title="Attach an agenda or a deck to this meeting"
+      title="Attach agendas, decks or notes to this meeting"
     >
       <Upload className="h-4 w-4" />
       Attach Docs

--- a/frontend/src/lib/capture/controller.test.ts
+++ b/frontend/src/lib/capture/controller.test.ts
@@ -918,6 +918,56 @@ describe("capture controller", () => {
     expect(controller.getState().coverageWarning.cause).toBe("backend-unreachable");
   });
 
+  it("does not count the upload queue as missing audio", () => {
+    // The production shape: the server stalled for two minutes, the recorder
+    // kept going, and the queue held everything it produced. Nothing was lost,
+    // so nothing should be claimed lost.
+    const controller = recordingWithCapturedAudio(4_618, 4_874);
+    controller.runtime = {
+      uploader: { pendingSegmentCount: () => 128 },
+    };
+
+    controller.evaluateCoverage();
+
+    expect(controller.getState().coverageWarning).toBeNull();
+    expect(notificationMocks.addNotification).not.toHaveBeenCalled();
+  });
+
+  it("reports the queue alongside a genuine shortfall", () => {
+    const controller = recordingWithCapturedAudio(4_618, 4_874);
+    controller.runtime = {
+      uploader: { pendingSegmentCount: () => 15 },
+    };
+
+    controller.evaluateCoverage();
+
+    const warning = controller.getState().coverageWarning;
+    expect(warning.queuedSeconds).toBe(30);
+    expect(warning.missingSeconds).toBe(226);
+    expect(notificationMocks.addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("waiting to upload"),
+      }),
+    );
+  });
+
+  it("still blames an outage that ended while the queue was draining", () => {
+    // A shortfall is noticed by a 15-second poll and persists while the queue
+    // drains, so the backend is usually reachable again by the time the warning
+    // is raised. Classifying on the live status alone reported `unknown` for
+    // the one case the classifier exists to name.
+    const controller = recordingWithCapturedAudio(4_618, 4_874);
+    connectivityMocks.status = "unreachable";
+    controller.evaluateCoverage();
+    expect(controller.getState().coverageWarning.cause).toBe("backend-unreachable");
+
+    connectivityMocks.status = "online";
+    controller.setState({ coverageWarning: null });
+    controller.evaluateCoverage();
+
+    expect(controller.getState().coverageWarning.cause).toBe("backend-unreachable");
+  });
+
   it("clears the warning when dismissed", () => {
     const controller = recordingWithCapturedAudio(4_618, 4_874);
     controller.evaluateCoverage();

--- a/frontend/src/lib/capture/controller.ts
+++ b/frontend/src/lib/capture/controller.ts
@@ -65,8 +65,11 @@ interface ActiveRuntime {
   mediaReleased?: boolean;
 }
 
+/** Nominal length of one recorded segment. Matches the recorder's timeslice. */
+const CAPTURE_TIMESLICE_SECONDS = 2;
+
 const sequenceToElapsedSeconds = (lastSequence: number) =>
-  lastSequence >= 0 ? (lastSequence + 1) * 2 : 0;
+  lastSequence >= 0 ? (lastSequence + 1) * CAPTURE_TIMESLICE_SECONDS : 0;
 
 const FINALIZE_UPLOAD_IN_PROGRESS_DETAIL =
   "Recording upload is still in progress; finalize after all segment uploads complete.";
@@ -129,6 +132,19 @@ const COVERAGE_WARNING_REARM_SECONDS = 60;
  * right trade for a warning about minutes of lost audio.
  */
 const COVERAGE_POLL_INTERVAL_MS = 15_000;
+
+/**
+ * How long an outage keeps explaining a shortfall after the server answers
+ * again.
+ *
+ * A shortfall is noticed by a poll that runs every 15 seconds, and it persists
+ * while the upload queue drains, so by the time the warning is raised the
+ * backend is usually reachable once more. Classifying on the live status alone
+ * therefore reported `unknown` for exactly the case the classification exists
+ * to name, and told the user to check their tab and their connection for a
+ * two-minute stall on the server.
+ */
+const COVERAGE_RECENT_OUTAGE_MS = 5 * 60_000;
 
 const withStageTimeout = async <T>(
   stage: CaptureStopStage,
@@ -229,6 +245,9 @@ export class CaptureController {
    * being attributed to it.
    */
   private sawCaptureFreeze = false;
+
+  /** When the backend was last seen to be unreachable, for the classifier. */
+  private lastUnreachableAt: number | null = null;
 
   private readonly wakeLock: CaptureWakeLock = createCaptureWakeLock();
 
@@ -1029,10 +1048,20 @@ export class CaptureController {
    */
   private classifyCoverageCause = (): CaptureCoverageCause => {
     if (!isReachable(useConnectivityStore.getState().status)) {
+      this.lastUnreachableAt = Date.now();
       return "backend-unreachable";
     }
     if (this.sawCaptureFreeze) {
       return "tab-suspended";
+    }
+    // An outage that has just ended still explains the gap it left behind. It
+    // ranks below a freeze, because a freeze is direct evidence the browser
+    // stopped recording while an outage is evidence it did not.
+    if (
+      this.lastUnreachableAt !== null &&
+      Date.now() - this.lastUnreachableAt <= COVERAGE_RECENT_OUTAGE_MS
+    ) {
+      return "backend-unreachable";
     }
     return "unknown";
   };
@@ -1041,9 +1070,13 @@ export class CaptureController {
     const captured = Math.round(warning.capturedSeconds / 60);
     const elapsed = Math.round(warning.elapsedSeconds / 60);
     const missing = Math.round(warning.missingSeconds / 60);
+    const queued = Math.round(warning.queuedSeconds / 60);
     const headline =
       `Nojoin has ${captured} of ${elapsed} minutes of audio, so around ` +
-      `${missing} minutes are missing. `;
+      `${missing} minutes are missing. ` +
+      (queued >= 1
+        ? `A further ${queued} minutes are recorded and waiting to upload. `
+        : "");
 
     if (warning.cause === "backend-unreachable") {
       return (
@@ -1068,6 +1101,19 @@ export class CaptureController {
   };
 
   /**
+   * Recorded audio the browser is still holding, estimated from the queue.
+   *
+   * Approximate for the same reason the captured figure is measured rather than
+   * derived: a segment carries a little more than the nominal timeslice. It is
+   * only ever subtracted from a shortfall, so the bias makes the warning
+   * slightly readier to fire, never readier to stay silent.
+   */
+  private queuedAudioSeconds = (): number => {
+    const pending = this.runtime?.uploader.pendingSegmentCount() ?? 0;
+    return pending * CAPTURE_TIMESLICE_SECONDS;
+  };
+
+  /**
    * Compares the audio the server holds against wall-clock recording time.
    */
   private evaluateCoverage = () => {
@@ -1083,7 +1129,15 @@ export class CaptureController {
     }
 
     const elapsedSeconds = this.state.elapsedSeconds;
-    const missingSeconds = Math.max(0, elapsedSeconds - capturedSeconds);
+    // What the browser is still holding is not missing. Subtracting the queue
+    // is the difference between "the server stopped answering and your audio is
+    // waiting" and "your meeting is being lost", which are the two readings of
+    // the same arithmetic and only one of them is true during an outage.
+    const queuedSeconds = this.queuedAudioSeconds();
+    const missingSeconds = Math.max(
+      0,
+      elapsedSeconds - capturedSeconds - queuedSeconds,
+    );
     if (
       elapsedSeconds <= 0 ||
       missingSeconds < COVERAGE_WARNING_MIN_MISSING_SECONDS ||
@@ -1104,6 +1158,7 @@ export class CaptureController {
       capturedSeconds,
       elapsedSeconds,
       missingSeconds,
+      queuedSeconds,
       cause: this.classifyCoverageCause(),
     };
     this.setState({ coverageWarning: warning, coverageWarningDismissedAt: null });

--- a/frontend/src/lib/capture/shared.ts
+++ b/frontend/src/lib/capture/shared.ts
@@ -88,7 +88,18 @@ export type CaptureCoverageCause =
 export interface CaptureCoverageWarning {
   capturedSeconds: number;
   elapsedSeconds: number;
+  /**
+   * Elapsed time the server holds no audio for and the browser is not holding
+   * either, so it is genuinely gone. Net of `queuedSeconds`.
+   */
   missingSeconds: number;
+  /**
+   * Recorded, still queued in the browser, not yet acknowledged by the server.
+   * Estimated from the queue length rather than measured, so it is approximate
+   * in the same direction as the timeslice. This audio is not lost; it uploads
+   * when the server answers again.
+   */
+  queuedSeconds: number;
   cause: CaptureCoverageCause;
 }
 

--- a/frontend/src/lib/capture/uploader.test.ts
+++ b/frontend/src/lib/capture/uploader.test.ts
@@ -6,6 +6,26 @@ import { createSegmentUploader } from "./uploader";
 const accepted = (sequence: number) => ({ status: "ok", segment: sequence });
 
 describe("capture uploader", () => {
+  it("reports how much it is still holding", async () => {
+    // The coverage check subtracts this, so a stalled server reads as a queue
+    // rather than as lost audio.
+    const uploadSegment = vi.fn(async () => {
+      await new Promise(() => {});
+      return accepted(0);
+    });
+    const uploader = createSegmentUploader({
+      recordingId: "rec-1",
+      uploadSegment: uploadSegment as never,
+    });
+
+    expect(uploader.pendingSegmentCount()).toBe(0);
+    uploader.enqueue(0, new Blob(["a"]));
+    uploader.enqueue(1, new Blob(["b"]));
+
+    expect(uploader.pendingSegmentCount()).toBe(2);
+    uploader.dispose();
+  });
+
   it("uploads queued segments in sequence and retries with backoff", async () => {
     const attempts: number[] = [];
     const uploaded: number[] = [];

--- a/frontend/src/lib/capture/uploader.ts
+++ b/frontend/src/lib/capture/uploader.ts
@@ -76,6 +76,19 @@ export class SegmentUploader {
     this.nextExpectedSequence = options.initialSequence ?? 0;
   }
 
+  /**
+   * Segments recorded but not yet acknowledged by the server.
+   *
+   * This is audio the browser is holding, not audio that has been lost, and
+   * the coverage check needs the difference: a server that stops answering for
+   * two minutes leaves the queue two minutes long, and counting that as missing
+   * tells the user their meeting is being lost while it is in fact sitting here
+   * waiting to upload.
+   */
+  pendingSegmentCount(): number {
+    return this.pending.size;
+  }
+
   enqueue(sequence: number, blob: Blob) {
     if (this.closed) {
       return;

--- a/frontend/src/lib/connectivity/monitor.test.ts
+++ b/frontend/src/lib/connectivity/monitor.test.ts
@@ -92,6 +92,61 @@ describe("ConnectivityMonitor driver", () => {
     monitor.stop();
   });
 
+  it("never runs two probes at once, however many requests fail", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    // A probe that never resolves on its own, standing in for one stalled
+    // across a tab suspension.
+    const release: Array<(ok: boolean) => void> = [];
+    const probe = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          release.push((ok) => {
+            inFlight -= 1;
+            resolve(ok);
+          });
+        }),
+    );
+    const { monitor, getState } = makeHarness(probe);
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(1);
+
+    // The resume storm: a burst of failed requests, each asking for a probe.
+    for (let i = 0; i < 8; i += 1) {
+      monitor.recordRequestOutcome({ reachedServer: false });
+      await vi.advanceTimersByTimeAsync(600);
+    }
+
+    expect(maxInFlight).toBe(1);
+    expect(probe).toHaveBeenCalledTimes(1);
+    // Nothing has been confirmed, so nothing is claimed.
+    expect(getState().status).not.toBe("unreachable");
+
+    release.forEach((resolve) => resolve(true));
+    monitor.stop();
+  });
+
+  it("does not count a probe that was suspended rather than answered", async () => {
+    // Fails, but only after far longer than its own timeout, which is what a
+    // tab frozen across the probe looks like: the abort fires on thaw.
+    const probe = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120_000));
+      return false;
+    });
+    const { monitor, getState } = makeHarness(probe);
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(STALE_AFTER_MS + 5_000 * PROBE_FAILURES_TO_UNREACHABLE + 200_000);
+
+    expect(probe.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(getState().probeFailureStreak).toBe(0);
+    expect(getState().status).not.toBe("unreachable");
+    monitor.stop();
+  });
+
   it("brings a probe forward when a real request fails", async () => {
     const probe = vi.fn().mockResolvedValue(true);
     const { monitor, getState } = makeHarness(probe);

--- a/frontend/src/lib/connectivity/monitor.ts
+++ b/frontend/src/lib/connectivity/monitor.ts
@@ -16,6 +16,19 @@ const CONFIRM_PROBE_INTERVAL_MS = 5_000;
 const REACTIVE_PROBE_DELAY_MS = 500;
 /** Liveness-probe timeout. Deliberately generous — a slow answer is not an outage. */
 const PROBE_TIMEOUT_MS = 10_000;
+/**
+ * A failed probe is only evidence if it was raced against the network for
+ * roughly its own timeout. Take this much longer and the browser was not
+ * running our code: a frozen or suspended tab stops the abort timer with the
+ * request, and both resume together, so the fetch is cancelled the instant the
+ * tab thaws without ever having been given a fair 10 seconds. Counting that as
+ * a confirmed failure turns a browser suspension into a backend outage.
+ *
+ * The `resume` event is not usable for this. It is advisory and not dispatched
+ * on every Chromium build (issue #166), so the elapsed wall clock is the only
+ * signal that holds everywhere.
+ */
+const SUSPENDED_PROBE_AFTER_MS = PROBE_TIMEOUT_MS * 2;
 
 /**
  * Cheap, unauthenticated, redirect-free liveness endpoint. Mirrors the axios
@@ -63,6 +76,18 @@ export class ConnectivityMonitor {
   private timer: TimerHandle | null = null;
 
   private running = false;
+
+  /**
+   * One probe at a time, always. Without this the driver stacks them: a tick
+   * that is awaiting its probe holds no timer, so every failing request calls
+   * `bringProbeForward` and schedules another tick 500ms later, which starts
+   * another probe. A tab that resumes from suspension fails many requests at
+   * once and produced seven concurrent probes in production, all aborted in the
+   * same instant, which is three times the confirmation threshold delivered in
+   * one go. The threshold means "three probes over ~15 seconds", and only a
+   * serialised prober makes that true.
+   */
+  private probing = false;
 
   private readonly listeners: Array<() => void> = [];
 
@@ -165,7 +190,9 @@ export class ConnectivityMonitor {
 
     const state = this.deps.getState();
     // Never probe a hidden or offline tab: those failures are false negatives.
-    const canProbe = state.browserOnline && state.visible;
+    // Nor a second time while one is still in flight; that is what the probe
+    // is for.
+    const canProbe = state.browserOnline && state.visible && !this.probing;
     // Probe when a real failure forced a verification, or (idle fallback) when
     // we lack fresh proof of reachability. Fresh real traffic already answers
     // the question, so an untriggered tick skips the synthetic load.
@@ -184,16 +211,36 @@ export class ConnectivityMonitor {
   }
 
   private async runProbe(): Promise<void> {
+    const startedAt = this.deps.now();
     let ok = false;
+    this.probing = true;
     try {
       ok = await this.deps.probe();
     } catch {
       ok = false;
+    } finally {
+      this.probing = false;
     }
     const at = this.deps.now();
-    this.deps.dispatch(
-      ok ? { type: "probe-succeeded", at } : { type: "probe-failed", at },
-    );
+
+    if (ok) {
+      this.deps.dispatch({ type: "probe-succeeded", at });
+      return;
+    }
+
+    // A failure the browser cannot vouch for is not counted. Either the tab was
+    // suspended across the probe, so its abort was decided by a timer that
+    // never ran, or it went to the background mid-probe, which the tick guard
+    // already refuses to probe in. `evaluate` still advances the clock, so
+    // staleness and the confirm cadence carry on as normal and the next probe,
+    // run with a fair timeout, decides.
+    const suspended = at - startedAt >= SUSPENDED_PROBE_AFTER_MS;
+    if (suspended || !this.deps.getState().visible) {
+      this.deps.dispatch({ type: "evaluate", at });
+      return;
+    }
+
+    this.deps.dispatch({ type: "probe-failed", at });
   }
 
   private scheduleNext(): void {
@@ -213,6 +260,11 @@ export class ConnectivityMonitor {
     }
     const state = this.deps.getState();
     if (!state.browserOnline || !state.visible) {
+      return;
+    }
+    // A probe already in flight is the verification this would ask for, and
+    // cancelling the tick that owns it would leave the driver with no timer.
+    if (this.probing) {
       return;
     }
     this.clearTimer();

--- a/frontend/src/lib/connectivity/reducer.test.ts
+++ b/frontend/src/lib/connectivity/reducer.test.ts
@@ -115,6 +115,27 @@ describe("connectivity reducer", () => {
     expect(state.status).not.toBe("unreachable");
   });
 
+  it("clears probe failures gathered in the background when the tab returns", () => {
+    let state = createInitialState();
+    state = reduce(state, { type: "request-succeeded", at: 0 });
+    state = reduce(state, { type: "visibility-changed", at: 1_000, visible: false });
+    state = reduce(state, { type: "probe-failed", at: 40_000 });
+    state = reduce(state, { type: "probe-failed", at: 45_000 });
+    state = reduce(state, { type: "probe-failed", at: 50_000 });
+    expect(state.status).toBe("unreachable");
+
+    state = reduce(state, {
+      type: "visibility-changed",
+      at: 51_000,
+      visible: true,
+    });
+
+    // Evidence collected while the page was not being run is discarded, and
+    // the machine goes back to checking rather than accusing the backend.
+    expect(state.probeFailureStreak).toBe(0);
+    expect(state.status).toBe("checking");
+  });
+
   it("never probes a hidden tab into unreachable (probe failures still counted only when driver runs them)", () => {
     // Sanity: visibility does not itself change reachability derivation.
     const visible = run([{ type: "visibility-changed", at: T0, visible: true }]);

--- a/frontend/src/lib/connectivity/reducer.ts
+++ b/frontend/src/lib/connectivity/reducer.ts
@@ -129,7 +129,20 @@ export const reduce = (
       return withStatus({ ...state, browserOnline: true }, event.at);
 
     case "visibility-changed":
-      return withStatus({ ...state, visible: event.visible }, event.at);
+      // Returning to the foreground starts the confirmation over. Failures
+      // recorded while the tab was hidden, throttled or frozen were gathered
+      // while the browser was not running the page properly, and holding them
+      // means a tab that comes back after a suspension alarms on evidence
+      // collected in the dark. A backend that really is down is re-confirmed
+      // within seconds by the confirm-cadence prober.
+      return withStatus(
+        {
+          ...state,
+          visible: event.visible,
+          probeFailureStreak: event.visible ? 0 : state.probeFailureStreak,
+        },
+        event.at,
+      );
 
     case "evaluate":
       return withStatus(state, event.at);


### PR DESCRIPTION
## Description

Three defects found on the production instance during a live meeting, plus one feature the first of them exposed.

**Live transcript overflowed its card.** The scroll window carried a rigid `min-h-[14rem]`. From 54rem the transcript module absorbs whatever the notes and documents cards leave, which on a short window is less than that, so the window overflowed the card, the frame drawn behind it stayed at the card's height, and the overspill painted across the notes card. The window now takes the card exactly above 54rem; the floor survives in the stacked layout, where the page scrolls.

**Documents could only be attached one at a time.** The dialog now holds a queue with a per-file visual-analysis switch (forced on for images, which have no text layer). Uploads run sequentially because the backend admits two per user and rejects the rest. A failure no longer aborts the batch, and a retry re-sends only what failed.

**The backend-unreachable alarm fired on evidence that proves nothing.** A tick awaiting its probe holds no timer, so every failing request scheduled another probe 500ms later; a stalled connection put seven in flight at once and delivered three times the confirmation threshold in one instant. Probes are serialised now, a probe that outlasts its own timeout by 2x is discarded as suspension rather than counted, and returning to the foreground clears the streak. A genuine outage still alarms on the intended timescale.

**The coverage warning counted queued audio as lost audio.** A server that stops answering for two minutes leaves two minutes in the browser's upload queue. That was reported as missing, which sends someone to check their tab and device over audio that was never at risk. The shortfall is now net of the queue, the queue is named separately, and an outage keeps explaining a shortfall for five minutes because the check polls every fifteen seconds and the queue outlasts that. The captured figure is also floored before formatting, having rendered as `50:11.099999999999909`.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update

## Checks run

- [x] Backend tests: `source .venv/bin/activate && pytest` (1492 passed)
- [ ] Python quality: `python scripts/check.py`
- [x] Frontend lint: `cd frontend && npm run lint` (0 errors, 4 pre-existing warnings, none in changed files)
- [x] Frontend unit tests: `cd frontend && npm run test` (510 passed)
- [x] Frontend build: `cd frontend && npm run build`
- [x] Docs validation: `python3 scripts/validate_docs.py`
- [x] Alembic validation: `python3 scripts/validate_alembic.py`

## Migration impact

- [x] No database migration in this PR.

## Documentation impact

- [x] Updated the relevant guide(s) in the same PR: `docs/DESIGN.md` (the min-height rule that follows from the capping rules), `docs/USAGE.md` (multi-file attach and the per-file switch), `docs/ARCHITECTURE.md` (the connectivity monitor, and the coverage warning net of the queue), `docs/CAPTURE.md` (queued audio is not missing audio).

## Security impact

- [x] No security-sensitive change.

## Manual verification

Not yet performed, which is why this is a draft. Pending before merge:

- Live transcript: confirm the panel no longer overflows onto the notes card on a short window, and that it scrolls internally and still follows new lines.
- Document upload: multi-select and drag-drop of several files, per-file visual-analysis toggle, image forced on, bulk on/off, sequential upload, partial failure and retry, from both the live view and the Documents tab.
- Capture smoke set: share picker, selected microphone, waveform/live state, pause/resume, stop/finalize, discard, unsupported-browser messaging.
- Coverage warning: confirm queued audio is reported as queued rather than missing during a real outage.

Recording actions are untouched, so the shared `useRecordingActions` hook is unaffected.

## Context

The unreachable banner that prompted this turned out to be a real server-side stall: roughly twice an hour during a live capture, every container on the host stops for about two minutes, including nginx's own loopback healthcheck. That is a host-level Docker problem, not a Nojoin one, and is not addressed here. These changes make the client's reporting of it truthful.
